### PR TITLE
coral_web: Show both tool description and error message when available

### DIFF
--- a/src/interfaces/coral_web/src/components/Configuration/Tools.tsx
+++ b/src/interfaces/coral_web/src/components/Configuration/Tools.tsx
@@ -119,7 +119,16 @@ const ToolSection = () => {
                     disabled={disabled}
                   />
                   {(description || error_message) && (
-                    <Tooltip label={description ?? error_message} />
+                    <Tooltip
+                      label={
+                        <div className="flex flex-col gap-y-2">
+                          {description && <Text>{description}</Text>}
+                          {error_message && (
+                            <Text className="text-danger-500">Error: {error_message}</Text>
+                          )}
+                        </div>
+                      }
+                    />
                   )}
                 </div>
               );

--- a/src/interfaces/coral_web/src/components/Shared/Logo.tsx
+++ b/src/interfaces/coral_web/src/components/Shared/Logo.tsx
@@ -17,13 +17,7 @@ export const Logo: React.FC<LogoProps> = ({
 }) => {
   if (hasCustomLogo === 'true') {
     // Modify this section to render a custom logo or text based on specific design guidelines.
-    return (
-      <img
-        src="/images/logo.png"
-        alt="Logo"
-        className={cx('h-full', className)}
-      />
-    );
+    return <img src="/images/logo.png" alt="Logo" className={cx('h-full', className)} />;
   }
 
   return (
@@ -76,5 +70,5 @@ export const Logo: React.FC<LogoProps> = ({
         })}
       />
     </svg>
-  )
-}
+  );
+};


### PR DESCRIPTION
<img width="446" alt="Screenshot 2024-05-16 at 15 24 29" src="https://github.com/cohere-ai/cohere-toolkit/assets/140425731/f67e62b7-3bb6-44e3-b4db-23830376eb3a">
