### PR TITLE
chore: clean up makefile with defunct docker command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,11 +15,6 @@ migrate:
 reset-db:
 	docker compose down
 	docker volume rm cohere_toolkit_db
-# TODO: have images point to :latest
-run-docker-images:
-	docker compose run -d db
-	docker run -d -p 4000:4000 --env-file .env ghcr.io/cohere-ai/cohere-toolkit-frontend:pr-75
-	docker run -d -p 8000:8000 --env-file .env ghcr.io/cohere-ai/cohere-toolkit-backend:pr-75
 setup:
 	pip3 install -r cli/requirements.txt
 	python3 cli/main.py


### PR DESCRIPTION
Removes docker command used in testing for docker images. Single container docker image is preferred

Thank you for contributing to the Cohere Toolkit!

- [ ] **PR title**: "area: description"
  - Where "area" is whichever of interface, frontend, model, tools, backend, etc. is being modified. Use "docs: ..." for purely docs changes, "infra: ..." for CI changes.
  - Example: "deployment: add Azure model option"


- [ ] **PR message**: ***Delete this entire checklist*** and replace with
    - **Description:** a description of the change
    - **Issue:** the issue # it fixes, if applicable
    - **Dependencies:** any dependencies required for this change


- [ ] **Add tests and docs**: Please include testing and documentation for your changes
- [ ] **Lint and test**: Run `make lint` and `make test` 