### PR TITLE
deployment: add docker compose down command in Makefile.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 dev:
 	@docker compose watch
+down:
+	@docker compose down
 run-tests:
 	docker compose run --build backend poetry run pytest src/backend/tests/$(file)
 run-community-tests:


### PR DESCRIPTION

  - **Description:** Add a target to Makefile to stop all containers.

i'm not sure if using `stop -> docker compose down` is more appropriate compared to using `stop -> docker compose stop` and `down -> docker compose down`. please feel free to adjust according to community consensus and norms.
