### PR TITLE
Change deployment > model in CLI

### DIFF
--- a/cli/main.py
+++ b/cli/main.py
@@ -14,8 +14,8 @@ class bcolors:
 
 
 """
-To add a new deployment, add a new DeploymentName enum and a new entry in the DEPLOYMENTS dictionary containing the secrets required for the deployment.
-If the deployment requires a custom implementation, add a new key "custom_implementation" with the function that will be called to set up the deployment.
+To add a new model, create a new DeploymentName enum and a new entry in the DEPLOYMENTS dictionary containing the secrets required for the model deployment.
+If the model requires a custom implementation, add a new key "custom_implementation" with the function that will be called to set up the model deployment.
 """
 
 
@@ -134,10 +134,10 @@ def write_env_file(secrets):
 
 
 def select_deployments_prompt(_):
-    print_styled("🚀 Let's set up your deployments.", bcolors.MAGENTA)
+    print_styled("🚀 Let's set up your model.", bcolors.MAGENTA)
 
     deployments = inquirer.checkbox(
-        "Select the deployments you want to set up",
+        "Select the chat model deployment that will power your application and follow the setup instructions.",
         choices=[deployment.value for deployment in DeploymentName],
         default=["Cohere Platform"],
         validate=lambda _, x: len(x) > 0,


### PR DESCRIPTION

Thank you for contributing to the Cohere Toolkit!

- [ ] **Change deployment > model in CLI**: "main.cli: mentions of deployment updated to be 'model'"
Users were getting confused by deployment being required, thinking that it was the app deployment. updates description to clarify that users should select a model in order for the app to work.


- [ ] **PR message**: 
    - **Description:** In main.cli, update mentions of deployment in the instructions to model.


- [ ] **Add tests and docs**: Please include testing and documentation for your changes
- [ ] **Lint and test**: Run `make lint` and `make run-tests` 