### PR TITLE
coral-web: add missing env setup banner

### DIFF
--- a/src/interfaces/coral_web/src/cohere-client/generated/index.ts
+++ b/src/interfaces/coral_web/src/cohere-client/generated/index.ts
@@ -48,6 +48,7 @@ export type { Tool } from './models/Tool';
 export type { ToolCall } from './models/ToolCall';
 export { ToolInputType } from './models/ToolInputType';
 export type { UpdateConversation } from './models/UpdateConversation';
+export type { UpdateDeploymentEnv } from './models/UpdateDeploymentEnv';
 export type { UpdateFile } from './models/UpdateFile';
 export type { UpdateUser } from './models/UpdateUser';
 export type { UploadFile } from './models/UploadFile';

--- a/src/interfaces/coral_web/src/cohere-client/generated/models/UpdateDeploymentEnv.ts
+++ b/src/interfaces/coral_web/src/cohere-client/generated/models/UpdateDeploymentEnv.ts
@@ -1,0 +1,7 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type UpdateDeploymentEnv = {
+  env_vars: Record<string, string>;
+};

--- a/src/interfaces/coral_web/src/cohere-client/generated/services/DefaultService.ts
+++ b/src/interfaces/coral_web/src/cohere-client/generated/services/DefaultService.ts
@@ -25,6 +25,7 @@ import type { ListFile } from '../models/ListFile';
 import type { ManagedTool } from '../models/ManagedTool';
 import type { NonStreamedChatResponse } from '../models/NonStreamedChatResponse';
 import type { UpdateConversation } from '../models/UpdateConversation';
+import type { UpdateDeploymentEnv } from '../models/UpdateDeploymentEnv';
 import type { UpdateFile } from '../models/UpdateFile';
 import type { UpdateUser } from '../models/UpdateUser';
 import type { UploadFile } from '../models/UploadFile';
@@ -626,6 +627,35 @@ export class DefaultService {
       query: {
         all: all,
       },
+      errors: {
+        422: `Validation Error`,
+      },
+    });
+  }
+  /**
+   * Set Env Vars
+   * Set environment variables for the deployment.
+   *
+   * Returns:
+   * str: Empty string.
+   * @returns any Successful Response
+   * @throws ApiError
+   */
+  public static setEnvVarsDeploymentsNameSetEnvVarsPost({
+    name,
+    requestBody,
+  }: {
+    name: string;
+    requestBody: UpdateDeploymentEnv;
+  }): CancelablePromise<any> {
+    return __request(OpenAPI, {
+      method: 'POST',
+      url: '/deployments/{name}/set_env_vars',
+      path: {
+        name: name,
+      },
+      body: requestBody,
+      mediaType: 'application/json',
       errors: {
         422: `Validation Error`,
       },

--- a/src/interfaces/coral_web/src/components/Layout.tsx
+++ b/src/interfaces/coral_web/src/components/Layout.tsx
@@ -1,10 +1,12 @@
 import { Transition } from '@headlessui/react';
 import { capitalize } from 'lodash';
-import React, { Children, PropsWithChildren } from 'react';
+import React, { Children, PropsWithChildren, useContext } from 'react';
 
 import { ConfigurationDrawer } from '@/components/Conversation/ConfigurationDrawer';
+import { Banner } from '@/components/Shared';
 import { NavigationBar } from '@/components/Shared/NavigationBar/NavigationBar';
 import { PageHead } from '@/components/Shared/PageHead';
+import { BannerContext } from '@/context/BannerContext';
 import { useIsDesktop } from '@/hooks/breakpoint';
 import { useSettingsStore } from '@/stores';
 import { cn } from '@/utils/cn';
@@ -27,6 +29,7 @@ type Props = {
  * On small devices (e.g. mobile), the left drawer and main section are stacked vertically.
  */
 export const Layout: React.FC<Props> = ({ title = 'Coral', children }) => {
+  const { message: bannerMessage } = useContext(BannerContext);
   const {
     settings: { isConvListPanelOpen, isMobileConvListPanelOpen },
   } = useSettingsStore();
@@ -56,6 +59,7 @@ export const Layout: React.FC<Props> = ({ title = 'Coral', children }) => {
       <PageHead title={capitalize(title)} />
       <div className="flex h-screen w-full flex-1 flex-col gap-3 bg-secondary-100 p-3">
         <NavigationBar />
+        {bannerMessage && <Banner size="sm">{bannerMessage}</Banner>}
 
         <div className={cn('relative flex h-full flex-grow flex-nowrap overflow-hidden')}>
           <Transition

--- a/src/interfaces/coral_web/src/constants.ts
+++ b/src/interfaces/coral_web/src/constants.ts
@@ -3,6 +3,8 @@ import { FileAccept } from '@/components/Shared/DragDropFileInput';
 export const DEFAULT_CONVERSATION_NAME = 'Chat with Coral';
 export const DEFAULT_TYPING_VELOCITY = 35;
 
+export const DEPLOYMENT_COHERE_PLATFORM = 'Cohere Platform';
+
 export const ACCEPTED_FILE_TYPES: FileAccept[] = [
   'text/csv',
   'text/plain',

--- a/src/interfaces/coral_web/src/context/BannerContext.tsx
+++ b/src/interfaces/coral_web/src/context/BannerContext.tsx
@@ -1,0 +1,33 @@
+import React, { PropsWithChildren, createContext, useState } from 'react';
+
+interface Context {
+  message: React.ReactNode;
+  setMessage: (message: React.ReactNode) => void;
+}
+
+const useBanner = (initialMessage?: string): Context => {
+  const [message, setMessage] = useState<React.ReactNode>(initialMessage ?? '');
+
+  return { message, setMessage };
+};
+
+const BannerContext = createContext<Context>({
+  message: '',
+  setMessage: () => {},
+});
+
+/**
+ * @description Provider for the BannerContext.
+ * Determines the message to display in the global banner.
+ */
+const BannerProvider: React.FC<PropsWithChildren> = ({ children }) => {
+  const { message, setMessage } = useBanner();
+
+  return (
+    <BannerContext.Provider value={{ message, setMessage }}>
+      <>{children}</>
+    </BannerContext.Provider>
+  );
+};
+
+export { BannerContext, BannerProvider };

--- a/src/interfaces/coral_web/src/context/index.tsx
+++ b/src/interfaces/coral_web/src/context/index.tsx
@@ -1,13 +1,21 @@
 import { useContext } from 'react';
 
+import { BannerContext, BannerProvider } from '@/context/BannerContext';
 import { ModalContext, ModalProvider } from '@/context/ModalContext';
 
-export const ContextStore: React.FC<{ children: React.ReactNode }> = ({ children }) => {
-  return <ModalProvider>{children}</ModalProvider>;
+export const ContextStore: React.FC<{
+  children: React.ReactNode;
+}> = ({ children }) => {
+  return (
+    <ModalProvider>
+      <BannerProvider>{children}</BannerProvider>
+    </ModalProvider>
+  );
 };
 
 export const useContextStore = () => {
   const modal = useContext(ModalContext);
+  const banner = useContext(BannerContext);
 
-  return { ...modal };
+  return { ...modal, banner };
 };

--- a/src/interfaces/coral_web/src/hooks/conversation.tsx
+++ b/src/interfaces/coral_web/src/hooks/conversation.tsx
@@ -30,6 +30,7 @@ export const useConversations = () => {
         return conversations;
       } catch (e) {
         if (!isAbortError(e)) {
+          console.error(e);
           throw e;
         }
         return [];
@@ -61,6 +62,7 @@ export const useConversation = ({
         });
       } catch (e) {
         if (!isAbortError(e)) {
+          console.error(e);
           throw e;
         }
         return {} as Conversation;
@@ -80,7 +82,12 @@ export const useEditConversation = () => {
     Omit<UpdateConversation, 'user_id'> & { conversationId: string }
   >({
     mutationFn: async (request) => {
-      return await client.editConversation(request);
+      try {
+        return await client.editConversation(request);
+      } catch (e) {
+        console.error(e);
+        throw e;
+      }
     },
     onSettled: () => {
       queryClient.invalidateQueries({ queryKey: ['conversations'] });

--- a/src/interfaces/coral_web/src/hooks/deployments.ts
+++ b/src/interfaces/coral_web/src/hooks/deployments.ts
@@ -2,6 +2,9 @@ import { useQuery } from '@tanstack/react-query';
 
 import { Deployment, useCohereClient } from '@/cohere-client';
 
+/**
+ * @description Hook to get available deployments.
+ */
 export const useListDeployments = (options?: { enabled?: boolean }) => {
   const cohereClient = useCohereClient();
   return useQuery<Deployment[], Error>({
@@ -9,6 +12,26 @@ export const useListDeployments = (options?: { enabled?: boolean }) => {
     queryFn: async () => {
       try {
         return await cohereClient.listDeployments();
+      } catch (e) {
+        console.error(e);
+        throw e;
+      }
+    },
+    refetchOnWindowFocus: false,
+    ...options,
+  });
+};
+
+/**
+ * @description Hook to get all possible deployments.
+ */
+export const useListAllDeployments = (options?: { enabled?: boolean }) => {
+  const cohereClient = useCohereClient();
+  return useQuery<Deployment[], Error>({
+    queryKey: ['allDeployments'],
+    queryFn: async () => {
+      try {
+        return await cohereClient.listAllDeployments();
       } catch (e) {
         console.error(e);
         throw e;

--- a/src/interfaces/coral_web/src/pages/index.tsx
+++ b/src/interfaces/coral_web/src/pages/index.tsx
@@ -1,29 +1,40 @@
 import { DehydratedState, QueryClient, dehydrate } from '@tanstack/react-query';
 import { GetServerSideProps, NextPage } from 'next';
-import { useEffect } from 'react';
+import { useContext, useEffect } from 'react';
 
 import { CohereClient } from '@/cohere-client';
 import Conversation from '@/components/Conversation';
 import ConversationListPanel from '@/components/ConversationList/ConversationListPanel';
 import { Layout, LayoutSection } from '@/components/Layout';
+import { BannerContext } from '@/context/BannerContext';
 import { appSSR } from '@/pages/_app';
-import { useCitationsStore, useConversationStore } from '@/stores';
+import { useCitationsStore, useConversationStore, useParamsStore } from '@/stores';
 
 type Props = {
   reactQueryState: DehydratedState;
 };
 
 const ChatPage: NextPage<Props> = () => {
+  const { setMessage } = useContext(BannerContext);
   const {
     conversation: { id },
     resetConversation,
   } = useConversationStore();
   const { resetCitations } = useCitationsStore();
+  const {
+    params: { deployment },
+  } = useParamsStore();
 
   useEffect(() => {
     resetConversation();
     resetCitations();
   }, []);
+
+  useEffect(() => {
+    if (!deployment) {
+      setMessage('Please select a deployment in the Tools Drawer > Settings tab.');
+    }
+  }, [deployment]);
 
   return (
     <Layout>


### PR DESCRIPTION
**Description:**

Adds a banner letting the user know if they need to setup their env files depending on the desired deployment. Note: `Cohere Platform` is always returned but when you attempt to make an API call without setting up your `COHERE_API_KEY` it'll throw an error. This PR also adds a small error message for when this happens and suggests checking if the api key is set.

**Tests:**

https://github.com/cohere-ai/cohere-toolkit/assets/5898755/8ec888e2-2d2c-41b9-acac-79342084c55b