### PR TITLE
coral-web: Delay composer focus on Document start option select

### DIFF
--- a/src/interfaces/coral_web/src/components/Messages/Welcome/StartOptions.tsx
+++ b/src/interfaces/coral_web/src/components/Messages/Welcome/StartOptions.tsx
@@ -61,7 +61,7 @@ export const StartOptions: React.FC<{
       features: ['Long document analysis and summarization'],
       params: {},
       onChange: () => {
-        focusComposer();
+        setTimeout(() => focusComposer(), 100);
       },
     },
   };


### PR DESCRIPTION
The composer wasn't being focused because the newly selected start option was focusing almost at the same time. A delay is added here to ensure the selected start option state settles before attempting to focus on the composer


https://github.com/cohere-ai/cohere-toolkit/assets/140425731/f0f73ce6-3866-4d1b-945c-04e1e831404d



