### PR TITLE
coral-web: Change default page head title from Coral --> Chat

### DIFF
--- a/src/interfaces/coral_web/src/components/EditEnvVariablesButton.tsx
+++ b/src/interfaces/coral_web/src/components/EditEnvVariablesButton.tsx
@@ -42,7 +42,7 @@ export const EditEnvVariablesButton: React.FC<{ className?: string }> = () => {
 export const EditEnvVariablesModal: React.FC<{
   defaultDeployment: string;
   onClose: () => void;
-}> = ({defaultDeployment, onClose }) => {
+}> = ({ defaultDeployment, onClose }) => {
   const { data: deployments } = useListAllDeployments();
 
   const [deployment, setDeployment] = useState<string | undefined>(defaultDeployment);

--- a/src/interfaces/coral_web/src/components/Layout.tsx
+++ b/src/interfaces/coral_web/src/components/Layout.tsx
@@ -30,7 +30,7 @@ type Props = {
  * It shows the navigation bar, the left drawer and main content.
  * On small devices (e.g. mobile), the left drawer and main section are stacked vertically.
  */
-export const Layout: React.FC<Props> = ({ title = 'Coral', children }) => {
+export const Layout: React.FC<Props> = ({ title = 'Chat', children }) => {
   const { message: bannerMessage } = useContext(BannerContext);
   const {
     settings: { isConvListPanelOpen, isMobileConvListPanelOpen },


### PR DESCRIPTION
Changes default page head title from Coral --> Chat

### Before
![Screenshot 2024-06-10 at 12 00 33](https://github.com/cohere-ai/cohere-toolkit/assets/140425731/793f6323-7c9c-4053-81fd-70a42191fc38)

### After

![Screenshot 2024-06-10 at 11 58 31](https://github.com/cohere-ai/cohere-toolkit/assets/140425731/c2b5b97d-eb53-4e4a-b243-d53b82ac0e1c)


**AI Description**

<!-- begin-generated-description -->

This pull request makes changes to two component files in the `src/interfaces/coral_web/src/components` directory:

- `EditEnvVariablesModal.tsx`: The component now expects an additional prop, `defaultDeployment` of type `string`. This prop is used to initialize the `deployment` state.
- `Layout.tsx`: The default value of the `title` prop has been changed from `'Coral'` to `'Chat''.

## Summary
The pull request updates the `EditEnvVariablesModal` and `Layout` components in the `coral_web` interface. The `EditEnvVariablesModal` component now expects a `defaultDeployment` prop, which is used to set the initial value of the `deployment` state. This change allows for more flexible usage of the component by providing a way to preset the deployment value. The `Layout` component has also been modified, changing the default title value from `'Coral'` to `'Chat'`, potentially indicating a change in the interface's branding or context.

<!-- end-generated-description -->
