### PR TITLE
coral-web: Only force enable file reader on send if files exist in conversation

### DIFF
--- a/src/interfaces/coral_web/src/components/Conversation/index.tsx
+++ b/src/interfaces/coral_web/src/components/Conversation/index.tsx
@@ -160,8 +160,8 @@ const Conversation: React.FC<Props> = ({ conversationId, welcomeMessageEnabled =
   };
 
   const handleSend = (msg?: string, overrideTools?: Tool[]) => {
-    const enableFileLoaderTool =
-      (files.length > 0 || composerFiles.length > 0) && !!defaultFileLoaderTool;
+    const filesExist = files.length > 0 || composerFiles.length > 0;
+    const enableFileLoaderTool = filesExist && !!defaultFileLoaderTool;
     const chatOverrideTools: Tool[] = [
       ...(overrideTools ?? []),
       ...(enableFileLoaderTool ? [{ name: defaultFileLoaderTool.name }] : []),
@@ -170,7 +170,9 @@ const Conversation: React.FC<Props> = ({ conversationId, welcomeMessageEnabled =
     if (startOption !== StartOptionKey.DOCUMENTS) {
       setStartOption(StartOptionKey.DOCUMENTS);
     }
-    enableDefaultFileLoaderTool();
+    if (filesExist) {
+      enableDefaultFileLoaderTool();
+    }
     send({ suggestedMessage: msg }, { tools: chatOverrideTools });
   };
 


### PR DESCRIPTION
**Description**
Only force enable file reader on message send if
- files exist in the conversation
- files don't exist in the conversation but a file has been uploaded in the message to be sent