### PR TITLE
Tests: skip when cohere api key is not set

### DIFF
--- a/src/backend/tests/routers/test_chat.py
+++ b/src/backend/tests/routers/test_chat.py
@@ -1,4 +1,5 @@
 import json
+import os
 import uuid
 from typing import Any
 
@@ -14,6 +15,8 @@ from backend.models.user import User
 from backend.schemas.tool import Category
 from backend.tests.factories import get_factory
 
+is_cohere_env_set = os.environ.get("COHERE_API_KEY") is not None
+
 
 @pytest.fixture()
 def user(session_chat: Session) -> User:
@@ -21,6 +24,7 @@ def user(session_chat: Session) -> User:
 
 
 # STREAMING CHAT TESTS
+@pytest.mark.skipif(not is_cohere_env_set, reason="Cohere API key not set")
 def test_streaming_new_chat(
     session_client_chat: TestClient, session_chat: Session, user: User
 ):
@@ -39,6 +43,7 @@ def test_streaming_new_chat(
     )
 
 
+@pytest.mark.skipif(not is_cohere_env_set, reason="Cohere API key not set")
 def test_streaming_existing_chat(
     session_client_chat: TestClient, session_chat: Session, user: User
 ):
@@ -83,6 +88,7 @@ def test_streaming_existing_chat(
     )
 
 
+@pytest.mark.skipif(not is_cohere_env_set, reason="Cohere API key not set")
 def test_fail_chat_missing_user_id(
     session_client_chat: TestClient, session_chat: Session, user: User
 ):
@@ -96,6 +102,7 @@ def test_fail_chat_missing_user_id(
     assert response.json() == {"detail": "User-Id required in request headers."}
 
 
+@pytest.mark.skipif(not is_cohere_env_set, reason="Cohere API key not set")
 def test_default_chat_missing_deployment_name(
     session_client_chat: TestClient, session_chat: Session, user: User
 ):
@@ -108,6 +115,7 @@ def test_default_chat_missing_deployment_name(
     assert response.status_code == 200
 
 
+@pytest.mark.skipif(not is_cohere_env_set, reason="Cohere API key not set")
 def test_streaming_fail_chat_missing_message(
     session_client_chat: TestClient, session_chat: Session, user: User
 ):
@@ -134,6 +142,7 @@ def test_streaming_fail_chat_missing_message(
     }
 
 
+@pytest.mark.skipif(not is_cohere_env_set, reason="Cohere API key not set")
 def test_streaming_chat_with_managed_tools(session_client_chat, session_chat, user):
     tools = session_client_chat.get("/tools", headers={"User-Id": user.id}).json()
     assert len(tools) > 0
@@ -156,6 +165,7 @@ def test_streaming_chat_with_managed_tools(session_client_chat, session_chat, us
     )
 
 
+@pytest.mark.skipif(not is_cohere_env_set, reason="Cohere API key not set")
 def test_streaming_chat_with_invalid_tool(
     session_client_chat: TestClient, session_chat: Session, user: User
 ):
@@ -172,6 +182,7 @@ def test_streaming_chat_with_invalid_tool(
     assert response.json() == {"detail": "Custom tools must have a description"}
 
 
+@pytest.mark.skipif(not is_cohere_env_set, reason="Cohere API key not set")
 def test_streaming_chat_with_managed_and_custom_tools(
     session_client_chat, session_chat, user
 ):
@@ -203,6 +214,7 @@ def test_streaming_chat_with_managed_and_custom_tools(
     assert response.json() == {"detail": "Cannot mix both managed and custom tools"}
 
 
+@pytest.mark.skipif(not is_cohere_env_set, reason="Cohere API key not set")
 def test_streaming_chat_with_search_queries_only(
     session_client_chat: TestClient, session_chat: Session, user: User
 ):
@@ -229,6 +241,7 @@ def test_streaming_chat_with_search_queries_only(
     )
 
 
+@pytest.mark.skipif(not is_cohere_env_set, reason="Cohere API key not set")
 def test_streaming_chat_with_chat_history(
     session_client_chat: TestClient, session_chat: Session
 ) -> None:
@@ -260,6 +273,7 @@ def test_streaming_chat_with_chat_history(
     )
 
 
+@pytest.mark.skipif(not is_cohere_env_set, reason="Cohere API key not set")
 def test_streaming_existing_chat_with_files_attaches_to_user_message(
     session_client_chat: TestClient, session_chat: Session, user: User
 ):
@@ -302,6 +316,7 @@ def test_streaming_existing_chat_with_files_attaches_to_user_message(
     )
 
 
+@pytest.mark.skipif(not is_cohere_env_set, reason="Cohere API key not set")
 def test_streaming_existing_chat_with_attached_files_does_not_attach(
     session_client_chat: TestClient, session_chat: Session, user: User
 ):
@@ -344,6 +359,7 @@ def test_streaming_existing_chat_with_attached_files_does_not_attach(
 
 
 # NON-STREAMING CHAT TESTS
+@pytest.mark.skipif(not is_cohere_env_set, reason="Cohere API key not set")
 def test_non_streaming_chat(
     session_client_chat: TestClient, session_chat: Session, user: User
 ):
@@ -362,6 +378,7 @@ def test_non_streaming_chat(
     validate_conversation(session_chat, user, conversation_id, 2)
 
 
+@pytest.mark.skipif(not is_cohere_env_set, reason="Cohere API key not set")
 def test_non_streaming_chat_with_managed_tools(session_client_chat, session_chat, user):
     tools = session_client_chat.get("/tools", headers={"User-Id": user.id}).json()
     assert len(tools) > 0
@@ -384,6 +401,7 @@ def test_non_streaming_chat_with_managed_tools(session_client_chat, session_chat
     validate_conversation(session_chat, user, conversation_id, 2)
 
 
+@pytest.mark.skipif(not is_cohere_env_set, reason="Cohere API key not set")
 def test_non_streaming_chat_with_managed_and_custom_tools(
     session_client_chat, session_chat, user
 ):
@@ -415,6 +433,7 @@ def test_non_streaming_chat_with_managed_and_custom_tools(
     assert response.json() == {"detail": "Cannot mix both managed and custom tools"}
 
 
+@pytest.mark.skipif(not is_cohere_env_set, reason="Cohere API key not set")
 def test_non_streaming_chat_with_custom_tools(session_client_chat, session_chat, user):
     response = session_client_chat.post(
         "/chat",
@@ -437,6 +456,7 @@ def test_non_streaming_chat_with_custom_tools(session_client_chat, session_chat,
     assert len(response.json()["tool_calls"]) == 1
 
 
+@pytest.mark.skipif(not is_cohere_env_set, reason="Cohere API key not set")
 def test_non_streaming_chat_with_search_queries_only(
     session_client_chat: TestClient, session_chat: Session, user: User
 ):
@@ -458,6 +478,7 @@ def test_non_streaming_chat_with_search_queries_only(
     validate_conversation(session_chat, user, conversation_id, 2)
 
 
+@pytest.mark.skipif(not is_cohere_env_set, reason="Cohere API key not set")
 def test_non_streaming_chat_with_chat_history(
     session_client_chat: TestClient, session_chat: Session
 ) -> None:
@@ -484,6 +505,7 @@ def test_non_streaming_chat_with_chat_history(
     validate_conversation(session_chat, user, conversation_id, 0)
 
 
+@pytest.mark.skipif(not is_cohere_env_set, reason="Cohere API key not set")
 def test_non_streaming_existing_chat_with_files_attaches_to_user_message(
     session_client_chat: TestClient, session_chat: Session, user: User
 ):
@@ -523,6 +545,7 @@ def test_non_streaming_existing_chat_with_files_attaches_to_user_message(
     assert message.agent == MessageAgent.USER
 
 
+@pytest.mark.skipif(not is_cohere_env_set, reason="Cohere API key not set")
 def test_non_streaming_existing_chat_with_attached_files_does_not_attach(
     session_client_chat: TestClient, session_chat: Session, user: User
 ):

--- a/src/backend/tests/tools/retrieval/test_collate.py
+++ b/src/backend/tests/tools/retrieval/test_collate.py
@@ -1,7 +1,14 @@
+import os
+
+import pytest
+
 from backend.chat.custom.model_deployments.cohere_platform import CohereDeployment
 from backend.tools.retrieval import collate
 
+is_cohere_env_set = os.environ.get("COHERE_API_KEY") is not None
 
+
+@pytest.mark.skipif(not is_cohere_env_set, reason="Cohere API key not set")
 def test_rerank() -> None:
     model = CohereDeployment()
     input = {

--- a/src/backend/tests/tools/retrieval/test_lang_chain.py
+++ b/src/backend/tests/tools/retrieval/test_lang_chain.py
@@ -1,11 +1,15 @@
+import os
 from unittest.mock import MagicMock, patch
 
+import pytest
 from langchain_core.documents.base import Document
 
 from backend.tools.retrieval.lang_chain import (
     LangChainVectorDBRetriever,
     LangChainWikiRetriever,
 )
+
+is_cohere_env_set = os.environ.get("COHERE_API_KEY") is not None
 
 
 def test_wiki_retriever() -> None:
@@ -54,6 +58,7 @@ def test_wiki_retriever() -> None:
     assert result == expected_docs
 
 
+@pytest.mark.skipif(not is_cohere_env_set, reason="Cohere API key not set")
 def test_wiki_retriever_no_docs() -> None:
     retriever = LangChainWikiRetriever()
     query = "Python programming"
@@ -71,6 +76,7 @@ def test_wiki_retriever_no_docs() -> None:
     assert result == []
 
 
+@pytest.mark.skipif(not is_cohere_env_set, reason="Cohere API key not set")
 def test_vector_db_retriever() -> None:
     file_path = "src/backend/tests/test_data/Mariana_Trench.pdf"
     retriever = LangChainVectorDBRetriever(file_path)
@@ -130,6 +136,7 @@ def test_vector_db_retriever() -> None:
     assert result == expected_docs
 
 
+@pytest.mark.skipif(not is_cohere_env_set, reason="Cohere API key not set")
 def test_vector_db_retriever_no_docs() -> None:
     file_path = "src/backend/tests/test_data/Mariana_Trench.pdf"
     retriever = LangChainVectorDBRetriever(file_path)


### PR DESCRIPTION
**Description:** cohere deployment is not required, so tests that depend on it should be skipped when the API key is not set