### PR TITLE
tools: Update default API hostname to localhost:8000

### DIFF
--- a/src/backend/cli/main.py
+++ b/src/backend/cli/main.py
@@ -43,7 +43,7 @@ WELCOME_MESSAGE = r"""
 """
 DATABASE_URL_DEFAULT = "postgresql+psycopg2://postgres:postgres@db:5432"
 PYTHON_INTERPRETER_URL_DEFAULT = "http://terrarium:8080"
-NEXT_PUBLIC_API_HOSTNAME_DEFAULT = "http://backend:8000"
+NEXT_PUBLIC_API_HOSTNAME_DEFAULT = "http://localhost:8000"
 
 DOT_ENV_FILE_PATH = ".env"
 


### PR DESCRIPTION
When we removed the proxy from the frontend, we didn't update the CLI setup script to use `localhost:8000` as the default backend instead of `backend:8000`.

<!-- begin-generated-description -->

This pull request updates the `NEXT_PUBLIC_API_HOSTNAME_DEFAULT` in the `main.py` file.

## Summary
The pull request updates the `NEXT_PUBLIC_API_HOSTNAME_DEFAULT` variable in the `main.py` file to use "http://localhost:8000" as the default API hostname instead of "http://backend:8000".

## Changes
- Updates `NEXT_PUBLIC_API_HOSTNAME_DEFAULT` to "http://localhost:8000".

<!-- end-generated-description -->
