### PR TITLE
tools: Update default NEXT_PUBLIC_API_HOSTNAME for the new api routing

### DIFF
--- a/.env-template
+++ b/.env-template
@@ -1,5 +1,5 @@
 # REQUIRED VARIABLES
-NEXT_PUBLIC_API_HOSTNAME=http://localhost:8000
+NEXT_PUBLIC_API_HOSTNAME=http://backend:8000
 DATABASE_URL=postgresql+psycopg2://postgres:postgres@db:5432
 
 # TOOLS

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ And then retry `poetry --version`
 
 - `COHERE_API_KEY`: If your application will interface with Cohere's API, you will need to supply an API key. Not required if using AWS Sagemaker or Azure.
   Sign up at https://dashboard.cohere.com/ to create an API key.
-- `NEXT_PUBLIC_API_HOSTNAME`: The backend URL which the frontend will communicate with. Defaults to http://localhost:8000
+- `NEXT_PUBLIC_API_HOSTNAME`: The backend URL which the frontend will communicate with. Defaults to http://backend:8000 for use with `docker compose`
 - `DATABASE_URL`: Your PostgreSQL database connection string for SQLAlchemy, should follow the format `postgresql+psycopg2://USER:PASSWORD@HOST:PORT`.
 
 ### AWS Sagemaker

--- a/src/backend/cli/main.py
+++ b/src/backend/cli/main.py
@@ -42,7 +42,7 @@ WELCOME_MESSAGE = r"""
 """
 DATABASE_URL_DEFAULT = "postgresql+psycopg2://postgres:postgres@db:5432"
 PYTHON_INTERPRETER_URL_DEFAULT = "http://localhost:8080"
-NEXT_PUBLIC_API_HOSTNAME_DEFAULT = "http://localhost:8000"
+NEXT_PUBLIC_API_HOSTNAME_DEFAULT = "http://backend:8000"
 
 DOT_ENV_FILE_PATH = ".env"
 


### PR DESCRIPTION
With the new routing of API requests through next.js, we need to update the default `NEXT_PUBLIC_API_HOSTNAME` value set in the `.env` file when running setup.