### PR TITLE
coral_web: Add is_available check to tools

### DIFF
--- a/src/interfaces/coral_web/src/components/Configuration/Tools.tsx
+++ b/src/interfaces/coral_web/src/components/Configuration/Tools.tsx
@@ -41,7 +41,7 @@ const ToolSection = () => {
   const { params, setParams } = useParamsStore();
   const { data } = useListTools();
   const { tools: paramTools } = params;
-  const tools = data?.filter((t) => t.is_visible) ?? [];
+  const tools = data?.filter((t) => t.is_visible && t.is_available) ?? [];
   const enabledTools = paramTools ?? [];
   const name = `select-all-tools`;
 

--- a/src/interfaces/coral_web/src/components/Configuration/Tools.tsx
+++ b/src/interfaces/coral_web/src/components/Configuration/Tools.tsx
@@ -41,7 +41,7 @@ const ToolSection = () => {
   const { params, setParams } = useParamsStore();
   const { data } = useListTools();
   const { tools: paramTools } = params;
-  const tools = data?.filter((t) => t.is_visible && t.is_available) ?? [];
+  const tools = data?.filter((t) => t.is_visible) ?? [];
   const enabledTools = paramTools ?? [];
   const name = `select-all-tools`;
 
@@ -95,11 +95,12 @@ const ToolSection = () => {
             />
           </div>
           <div className="flex flex-col gap-y-5">
-            {tools.map(({ name, error_message }) => {
+            {tools.map(({ name, is_available, description, error_message }) => {
               const enabledTool = enabledTools.find(
                 (enabledTool) => enabledTool.name.toLocaleLowerCase() === name.toLocaleLowerCase()
               );
               const checked = !!enabledTool;
+              const disabled = !is_available;
 
               return (
                 <div key={name} className="flex items-center gap-x-1">
@@ -112,8 +113,12 @@ const ToolSection = () => {
                     name={name}
                     theme="secondary"
                     dataTestId={`checkbox-tool-${name}`}
+                    labelClassName={cn({
+                      'text-volcanic-500': disabled,
+                    })}
+                    disabled={disabled}
                   />
-                  {error_message && <Tooltip label={error_message} />}
+                  {(description || error_message) && <Tooltip label={description ?? error_message} />}
                 </div>
               );
             })}

--- a/src/interfaces/coral_web/src/components/Configuration/Tools.tsx
+++ b/src/interfaces/coral_web/src/components/Configuration/Tools.tsx
@@ -4,7 +4,7 @@ import React, { Fragment } from 'react';
 import { Tool } from '@/cohere-client';
 import { FilesSection } from '@/components/Configuration/Files';
 import { ToolsInfoBox } from '@/components/Configuration/ToolsInfoBox';
-import { Checkbox, Switch, Text } from '@/components/Shared';
+import { Checkbox, Switch, Text, Tooltip } from '@/components/Shared';
 import { WelcomeGuideTooltip } from '@/components/WelcomeGuideTooltip';
 import { useFilesInConversation } from '@/hooks/files';
 import { useListTools } from '@/hooks/tools';
@@ -95,17 +95,17 @@ const ToolSection = () => {
             />
           </div>
           <div className="flex flex-col gap-y-5">
-            {tools.map(({ name }) => {
+            {tools.map(({ name, error_message }) => {
               const enabledTool = enabledTools.find(
                 (enabledTool) => enabledTool.name.toLocaleLowerCase() === name.toLocaleLowerCase()
               );
               const checked = !!enabledTool;
 
               return (
-                <Fragment key={name}>
+                <div key={name} className="flex items-center gap-x-1">
                   <Checkbox
                     checked={checked}
-                    onChange={async (e) => {
+                    onChange={(e) => {
                       onToolToggle(name, e.target.checked);
                     }}
                     label={name}
@@ -113,7 +113,8 @@ const ToolSection = () => {
                     theme="secondary"
                     dataTestId={`checkbox-tool-${name}`}
                   />
-                </Fragment>
+                  {error_message && <Tooltip label={error_message} />}
+                </div>
               );
             })}
           </div>


### PR DESCRIPTION
**Description**
- disables tools that have a false `is_available` value
- add tool `description` as tooltip, else  use `error_message`

![Screenshot 2024-05-01 at 11 13 48](https://github.com/cohere-ai/cohere-toolkit/assets/140425731/28a9e773-a7e5-4ef9-a4e7-9e54e85366ab)

