### PR TITLE
coral-web: Update wikipedia tool name

### DIFF
--- a/src/interfaces/coral_web/src/cohere-client/constants.ts
+++ b/src/interfaces/coral_web/src/cohere-client/constants.ts
@@ -16,7 +16,7 @@ export const COHERE_PLATFORM_DEPLOYMENT_DEFAULT_CHAT_MODEL = 'command';
 export const SAGEMAKER_DEPLOYMENT_DEFAULT_CHAT_MODEL = 'command-r';
 
 export const DEFAULT_CHAT_TEMPERATURE = 0.3;
-export const DEFAULT_CHAT_TOOL = 'Wiki Retriever - LangChain';
+export const DEFAULT_CHAT_TOOL = 'Wikipedia';
 export const FILE_TOOL_CATEGORY = 'File loader';
 
 export const ERROR_FINISH_REASON_TO_MESSAGE = {


### PR DESCRIPTION
**Description**

Updates the default chat tool value from `Wiki Retriever - LangChain` --> `Wikipedia` to match the backend.
This also fixes the issue of the `Chat with Wikipedia` start option not enabling the default chat tool when selected