### PR TITLE
coral-web: include conversationId in file upload

### DIFF
--- a/src/interfaces/coral_web/src/components/Conversation/index.tsx
+++ b/src/interfaces/coral_web/src/components/Conversation/index.tsx
@@ -151,7 +151,7 @@ const Conversation: React.FC<Props> = ({ conversationId, welcomeMessageEnabled =
   };
 
   const handleUploadFile = async (e: React.ChangeEvent<HTMLInputElement>) => {
-    const newFileIds = await uploadFile(e.target.files?.[0]);
+    const newFileIds = await uploadFile(e.target.files?.[0], conversationId);
     if (!newFileIds) return;
     if (startOption !== StartOptionKey.DOCUMENTS) {
       setStartOption(StartOptionKey.DOCUMENTS);


### PR DESCRIPTION
**Description**
File uploads were always creating a new conversation due to the conversation id being missing from the request. The PR adds the `conversation_id` to the file upload request