### PR TITLE
Removed setup only dependency for makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ reset-db:
 	docker compose down
 	docker volume rm cohere_toolkit_db
 setup:
-	poetry install --only setup --verbose
+	poetry install --verbose
 	poetry run python3 src/backend/cli/main.py
 lint:
 	poetry run black .


### PR DESCRIPTION
Thank you for contributing to the Cohere Toolkit!

- [ ] **PR title**: "area: environment setup"

- [ ] **PR message**:  I've tried to install for debian 12 using the linux friendly instructions in the quickstart and the option 2 installation instructions. However, the `make setup` or `make first-run` commands fail with dependency errors. I think this is because of the `--only setup` restriction, which could restrict the dependency installs from pyproject.toml solely to setup dependencies rather than all dependencies
    - **Description:** Removes the setup-only restriction
    - **Dependencies:** none
    