### PR TITLE
backend: Set up next.js to proxy requests to the API

### DIFF
--- a/src/backend/routers/conversation.py
+++ b/src/backend/routers/conversation.py
@@ -56,7 +56,7 @@ def get_conversation(
     return conversation
 
 
-@router.get("/", response_model=list[ConversationWithoutMessages])
+@router.get("", response_model=list[ConversationWithoutMessages])
 def list_conversations(
     *, offset: int = 0, limit: int = 100, session: DBSessionDep, request: Request
 ) -> list[ConversationWithoutMessages]:

--- a/src/backend/routers/deployment.py
+++ b/src/backend/routers/deployment.py
@@ -12,7 +12,7 @@ router = APIRouter(
 )
 
 
-@router.get("/", response_model=list[Deployment])
+@router.get("", response_model=list[Deployment])
 def list_deployments(all: bool = False) -> list[Deployment]:
     """
     List all available deployments and their models.

--- a/src/backend/routers/tool.py
+++ b/src/backend/routers/tool.py
@@ -6,7 +6,7 @@ from backend.schemas.tool import ManagedTool
 router = APIRouter(prefix="/tools")
 
 
-@router.get("/", response_model=list[ManagedTool])
+@router.get("", response_model=list[ManagedTool])
 def list_tools() -> list[ManagedTool]:
     """
     List all available tools.

--- a/src/interfaces/coral_web/.env.development
+++ b/src/interfaces/coral_web/.env.development
@@ -1,2 +1,2 @@
 # Client
-NEXT_PUBLIC_API_HOSTNAME=http://localhost:8000
+NEXT_PUBLIC_API_HOSTNAME=http://backend:8000

--- a/src/interfaces/coral_web/next.config.mjs
+++ b/src/interfaces/coral_web/next.config.mjs
@@ -41,6 +41,14 @@ const nextConfig = {
       },
     ];
   },
+  async rewrites() {
+    return [
+      {
+        source: '/api/:path*',
+        destination: `${env.NEXT_PUBLIC_API_HOSTNAME}/:path*`,
+      },
+    ];
+  }
 };
 
 const getNextConfig = (phase) => {

--- a/src/interfaces/coral_web/src/cohere-client/client.ts
+++ b/src/interfaces/coral_web/src/cohere-client/client.ts
@@ -214,7 +214,7 @@ export class CohereClient {
   }: {
     signal?: AbortSignal;
   }): Promise<ConversationWithoutMessages[]> {
-    const response = await this.fetch(`${this.getEndpoint('conversations')}/`, {
+    const response = await this.fetch(`${this.getEndpoint('conversations')}`, {
       method: 'GET',
       headers: this.getHeaders(),
       signal,
@@ -301,7 +301,7 @@ export class CohereClient {
   }
 
   public async listTools({ signal }: { signal?: AbortSignal }): Promise<Tool[]> {
-    const response = await this.fetch(`${this.getEndpoint('tools')}/`, {
+    const response = await this.fetch(`${this.getEndpoint('tools')}`, {
       method: 'GET',
       headers: this.getHeaders(),
       signal,
@@ -320,7 +320,7 @@ export class CohereClient {
   }
 
   public async listDeployments(): Promise<Deployment[]> {
-    const response = await this.fetch(`${this.getEndpoint('deployments')}/`, {
+    const response = await this.fetch(`${this.getEndpoint('deployments')}`, {
       method: 'GET',
       headers: this.getHeaders(),
     });
@@ -338,7 +338,7 @@ export class CohereClient {
   }
 
   public async listAllDeployments(): Promise<Deployment[]> {
-    const response = await this.fetch(`${this.getEndpoint('deployments')}/?all=1`, {
+    const response = await this.fetch(`${this.getEndpoint('deployments')}?all=1`, {
       method: 'GET',
       headers: this.getHeaders(),
     });
@@ -383,7 +383,7 @@ export class CohereClient {
       | 'deployments'
       | 'experimental_features'
   ) {
-    return `${this.hostname}/${endpoint}`;
+    return `/api/${endpoint}`;
   }
 
   private getHeaders(omitContentType = false) {


### PR DESCRIPTION
Google Cloud Run only allows us to have one open port for the application. This means that if we want to run the backend and the frontend in the same container on GCR, the client won't be able to directly reach the backend and we'll need to proxy through the next.js application serving the frontend code.

This change adds a `rewrite` rule to the next.js config to allow for that proxying. The way this PR is written now, all API requests would be changed to route through next.js, though it would be possible to make that configurable to skip a hop.