### PR TITLE
coral-web: fix deployments dropdown  check

### DIFF
--- a/src/interfaces/coral_web/src/components/DeploymentsDropdown.tsx
+++ b/src/interfaces/coral_web/src/components/DeploymentsDropdown.tsx
@@ -1,6 +1,6 @@
-import { useContext, useState } from 'react';
+import { useContext } from 'react';
 
-import { Dropdown, DropdownOptionGroups, Text } from '@/components/Shared';
+import { Dropdown, DropdownOptionGroups } from '@/components/Shared';
 import { BannerContext } from '@/context/BannerContext';
 import { ModalContext } from '@/context/ModalContext';
 import { useListAllDeployments } from '@/hooks/deployments';
@@ -33,7 +33,7 @@ export const DeploymentsDropdown: React.FC = () => {
       value={deployment}
       onChange={(deploymentName: string) => {
         const deployment = allDeployments.find((d) => d.name === deploymentName);
-        if (!deployment.is_available) {
+        if (deployment && !deployment.is_available) {
           open({
             title: 'Configure Model Deployment',
             content: <EditEnvVariablesModal onClose={close} defaultDeployment={deployment.name} />,


### PR DESCRIPTION
**Description:**

Adds a missing check for `deployment` being `undefined` with the `DeploymentsDropdown.tsx`. In reality, this should never be `undefined` since the dropdown is filled in by the `allDeployments` endpoint.

**AI Description**

<!-- begin-generated-description -->

This pull request makes changes to the `DeploymentsDropdown` component in the `src/interfaces/coral_web/src/components/DeploymentsDropdown.tsx` file. 

## Summary
The pull request removes the `useState` import from 'react' and updates the condition check inside the `DeploymentsDropdown` functional component.

## Changes
- Removed `useState` from imports.
- Updated the condition check inside the `DeploymentsDropdown` function to include an additional check for `deployment`. Now, it checks if `deployment` exists and if it's not available (`!deployment.is_available`).

<!-- end-generated-description -->
