### PR TITLE
Backend: Fix non straming chat

### DIFF
--- a/src/backend/routers/chat.py
+++ b/src/backend/routers/chat.py
@@ -644,7 +644,7 @@ def generate_chat_response(
 
     response_message.text = non_streamed_chat_response.text
     response_message.generation_id = non_streamed_chat_response.generation_id
-    
+
     if should_store:
         update_conversation_after_turn(
             session,


### PR DESCRIPTION
- **Description:** Message and GenerationID were not stored using non-streaming chat. This PR adds those values to the response message. 

- [X] **Add tests and docs**: Please include testing and documentation for your changes
- [X] **Lint and test**: Run `make lint` and `make test` 