### PR TITLE
Update readme to point to single container docker deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,14 +72,14 @@ Requirements:
 #### Option 1 - Install locally with Docker:
 Ensure your shell is authenticated with [GHCR](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#authenticating-with-a-personal-access-token-classic).
 
-Pull the images from Github's Artifact Registry
+Pull the [Single Container Image](docs/deployment_guides/single_container.md) from Github's Artifact Registry
 ```bash
-docker pull ghcr.io/cohere-ai/cohere-toolkit-backend:latest && docker pull ghcr.io/cohere-ai/cohere-toolkit-frontend:latest 
+docker pull ghcr.io/cohere-ai/cohere-toolkit:latest
 ```
 
 Run the images locally:
 ```bash
-make run-docker-images
+docker run --name=cohere-toolkit -itd -e COHERE_API_KEY='Your Cohere API key here' -p 8000:8000 -p 4000:4000 cohere-ai/toolkit
 ```
 
 #### Option 2 - Build locally from scratch:


### PR DESCRIPTION
We want to encourage people to use the docker single container image because it is faster and easier to pull. This PR updates the instructions to point to single container docker instead of backend and FE images

Thank you for contributing to the Cohere Toolkit!

- [ ] **PR title**: "area: description"
  - Where "area" is whichever of interface, frontend, model, tools, backend, etc. is being modified. Use "docs: ..." for purely docs changes, "infra: ..." for CI changes.
  - Example: "deployment: add Azure model option"


- [ ] **PR message**: ***Delete this entire checklist*** and replace with
    - **Description:** a description of the change
    - **Issue:** the issue # it fixes, if applicable
    - **Dependencies:** any dependencies required for this change


- [ ] **Add tests and docs**: Please include testing and documentation for your changes
- [ ] **Lint and test**: Run `make lint` and `make test` 