### PR TITLE
feat: update readme to point to correct single container image

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ docker pull ghcr.io/cohere-ai/cohere-toolkit:latest
 
 Run the images locally:
 ```bash
-docker run --name=cohere-toolkit -itd -e COHERE_API_KEY='Your Cohere API key here' -p 8000:8000 -p 4000:4000 cohere-ai/toolkit
+docker run --name=cohere-toolkit -itd -e COHERE_API_KEY='Your Cohere API key here' -p 8000:8000 -p 4000:4000 cohere-ai/cohere-toolkit
 ```
 
 #### Option 2 - Build locally from scratch:

--- a/docs/deployment_guides/single_container.md
+++ b/docs/deployment_guides/single_container.md
@@ -25,7 +25,7 @@ docker build -t cohere-ai/toolkit . -f standalone.Dockerfile
 
 You can then run the container with the following command:
 ```bash
-docker run --name=cohere-toolkit -itd -e COHERE_API_KEY='Your Cohere API key here' -p 8000:8000 -p 4000:4000 cohere-ai/toolkit
+docker run --name=cohere-toolkit -itd -e COHERE_API_KEY='Your Cohere API key here' -p 8000:8000 -p 4000:4000 cohere-ai/cohere-toolkit
 ```
 
 ### Option 2 - Pull from Registry


### PR DESCRIPTION
Docker run command was pointing to a stale image, this PR updates the readme to point to the correct single container image

Thank you for contributing to the Cohere Toolkit!

- [ ] **PR title**: "area: description"
  - Where "area" is whichever of interface, frontend, model, tools, backend, etc. is being modified. Use "docs: ..." for purely docs changes, "infra: ..." for CI changes.
  - Example: "deployment: add Azure model option"


- [ ] **PR message**: ***Delete this entire checklist*** and replace with
    - **Description:** a description of the change
    - **Issue:** the issue # it fixes, if applicable
    - **Dependencies:** any dependencies required for this change


- [ ] **Add tests and docs**: Please include testing and documentation for your changes
- [ ] **Lint and test**: Run `make lint` and `make test` 