### PR TITLE
coral-web: support langchain multihop

### DIFF
--- a/src/interfaces/coral_web/src/cohere-client/client.ts
+++ b/src/interfaces/coral_web/src/cohere-client/client.ts
@@ -176,6 +176,39 @@ export class CohereClient {
     });
   }
 
+  public async langchainChat({
+    request,
+    headers,
+    signal,
+    onOpen,
+    onMessage,
+    onClose,
+    onError,
+  }: {
+    request: CohereChatRequest;
+    headers?: Record<string, string>;
+    signal?: AbortSignal;
+    onOpen?: FetchEventSourceInit['onopen'];
+    onMessage?: FetchEventSourceInit['onmessage'];
+    onClose?: FetchEventSourceInit['onclose'];
+    onError?: FetchEventSourceInit['onerror'];
+  }) {
+    const chatRequest = mapToChatRequest(request);
+    const requestBody = JSON.stringify({
+      ...chatRequest,
+    });
+    return await fetchEventSource(this.getEndpoint('langchain-chat'), {
+      method: 'POST',
+      headers: { ...this.getHeaders(), ...headers },
+      body: requestBody,
+      signal,
+      onopen: onOpen,
+      onmessage: onMessage,
+      onclose: onClose,
+      onerror: onError,
+    });
+  }
+
   public async listConversations({
     signal,
   }: {
@@ -344,6 +377,7 @@ export class CohereClient {
     endpoint:
       | 'upload'
       | 'chat-stream'
+      | 'langchain-chat'
       | 'conversations'
       | 'tools'
       | 'deployments'

--- a/src/interfaces/coral_web/src/cohere-client/generated/index.ts
+++ b/src/interfaces/coral_web/src/cohere-client/generated/index.ts
@@ -42,6 +42,7 @@ export type { StreamSearchQueriesGeneration } from './models/StreamSearchQueries
 export type { StreamSearchResults } from './models/StreamSearchResults';
 export type { StreamStart } from './models/StreamStart';
 export type { StreamTextGeneration } from './models/StreamTextGeneration';
+export type { StreamToolCallsGeneration } from './models/StreamToolCallsGeneration';
 export type { StreamToolInput } from './models/StreamToolInput';
 export type { StreamToolResult } from './models/StreamToolResult';
 export type { Tool } from './models/Tool';

--- a/src/interfaces/coral_web/src/cohere-client/generated/models/ChatResponseEvent.ts
+++ b/src/interfaces/coral_web/src/cohere-client/generated/models/ChatResponseEvent.ts
@@ -14,6 +14,7 @@ import type { StreamSearchQueriesGeneration } from './StreamSearchQueriesGenerat
 import type { StreamSearchResults } from './StreamSearchResults';
 import type { StreamStart } from './StreamStart';
 import type { StreamTextGeneration } from './StreamTextGeneration';
+import type { StreamToolCallsGeneration } from './StreamToolCallsGeneration';
 import type { StreamToolInput } from './StreamToolInput';
 import type { StreamToolResult } from './StreamToolResult';
 
@@ -29,5 +30,6 @@ export type ChatResponseEvent = {
     | StreamToolInput
     | StreamToolResult
     | StreamSearchQueriesGeneration
+    | StreamToolCallsGeneration
     | NonStreamedChatResponse;
 };

--- a/src/interfaces/coral_web/src/cohere-client/generated/models/ManagedTool.ts
+++ b/src/interfaces/coral_web/src/cohere-client/generated/models/ManagedTool.ts
@@ -13,5 +13,7 @@ export type ManagedTool = {
   parameter_definitions?: Record<string, any> | null;
   kwargs?: Record<string, any>;
   is_visible?: boolean;
+  is_available?: boolean;
+  error_message?: string | null;
   category?: Category;
 };

--- a/src/interfaces/coral_web/src/cohere-client/generated/models/StreamEnd.ts
+++ b/src/interfaces/coral_web/src/cohere-client/generated/models/StreamEnd.ts
@@ -8,15 +8,17 @@
 import type { Citation } from './Citation';
 import type { Document } from './Document';
 import type { SearchQuery } from './SearchQuery';
+import type { ToolCall } from './ToolCall';
 
 export type StreamEnd = {
-  response_id: string | null;
-  generation_id: string | null;
-  conversation_id: string | null;
+  response_id?: string | null;
+  generation_id?: string | null;
+  conversation_id?: string | null;
   text: string;
   citations?: Array<Citation>;
   documents?: Array<Document>;
   search_results?: Array<Record<string, any>>;
   search_queries?: Array<SearchQuery>;
+  tool_calls?: Array<ToolCall>;
   finish_reason: string;
 };

--- a/src/interfaces/coral_web/src/cohere-client/generated/models/StreamToolCallsGeneration.ts
+++ b/src/interfaces/coral_web/src/cohere-client/generated/models/StreamToolCallsGeneration.ts
@@ -1,12 +1,16 @@
 /* generated using openapi-typescript-codegen -- do no edit */
+
 /* istanbul ignore file */
+
 /* tslint:disable */
+
 /* eslint-disable */
+import type { ToolCall } from './ToolCall';
+
 /**
- * Stream start event.
+ * Stream tool calls generation event.
  */
-export type StreamStart = {
+export type StreamToolCallsGeneration = {
   is_finished: boolean;
-  generation_id?: string | null;
-  conversation_id?: string | null;
+  tool_calls?: Array<ToolCall>;
 };

--- a/src/interfaces/coral_web/src/cohere-client/generated/models/StreamToolResult.ts
+++ b/src/interfaces/coral_web/src/cohere-client/generated/models/StreamToolResult.ts
@@ -9,6 +9,7 @@ import type { Document } from './Document';
 
 export type StreamToolResult = {
   is_finished: boolean;
-  result: string | null;
+  result: any;
+  tool_name: string;
   documents?: Array<Document>;
 };

--- a/src/interfaces/coral_web/src/cohere-client/generated/services/DefaultService.ts
+++ b/src/interfaces/coral_web/src/cohere-client/generated/services/DefaultService.ts
@@ -597,7 +597,7 @@ export class DefaultService {
    * List all available tools.
    *
    * Returns:
-   * list[Tool]: List of available tools.
+   * list[ManagedTool]: List of available tools.
    * @returns ManagedTool Successful Response
    * @throws ApiError
    */

--- a/src/interfaces/coral_web/src/components/Citations/CitationDocument.tsx
+++ b/src/interfaces/coral_web/src/components/Citations/CitationDocument.tsx
@@ -151,7 +151,6 @@ export const CitationDocument: React.FC<Props> = ({ document, isExpandable = fal
       {isExpanded && isExpandable && (
         <div className="flex flex-col">
           {getSnippet(30, 'line-clamp-3')}
-          {/* TODO(jessica): should we enable this/will we support this? */}
           <button
             className="self-end p-0 text-primary-900 transition-colors ease-in-out hover:text-primary-700"
             onClick={openFullSnippetModal}

--- a/src/interfaces/coral_web/src/components/Citations/CitationTextHighlighter.tsx
+++ b/src/interfaces/coral_web/src/components/Citations/CitationTextHighlighter.tsx
@@ -80,7 +80,6 @@ export const CitationTextHighlighter: React.FC<Props> = ({
             generationId={generationId}
             // Used to find the keyword to bold but since we don't have it yet here when the message is
             // still streaming in we can just ignore it for now instead of not showing the popup at all
-            // TODO(jessica): pass in cited text from citation event as a backup
             message={message?.originalText ?? ''}
           />
         ),

--- a/src/interfaces/coral_web/src/components/MarkdownImage.tsx
+++ b/src/interfaces/coral_web/src/components/MarkdownImage.tsx
@@ -1,0 +1,53 @@
+import { Text } from '@/components/Shared';
+import { useCitationsStore } from '@/stores';
+
+type Props = {
+  node: {
+    properties: {
+      alt: string;
+      src: string;
+    };
+  };
+};
+
+/**
+ * @description Renders an image markdown node. Inserts files from the citations
+ * store if they exist as a base64 image, otherwise uses the file path.
+ */
+export const MarkdownImage: React.FC<Props> = ({ node }) => {
+  const {
+    citations: { outputFiles },
+  } = useCitationsStore();
+
+  const caption = node.properties.alt;
+  // Remove quotes from the url
+  const fileName = decodeURIComponent(node.properties.src).replace(/['"]/g, '');
+
+  if (outputFiles[fileName]) {
+    return <B64Image data={outputFiles[fileName].data} caption={caption} />;
+  } else {
+    return (
+      <>
+        <img className="w-full" src={fileName} alt={caption} />
+        {caption && (
+          <Text as="span" styleAs="caption" className="mb-2 text-secondary-800">
+            {caption}
+          </Text>
+        )}
+      </>
+    );
+  }
+};
+
+export const B64Image: React.FC<{ data: string; caption?: string }> = ({ data, caption }) => {
+  return (
+    <>
+      <img className="w-full" src={`data:image/png;base64,${data}`} alt={caption} />
+      {caption && (
+        <Text as="span" styleAs="caption" className="mb-2 text-secondary-800">
+          {caption}
+        </Text>
+      )}
+    </>
+  );
+};

--- a/src/interfaces/coral_web/src/components/MessageContent.tsx
+++ b/src/interfaces/coral_web/src/components/MessageContent.tsx
@@ -3,6 +3,7 @@ import { PropsWithChildren } from 'react';
 
 import { CitationTextHighlighter } from '@/components/Citations/CitationTextHighlighter';
 import { DataTable } from '@/components/DataTable';
+import { MarkdownImage } from '@/components/MarkdownImage';
 import { Icon } from '@/components/Shared';
 import { Markdown, Text } from '@/components/Shared';
 import { UploadedFile } from '@/components/UploadedFile';
@@ -108,6 +109,7 @@ export const MessageContent: React.FC<Props> = ({ isLast, message, onRetry }) =>
           })}
           text={message.text}
           customComponents={{
+            img: MarkdownImage as any,
             cite: CitationTextHighlighter as any,
             table: DataTable as any,
           }}

--- a/src/interfaces/coral_web/src/components/ToolEvents.tsx
+++ b/src/interfaces/coral_web/src/components/ToolEvents.tsx
@@ -1,0 +1,115 @@
+import { Transition } from '@headlessui/react';
+import { Fragment, PropsWithChildren } from 'react';
+
+import { StreamToolInput, ToolInputType } from '@/cohere-client';
+import { Icon, IconName, Markdown, Text } from '@/components/Shared';
+import {
+  TOOL_FALLBACK_ICON,
+  TOOL_ID_TO_DISPLAY_INFO,
+  TOOL_INTERNET_SEARCH_ID,
+  TOOL_PYTHON_INTERPRETER_ID,
+} from '@/constants';
+import { cn } from '@/utils';
+
+type Props = {
+  show: boolean;
+  events: StreamToolInput[] | undefined;
+};
+
+/**
+ * @description Renders a list of events depending on the model's plan and tool inputs.
+ */
+export const ToolEvents: React.FC<Props> = ({ show, events }) => {
+  return (
+    <Transition
+      show={show}
+      enterFrom="opacity-0"
+      enterTo="opacity-100"
+      enter="duration-500"
+      leaveFrom="opacity-100"
+      leaveTo="opacity-0"
+      className={cn('flex w-full flex-col gap-y-2 pb-2', 'transition-opacity ease-in-out')}
+    >
+      {events?.map((toolEvent, i) => (
+        <Fragment key={i}>
+          {toolEvent.text && <ToolEvent plan={toolEvent.text} />}
+          <ToolEvent event={toolEvent} />
+        </Fragment>
+      ))}
+    </Transition>
+  );
+};
+
+type ToolEventProps = {
+  plan?: string;
+  event?: StreamToolInput;
+};
+
+/**
+ * @description Renders a step event depending on the tool's input or output.
+ */
+const ToolEvent: React.FC<ToolEventProps> = ({ plan, event }) => {
+  if (!event) {
+    return <ToolEventWrapper>{plan}</ToolEventWrapper>;
+  }
+
+  const toolName = event.tool_name;
+  const input = event.input;
+  const icon = toolName ? TOOL_ID_TO_DISPLAY_INFO[toolName]?.icon : TOOL_FALLBACK_ICON;
+
+  switch (toolName) {
+    case TOOL_PYTHON_INTERPRETER_ID: {
+      if (event.input_type === ToolInputType.CODE) {
+        let codeString = '```python\n';
+        codeString += input;
+        codeString += '\n```';
+
+        return (
+          <>
+            <ToolEventWrapper icon={icon}>
+              Using <b className="font-medium">{toolName}</b>
+            </ToolEventWrapper>
+            <Markdown text={codeString} className="w-full" />
+          </>
+        );
+      } else {
+        return (
+          <ToolEventWrapper icon={icon}>
+            Using <b className="font-medium">{toolName}</b>
+          </ToolEventWrapper>
+        );
+      }
+    }
+
+    case TOOL_INTERNET_SEARCH_ID: {
+      return (
+        <ToolEventWrapper icon={icon}>
+          Searching <b className="font-medium">{input}</b>
+        </ToolEventWrapper>
+      );
+    }
+
+    default: {
+      return (
+        <ToolEventWrapper icon={icon}>
+          Using <b className="font-medium">{toolName}</b>
+        </ToolEventWrapper>
+      );
+    }
+  }
+};
+
+/**
+ * @description Renders the wrapper for the tool event.
+ */
+const ToolEventWrapper: React.FC<PropsWithChildren<{ icon?: IconName }>> = ({
+  icon = 'list',
+  children,
+}) => {
+  return (
+    <div className="flex w-full gap-x-2 rounded bg-secondary-50 px-3 py-2 transition-colors ease-in-out group-hover:bg-secondary-100">
+      <Icon name={icon} kind="outline" className="flex h-[21px] items-center text-secondary-600" />
+      <Text className="text-secondary-800">{children}</Text>
+    </div>
+  );
+};

--- a/src/interfaces/coral_web/src/constants.ts
+++ b/src/interfaces/coral_web/src/constants.ts
@@ -1,3 +1,4 @@
+import { IconName } from '@/components/Shared';
 import { FileAccept } from '@/components/Shared/DragDropFileInput';
 
 export const DEFAULT_CONVERSATION_NAME = 'Chat with Coral';
@@ -34,4 +35,15 @@ export const CONFIGURATION_PANEL_ID = 'configuration';
 export const LOCAL_STORAGE_KEYS = {
   welcomeGuideState: 'onboarding/welcome/onboardState',
   welcomeGuideInfoBox: 'onboarding/welcome/infoBox',
+};
+
+// Tools
+export const TOOL_INTERNET_SEARCH_ID = 'internet_search';
+export const TOOL_PYTHON_INTERPRETER_ID = 'python_interpreter';
+
+export const TOOL_FALLBACK_ICON = 'circles-four';
+
+export const TOOL_ID_TO_DISPLAY_INFO: { [id: string]: { name: string; icon: IconName } } = {
+  [TOOL_INTERNET_SEARCH_ID]: { name: 'Internet Search', icon: 'search' },
+  [TOOL_PYTHON_INTERPRETER_ID]: { name: 'Python Interpreter', icon: 'code' },
 };

--- a/src/interfaces/coral_web/src/stores/index.ts
+++ b/src/interfaces/coral_web/src/stores/index.ts
@@ -32,6 +32,7 @@ export const useCitationsStore = () => {
       selectCitation: state.selectCitation,
       hoverCitation: state.hoverCitation,
       resetCitations: state.resetCitations,
+      saveOutputFiles: state.saveOutputFiles,
     }),
     shallow
   );

--- a/src/interfaces/coral_web/src/stores/slices/citationsSlice.ts
+++ b/src/interfaces/coral_web/src/stores/slices/citationsSlice.ts
@@ -10,6 +10,7 @@ const INITIAL_STATE: State = {
   selectedCitation: null,
   hoveredGenerationId: null,
   searchResults: {},
+  outputFiles: {},
 };
 
 type Citation = {
@@ -31,12 +32,15 @@ interface SearchResults {
   [documentId: string]: Record<string, any>;
 }
 
+export type OutputFiles = { [name: string]: { name: string; data: string } };
+
 type State = {
   citationReferences: CitationReferences;
   hasCitations: boolean;
   selectedCitation: Citation | null;
   hoveredGenerationId: string | null;
   searchResults: SearchResults;
+  outputFiles: OutputFiles;
 };
 
 type Actions = {
@@ -45,6 +49,7 @@ type Actions = {
   selectCitation: (citation: Citation | null) => void;
   hoverCitation: (generationId: string | null) => void;
   resetCitations: VoidFunction;
+  saveOutputFiles: (outputFiles: OutputFiles) => void;
 };
 
 export type CitationsStore = {
@@ -102,6 +107,14 @@ export const createCitationsSlice: StateCreator<StoreState, [], [], CitationsSto
   resetCitations() {
     set(() => ({
       citations: INITIAL_STATE,
+    }));
+  },
+  saveOutputFiles(outputFiles) {
+    set((state) => ({
+      citations: {
+        ...state.citations,
+        outputFiles,
+      },
     }));
   },
   citations: INITIAL_STATE,

--- a/src/interfaces/coral_web/src/themes/cohereTheme.js
+++ b/src/interfaces/coral_web/src/themes/cohereTheme.js
@@ -1,11 +1,9 @@
 const defaultTheme = require('tailwindcss/defaultTheme');
 
-// any changes to the theme should be reflected into our `customTwMerge` in  `utils/cn.ts`
+// Any changes to the theme should be reflected into our `customTwMerge` in `utils/cn.ts`
 module.exports = {
   theme: {
     extend: {
-      // TODO(jessica): shift colors to `extend` for now so that using the old theme and nature theme
-      // merge nicely
       colors: {
         transparent: 'transparent',
         pureWhite: '#FFFFFF',

--- a/src/interfaces/coral_web/src/types/message.ts
+++ b/src/interfaces/coral_web/src/types/message.ts
@@ -1,4 +1,4 @@
-import { Citation, File } from '@/cohere-client';
+import { Citation, File, StreamToolInput } from '@/cohere-client';
 
 export enum BotState {
   LOADING = 'loading',
@@ -38,8 +38,7 @@ export type FulfilledMessage = BaseMessage & {
   citations?: Citation[];
   isRAGOn?: boolean;
   originalText: string;
-  /* UUID to trace log from given response */
-  traceId?: string;
+  toolEvents?: StreamToolInput[];
 };
 
 /**
@@ -48,6 +47,7 @@ export type FulfilledMessage = BaseMessage & {
 export type AbortedMessage = BaseMessage & {
   type: MessageType.BOT;
   state: BotState.ABORTED;
+  toolEvents?: StreamToolInput[];
 };
 
 /**
@@ -66,9 +66,10 @@ export type TypingMessage = BaseMessage & {
   type: MessageType.BOT;
   state: BotState.TYPING;
   generationId: string;
+  originalText: string;
   citations?: Citation[];
   isRAGOn?: boolean;
-  originalText: string;
+  toolEvents?: StreamToolInput[];
 };
 
 /**
@@ -77,6 +78,7 @@ export type TypingMessage = BaseMessage & {
 export type ErrorMessage = BaseMessage & {
   type: MessageType.BOT;
   state: BotState.ERROR;
+  toolEvents?: StreamToolInput[];
 };
 
 /**

--- a/src/interfaces/coral_web/src/utils/citations.ts
+++ b/src/interfaces/coral_web/src/utils/citations.ts
@@ -1,6 +1,15 @@
 import { Citation } from '@/cohere-client';
 
 /**
+ * @description Helper function to temporarily ensure markdown image syntax provided by the model is correct.
+ * This is a temporary fix as the current model is consistently returning incorrect markdown image syntax.
+ * @param text - message text or citation text
+ */
+export const fixMarkdownImagesInText = (text: string) => {
+  return text.replace('! [', '![');
+};
+
+/**
  * Replace text string with citations following the format:
  *  :cite[<text>]{generationId="<generationId>" start="<startIndex>" end"<endIndex>"}
  * @param text
@@ -20,11 +29,16 @@ export const replaceTextWithCitations = (
   citations.forEach(({ start = 0, end = 0, text: citationText }) => {
     const citeStart = start + lengthDifference;
     const citeEnd = end + lengthDifference;
+
+    const fixedText = fixMarkdownImagesInText(citationText);
+
     // Encode the citationText in case there are any weird characters or unclosed brackets that will
-    // interfere with parsing the markdown.
-    const citationId = `:cite[${encodeURIComponent(
-      citationText ?? ''
-    )}]{generationId="${generationId}" start="${start}" end="${end}"}`;
+    // interfere with parsing the markdown. However, let markdown images through so they may be properly
+    // rendered.
+    const isMarkdownImage = fixedText.match(/!\[.*\]\(.*\)/);
+    const encodedCitationText = isMarkdownImage ? fixedText : encodeURIComponent(fixedText);
+    const citationId = `:cite[${encodedCitationText}]{generationId="${generationId}" start="${start}" end="${end}"}`;
+
     replacedText = replacedText.slice(0, citeStart) + citationId + replacedText.slice(citeEnd);
     lengthDifference += citationId.length - (citeEnd - citeStart);
   });


### PR DESCRIPTION
**Description:**

This PR adds support for rendering tool events sent from the langchain multihop chat endpoint, including adding the functionality to render images from the python interpreter in multihop mode.

**Tests:**

To test, add `USE_EXPERIMENTAL_LANGCHAIN=true` to your `.env` file. Then, select the `python_interpreter` and `internet search` tools and ask a query like `plot the 3 tallest mountains in the world`.

https://github.com/cohere-ai/cohere-toolkit/assets/5898755/bb1b0c5e-0734-4f9c-afe6-cb4f56110e46