### PR TITLE
[coral-web] rename schema fields and update openapi client

### DIFF
--- a/src/backend/database_models/agent.py
+++ b/src/backend/database_models/agent.py
@@ -6,14 +6,14 @@ from sqlalchemy.orm import Mapped, mapped_column, relationship
 from backend.database_models.base import Base
 
 
-class Deployment(StrEnum):
+class AgentDeployment(StrEnum):
     COHERE_PLATFORM = "Cohere Platform"
     SAGE_MAKER = "SageMaker"
     AZURE = "Azure"
     BEDROCK = "Bedrock"
 
 
-class Model(StrEnum):
+class AgentModel(StrEnum):
     COMMAND_R = "command-r"
     COMMAND_R_PLUS = "command-r-plus"
     COMMAND_LIGHT = "command-light"
@@ -33,9 +33,11 @@ class Agent(Base):
     # TODO @scott-cohere: eventually switch to Fkey when new deployment tables are implemented
     # TODO @scott-cohere: deployments have different names for models, need to implement mapping later
     # enum place holders
-    model: Mapped[Model] = mapped_column(Enum(Model, native_enum=False), nullable=False)
-    deployment: Mapped[Deployment] = mapped_column(
-        Enum(Deployment, native_enum=False), nullable=False
+    model: Mapped[AgentModel] = mapped_column(
+        Enum(AgentModel, native_enum=False), nullable=False
+    )
+    deployment: Mapped[AgentDeployment] = mapped_column(
+        Enum(AgentDeployment, native_enum=False), nullable=False
     )
 
     user_id: Mapped[str] = mapped_column(Text, nullable=False)

--- a/src/backend/schemas/agent.py
+++ b/src/backend/schemas/agent.py
@@ -3,7 +3,7 @@ from typing import Optional
 
 from pydantic import BaseModel
 
-from backend.database_models.agent import Deployment, Model
+from backend.database_models.agent import AgentDeployment, AgentModel
 
 
 class AgentBase(BaseModel):
@@ -22,8 +22,8 @@ class Agent(AgentBase):
     temperature: float
     # tools: List[Tool]
 
-    model: Model
-    deployment: Deployment
+    model: AgentModel
+    deployment: AgentDeployment
 
     class Config:
         from_attributes = True
@@ -36,8 +36,8 @@ class CreateAgent(BaseModel):
     description: Optional[str] = None
     preamble: Optional[str] = None
     temperature: Optional[float] = None
-    model: Model
-    deployment: Deployment
+    model: AgentModel
+    deployment: AgentDeployment
 
     class Config:
         from_attributes = True
@@ -50,8 +50,8 @@ class UpdateAgent(BaseModel):
     description: Optional[str] = None
     preamble: Optional[str] = None
     temperature: Optional[float] = None
-    model: Optional[Model] = None
-    deployment: Optional[Deployment] = None
+    model: Optional[AgentModel] = None
+    deployment: Optional[AgentDeployment] = None
     # tools: Optional[List[Tool]] = None
 
     class Config:

--- a/src/backend/tests/crud/test_agent.py
+++ b/src/backend/tests/crud/test_agent.py
@@ -4,7 +4,7 @@ import pytest
 from sqlalchemy.exc import IntegrityError
 
 from backend.crud import agent as agent_crud
-from backend.database_models.agent import Agent, Deployment, Model
+from backend.database_models.agent import Agent, AgentDeployment, AgentModel
 from backend.schemas.agent import UpdateAgent
 from backend.tests.factories import get_factory
 
@@ -17,8 +17,8 @@ def test_create_agent(session, user):
         description="test",
         preamble="test",
         temperature=0.5,
-        model=Model.COMMAND_R_PLUS,
-        deployment=Deployment.COHERE_PLATFORM,
+        model=AgentModel.COMMAND_R_PLUS,
+        deployment=AgentDeployment.COHERE_PLATFORM,
     )
 
     agent = agent_crud.create_agent(session, agent_data)
@@ -28,8 +28,8 @@ def test_create_agent(session, user):
     assert agent.description == "test"
     assert agent.preamble == "test"
     assert agent.temperature == 0.5
-    assert agent.model == Model.COMMAND_R_PLUS
-    assert agent.deployment == Deployment.COHERE_PLATFORM
+    assert agent.model == AgentModel.COMMAND_R_PLUS
+    assert agent.deployment == AgentDeployment.COHERE_PLATFORM
 
     agent = agent_crud.get_agent(session, agent.id)
     assert agent.user_id == user.id
@@ -38,16 +38,16 @@ def test_create_agent(session, user):
     assert agent.description == "test"
     assert agent.preamble == "test"
     assert agent.temperature == 0.5
-    assert agent.model == Model.COMMAND_R_PLUS
-    assert agent.deployment == Deployment.COHERE_PLATFORM
+    assert agent.model == AgentModel.COMMAND_R_PLUS
+    assert agent.deployment == AgentDeployment.COHERE_PLATFORM
 
 
 def test_create_agent_empty_non_required_fields(session, user):
     agent_data = Agent(
         user_id=user.id,
         name="test",
-        deployment=Deployment.COHERE_PLATFORM,
-        model=Model.COMMAND_R_PLUS,
+        deployment=AgentDeployment.COHERE_PLATFORM,
+        model=AgentModel.COMMAND_R_PLUS,
     )
 
     agent = agent_crud.create_agent(session, agent_data)
@@ -57,8 +57,8 @@ def test_create_agent_empty_non_required_fields(session, user):
     assert agent.description == ""
     assert agent.preamble == ""
     assert agent.temperature == 0.3
-    assert agent.model == Model.COMMAND_R_PLUS
-    assert agent.deployment == Deployment.COHERE_PLATFORM
+    assert agent.model == AgentModel.COMMAND_R_PLUS
+    assert agent.deployment == AgentDeployment.COHERE_PLATFORM
 
     agent = agent_crud.get_agent(session, agent.id)
     assert agent.user_id == user.id
@@ -67,15 +67,15 @@ def test_create_agent_empty_non_required_fields(session, user):
     assert agent.description == ""
     assert agent.preamble == ""
     assert agent.temperature == 0.3
-    assert agent.model == Model.COMMAND_R_PLUS
-    assert agent.deployment == Deployment.COHERE_PLATFORM
+    assert agent.model == AgentModel.COMMAND_R_PLUS
+    assert agent.deployment == AgentDeployment.COHERE_PLATFORM
 
 
 def test_create_agent_missing_name(session, user):
     agent_data = Agent(
         user_id=user.id,
-        model=Model.COMMAND_R_PLUS,
-        deployment=Deployment.COHERE_PLATFORM,
+        model=AgentModel.COMMAND_R_PLUS,
+        deployment=AgentDeployment.COHERE_PLATFORM,
     )
 
     with pytest.raises(IntegrityError):
@@ -86,7 +86,7 @@ def test_create_agent_missing_model(session, user):
     agent_data = Agent(
         user_id=user.id,
         name="test",
-        deployment=Deployment.COHERE_PLATFORM,
+        deployment=AgentDeployment.COHERE_PLATFORM,
     )
 
     with pytest.raises(IntegrityError):
@@ -97,7 +97,7 @@ def test_create_agent_missing_deployment(session, user):
     agent_data = Agent(
         user_id=user.id,
         name="test",
-        model=Model.COMMAND_R_PLUS,
+        model=AgentModel.COMMAND_R_PLUS,
     )
 
     with pytest.raises(IntegrityError):
@@ -107,8 +107,8 @@ def test_create_agent_missing_deployment(session, user):
 def test_create_agent_missing_user_id(session):
     agent_data = Agent(
         name="test",
-        model=Model.COMMAND_R_PLUS,
-        deployment=Deployment.COHERE_PLATFORM,
+        model=AgentModel.COMMAND_R_PLUS,
+        deployment=AgentDeployment.COHERE_PLATFORM,
     )
 
     with pytest.raises(IntegrityError):
@@ -127,8 +127,8 @@ def test_create_agent_duplicate_name_version(session, user):
         description="test",
         preamble="test",
         temperature=0.5,
-        model=Model.COMMAND_R_PLUS,
-        deployment=Deployment.COHERE_PLATFORM,
+        model=AgentModel.COMMAND_R_PLUS,
+        deployment=AgentDeployment.COHERE_PLATFORM,
     )
 
     with pytest.raises(IntegrityError):

--- a/src/backend/tests/factories/agent.py
+++ b/src/backend/tests/factories/agent.py
@@ -1,6 +1,6 @@
 import factory
 
-from backend.database_models.agent import Agent, Deployment, Model
+from backend.database_models.agent import Agent, AgentDeployment, AgentModel
 
 from .base import BaseFactory
 
@@ -20,18 +20,18 @@ class AgentFactory(BaseFactory):
     model = factory.Faker(
         "random_element",
         elements=(
-            Model.COMMAND_R,
-            Model.COMMAND_R_PLUS,
-            Model.COMMAND_LIGHT,
-            Model.COMMAND,
+            AgentModel.COMMAND_R,
+            AgentModel.COMMAND_R_PLUS,
+            AgentModel.COMMAND_LIGHT,
+            AgentModel.COMMAND,
         ),
     )
     deployment = factory.Faker(
         "random_element",
         elements=(
-            Deployment.COHERE_PLATFORM,
-            Deployment.SAGE_MAKER,
-            Deployment.AZURE,
-            Deployment.BEDROCK,
+            AgentDeployment.COHERE_PLATFORM,
+            AgentDeployment.SAGE_MAKER,
+            AgentDeployment.AZURE,
+            AgentDeployment.BEDROCK,
         ),
     )

--- a/src/backend/tests/routers/test_agent.py
+++ b/src/backend/tests/routers/test_agent.py
@@ -1,7 +1,7 @@
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
-from backend.database_models.agent import Agent, Deployment, Model
+from backend.database_models.agent import Agent, AgentDeployment, AgentModel
 from backend.tests.factories import get_factory
 
 
@@ -12,8 +12,8 @@ def test_create_agent(session_client: TestClient, session: Session) -> None:
         "description": "test description",
         "preamble": "test preamble",
         "temperature": 0.5,
-        "model": Model.COMMAND_R,
-        "deployment": Deployment.COHERE_PLATFORM,
+        "model": AgentModel.COMMAND_R,
+        "deployment": AgentDeployment.COHERE_PLATFORM,
     }
 
     response = session_client.post(
@@ -48,8 +48,8 @@ def test_create_agent_missing_name(
         "description": "test description",
         "preamble": "test preamble",
         "temperature": 0.5,
-        "model": Model.COMMAND_R,
-        "deployment": Deployment.COHERE_PLATFORM,
+        "model": AgentModel.COMMAND_R,
+        "deployment": AgentDeployment.COHERE_PLATFORM,
     }
     response = session_client.post(
         "/v1/agents", json=request_json, headers={"User-Id": "123"}
@@ -65,7 +65,7 @@ def test_create_agent_missing_model(
         "description": "test description",
         "preamble": "test preamble",
         "temperature": 0.5,
-        "deployment": Deployment.COHERE_PLATFORM,
+        "deployment": AgentDeployment.COHERE_PLATFORM,
     }
     response = session_client.post(
         "/v1/agents", json=request_json, headers={"User-Id": "123"}
@@ -81,7 +81,7 @@ def test_create_agent_missing_deployment(
         "description": "test description",
         "preamble": "test preamble",
         "temperature": 0.5,
-        "model": Model.COMMAND_R,
+        "model": AgentModel.COMMAND_R,
     }
     response = session_client.post(
         "/v1/agents", json=request_json, headers={"User-Id": "123"}
@@ -94,8 +94,8 @@ def test_create_agent_missing_user_id_header(
 ) -> None:
     request_json = {
         "name": "test agent",
-        "model": Model.COMMAND_R,
-        "deployment": Deployment.COHERE_PLATFORM,
+        "model": AgentModel.COMMAND_R,
+        "deployment": AgentDeployment.COHERE_PLATFORM,
     }
     response = session_client.post("/v1/agents", json=request_json)
     assert response.status_code == 401
@@ -106,8 +106,8 @@ def test_create_agent_missing_non_required_fields(
 ) -> None:
     request_json = {
         "name": "test agent",
-        "model": Model.COMMAND_R,
-        "deployment": Deployment.COHERE_PLATFORM,
+        "model": AgentModel.COMMAND_R,
+        "deployment": AgentDeployment.COHERE_PLATFORM,
     }
 
     print(request_json)
@@ -216,8 +216,8 @@ def test_update_agent(session_client: TestClient, session: Session) -> None:
         description="test description",
         preamble="test preamble",
         temperature=0.5,
-        model=Model.COMMAND_R,
-        deployment=Deployment.COHERE_PLATFORM,
+        model=AgentModel.COMMAND_R,
+        deployment=AgentDeployment.COHERE_PLATFORM,
     )
 
     request_json = {
@@ -226,8 +226,8 @@ def test_update_agent(session_client: TestClient, session: Session) -> None:
         "description": "updated description",
         "preamble": "updated preamble",
         "temperature": 0.7,
-        "model": Model.COMMAND_R_PLUS,
-        "deployment": Deployment.SAGE_MAKER,
+        "model": AgentModel.COMMAND_R_PLUS,
+        "deployment": AgentDeployment.SAGE_MAKER,
     }
 
     response = session_client.put(
@@ -240,8 +240,8 @@ def test_update_agent(session_client: TestClient, session: Session) -> None:
     assert updated_agent["description"] == "updated description"
     assert updated_agent["preamble"] == "updated preamble"
     assert updated_agent["temperature"] == 0.7
-    assert updated_agent["model"] == Model.COMMAND_R_PLUS
-    assert updated_agent["deployment"] == Deployment.SAGE_MAKER
+    assert updated_agent["model"] == AgentModel.COMMAND_R_PLUS
+    assert updated_agent["deployment"] == AgentDeployment.SAGE_MAKER
 
 
 def test_partial_update_agent(session_client: TestClient, session: Session) -> None:
@@ -251,8 +251,8 @@ def test_partial_update_agent(session_client: TestClient, session: Session) -> N
         description="test description",
         preamble="test preamble",
         temperature=0.5,
-        model=Model.COMMAND_R,
-        deployment=Deployment.COHERE_PLATFORM,
+        model=AgentModel.COMMAND_R,
+        deployment=AgentDeployment.COHERE_PLATFORM,
     )
 
     request_json = {
@@ -269,8 +269,8 @@ def test_partial_update_agent(session_client: TestClient, session: Session) -> N
     assert updated_agent["description"] == "test description"
     assert updated_agent["preamble"] == "test preamble"
     assert updated_agent["temperature"] == 0.5
-    assert updated_agent["model"] == Model.COMMAND_R
-    assert updated_agent["deployment"] == Deployment.COHERE_PLATFORM
+    assert updated_agent["model"] == AgentModel.COMMAND_R
+    assert updated_agent["deployment"] == AgentDeployment.COHERE_PLATFORM
 
 
 def test_update_nonexistent_agent(session_client: TestClient, session: Session) -> None:
@@ -293,8 +293,8 @@ def test_update_agent_wrong_model_deployment_enums(
         description="test description",
         preamble="test preamble",
         temperature=0.5,
-        model=Model.COMMAND_R,
-        deployment=Deployment.COHERE_PLATFORM,
+        model=AgentModel.COMMAND_R,
+        deployment=AgentDeployment.COHERE_PLATFORM,
     )
 
     request_json = {

--- a/src/interfaces/coral_web/src/cohere-client/generated/index.ts
+++ b/src/interfaces/coral_web/src/cohere-client/generated/index.ts
@@ -7,6 +7,10 @@ export { CancelablePromise, CancelError } from './core/CancelablePromise';
 export { OpenAPI } from './core/OpenAPI';
 export type { OpenAPIConfig } from './core/OpenAPI';
 
+export type { Agent } from './models/Agent';
+export { AgentDeployment } from './models/AgentDeployment';
+export { AgentModel } from './models/AgentModel';
+export type { Auth } from './models/Auth';
 export type { Body_upload_file_v1_conversations_upload_file_post } from './models/Body_upload_file_v1_conversations_upload_file_post';
 export { Category } from './models/Category';
 export type { ChatMessage } from './models/ChatMessage';
@@ -17,7 +21,9 @@ export { CohereChatPromptTruncation } from './models/CohereChatPromptTruncation'
 export type { CohereChatRequest } from './models/CohereChatRequest';
 export type { Conversation } from './models/Conversation';
 export type { ConversationWithoutMessages } from './models/ConversationWithoutMessages';
+export type { CreateAgent } from './models/CreateAgent';
 export type { CreateUser } from './models/CreateUser';
+export type { DeleteAgent } from './models/DeleteAgent';
 export type { DeleteConversation } from './models/DeleteConversation';
 export type { DeleteFile } from './models/DeleteFile';
 export type { DeleteUser } from './models/DeleteUser';
@@ -47,6 +53,7 @@ export type { StreamToolResult } from './models/StreamToolResult';
 export type { Tool } from './models/Tool';
 export type { ToolCall } from './models/ToolCall';
 export { ToolInputType } from './models/ToolInputType';
+export type { UpdateAgent } from './models/UpdateAgent';
 export type { UpdateConversation } from './models/UpdateConversation';
 export type { UpdateDeploymentEnv } from './models/UpdateDeploymentEnv';
 export type { UpdateFile } from './models/UpdateFile';

--- a/src/interfaces/coral_web/src/cohere-client/generated/models/Agent.ts
+++ b/src/interfaces/coral_web/src/cohere-client/generated/models/Agent.ts
@@ -1,0 +1,23 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+
+/* istanbul ignore file */
+
+/* tslint:disable */
+
+/* eslint-disable */
+import type { AgentDeployment } from './AgentDeployment';
+import type { AgentModel } from './AgentModel';
+
+export type Agent = {
+  user_id: string;
+  id: string;
+  created_at: string;
+  updated_at: string;
+  version: number;
+  name: string;
+  description: string | null;
+  preamble: string | null;
+  temperature: number;
+  model: AgentModel;
+  deployment: AgentDeployment;
+};

--- a/src/interfaces/coral_web/src/cohere-client/generated/models/AgentDeployment.ts
+++ b/src/interfaces/coral_web/src/cohere-client/generated/models/AgentDeployment.ts
@@ -1,0 +1,10 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export enum AgentDeployment {
+  COHERE_PLATFORM = 'Cohere Platform',
+  SAGE_MAKER = 'SageMaker',
+  AZURE = 'Azure',
+  BEDROCK = 'Bedrock',
+}

--- a/src/interfaces/coral_web/src/cohere-client/generated/models/AgentModel.ts
+++ b/src/interfaces/coral_web/src/cohere-client/generated/models/AgentModel.ts
@@ -1,0 +1,10 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export enum AgentModel {
+  COMMAND_R = 'command-r',
+  COMMAND_R_PLUS = 'command-r-plus',
+  COMMAND_LIGHT = 'command-light',
+  COMMAND = 'command',
+}

--- a/src/interfaces/coral_web/src/cohere-client/generated/models/Auth.ts
+++ b/src/interfaces/coral_web/src/cohere-client/generated/models/Auth.ts
@@ -2,9 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-/**
- * Stream text generation event.
- */
-export type StreamTextGeneration = {
-  text: string;
+export type Auth = {
+  strategy: string;
 };

--- a/src/interfaces/coral_web/src/cohere-client/generated/models/ChatMessage.ts
+++ b/src/interfaces/coral_web/src/cohere-client/generated/models/ChatMessage.ts
@@ -12,5 +12,6 @@ import type { ChatRole } from './ChatRole';
  */
 export type ChatMessage = {
   role: ChatRole;
-  message: string;
+  message: string | null;
+  tool_results?: null;
 };

--- a/src/interfaces/coral_web/src/cohere-client/generated/models/ChatRole.ts
+++ b/src/interfaces/coral_web/src/cohere-client/generated/models/ChatRole.ts
@@ -3,9 +3,11 @@
 /* tslint:disable */
 /* eslint-disable */
 /**
- * One of CHATBOT|USER to identify who the message is coming from.
+ * One of CHATBOT|USER|SYSTEM to identify who the message is coming from.
  */
 export enum ChatRole {
   CHATBOT = 'CHATBOT',
   USER = 'USER',
+  SYSTEM = 'SYSTEM',
+  TOOL = 'TOOL',
 }

--- a/src/interfaces/coral_web/src/cohere-client/generated/models/CohereChatRequest.ts
+++ b/src/interfaces/coral_web/src/cohere-client/generated/models/CohereChatRequest.ts
@@ -32,4 +32,5 @@ export type CohereChatRequest = {
   presence_penalty?: number | null;
   frequency_penalty?: number | null;
   prompt_truncation?: CohereChatPromptTruncation;
+  tool_results?: null;
 };

--- a/src/interfaces/coral_web/src/cohere-client/generated/models/CreateAgent.ts
+++ b/src/interfaces/coral_web/src/cohere-client/generated/models/CreateAgent.ts
@@ -1,0 +1,19 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+
+/* istanbul ignore file */
+
+/* tslint:disable */
+
+/* eslint-disable */
+import type { AgentDeployment } from './AgentDeployment';
+import type { AgentModel } from './AgentModel';
+
+export type CreateAgent = {
+  name: string;
+  version?: number | null;
+  description?: string | null;
+  preamble?: string | null;
+  temperature?: number | null;
+  model: AgentModel;
+  deployment: AgentDeployment;
+};

--- a/src/interfaces/coral_web/src/cohere-client/generated/models/DeleteAgent.ts
+++ b/src/interfaces/coral_web/src/cohere-client/generated/models/DeleteAgent.ts
@@ -2,9 +2,4 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-/**
- * Stream text generation event.
- */
-export type StreamTextGeneration = {
-  text: string;
-};
+export type DeleteAgent = {};

--- a/src/interfaces/coral_web/src/cohere-client/generated/models/Login.ts
+++ b/src/interfaces/coral_web/src/cohere-client/generated/models/Login.ts
@@ -4,5 +4,5 @@
 /* eslint-disable */
 export type Login = {
   strategy: string;
-  payload: Record<string, string>;
+  payload?: Record<string, string> | null;
 };

--- a/src/interfaces/coral_web/src/cohere-client/generated/models/NonStreamedChatResponse.ts
+++ b/src/interfaces/coral_web/src/cohere-client/generated/models/NonStreamedChatResponse.ts
@@ -12,7 +12,6 @@ import type { SearchQuery } from './SearchQuery';
 import type { ToolCall } from './ToolCall';
 
 export type NonStreamedChatResponse = {
-  is_finished: boolean;
   response_id: string | null;
   generation_id: string | null;
   chat_history: Array<ChatMessage> | null;

--- a/src/interfaces/coral_web/src/cohere-client/generated/models/StreamCitationGeneration.ts
+++ b/src/interfaces/coral_web/src/cohere-client/generated/models/StreamCitationGeneration.ts
@@ -11,6 +11,5 @@ import type { Citation } from './Citation';
  * Stream citation generation event.
  */
 export type StreamCitationGeneration = {
-  is_finished: boolean;
   citations?: Array<Citation>;
 };

--- a/src/interfaces/coral_web/src/cohere-client/generated/models/StreamQueryGeneration.ts
+++ b/src/interfaces/coral_web/src/cohere-client/generated/models/StreamQueryGeneration.ts
@@ -6,6 +6,5 @@
  * Stream query generation event.
  */
 export type StreamQueryGeneration = {
-  is_finished: boolean;
   query: string;
 };

--- a/src/interfaces/coral_web/src/cohere-client/generated/models/StreamSearchQueriesGeneration.ts
+++ b/src/interfaces/coral_web/src/cohere-client/generated/models/StreamSearchQueriesGeneration.ts
@@ -11,6 +11,5 @@ import type { SearchQuery } from './SearchQuery';
  * Stream queries generation event.
  */
 export type StreamSearchQueriesGeneration = {
-  is_finished: boolean;
   search_queries?: Array<SearchQuery>;
 };

--- a/src/interfaces/coral_web/src/cohere-client/generated/models/StreamSearchResults.ts
+++ b/src/interfaces/coral_web/src/cohere-client/generated/models/StreamSearchResults.ts
@@ -8,7 +8,6 @@
 import type { Document } from './Document';
 
 export type StreamSearchResults = {
-  is_finished: boolean;
   search_results?: Array<Record<string, any>>;
   documents?: Array<Document>;
 };

--- a/src/interfaces/coral_web/src/cohere-client/generated/models/StreamStart.ts
+++ b/src/interfaces/coral_web/src/cohere-client/generated/models/StreamStart.ts
@@ -6,7 +6,6 @@
  * Stream start event.
  */
 export type StreamStart = {
-  is_finished: boolean;
   generation_id?: string | null;
   conversation_id?: string | null;
 };

--- a/src/interfaces/coral_web/src/cohere-client/generated/models/StreamToolCallsGeneration.ts
+++ b/src/interfaces/coral_web/src/cohere-client/generated/models/StreamToolCallsGeneration.ts
@@ -11,6 +11,5 @@ import type { ToolCall } from './ToolCall';
  * Stream tool calls generation event.
  */
 export type StreamToolCallsGeneration = {
-  is_finished: boolean;
   tool_calls?: Array<ToolCall>;
 };

--- a/src/interfaces/coral_web/src/cohere-client/generated/models/StreamToolInput.ts
+++ b/src/interfaces/coral_web/src/cohere-client/generated/models/StreamToolInput.ts
@@ -8,7 +8,6 @@
 import type { ToolInputType } from './ToolInputType';
 
 export type StreamToolInput = {
-  is_finished: boolean;
   input_type: ToolInputType;
   tool_name: string;
   input: string;

--- a/src/interfaces/coral_web/src/cohere-client/generated/models/StreamToolResult.ts
+++ b/src/interfaces/coral_web/src/cohere-client/generated/models/StreamToolResult.ts
@@ -8,7 +8,6 @@
 import type { Document } from './Document';
 
 export type StreamToolResult = {
-  is_finished: boolean;
   result: any;
   tool_name: string;
   documents?: Array<Document>;

--- a/src/interfaces/coral_web/src/cohere-client/generated/models/UpdateAgent.ts
+++ b/src/interfaces/coral_web/src/cohere-client/generated/models/UpdateAgent.ts
@@ -1,0 +1,19 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+
+/* istanbul ignore file */
+
+/* tslint:disable */
+
+/* eslint-disable */
+import type { AgentDeployment } from './AgentDeployment';
+import type { AgentModel } from './AgentModel';
+
+export type UpdateAgent = {
+  name?: string | null;
+  version?: number | null;
+  description?: string | null;
+  preamble?: string | null;
+  temperature?: number | null;
+  model?: AgentModel | null;
+  deployment?: AgentDeployment | null;
+};

--- a/src/interfaces/coral_web/src/components/EditEnvVariablesButton.tsx
+++ b/src/interfaces/coral_web/src/components/EditEnvVariablesButton.tsx
@@ -42,7 +42,7 @@ export const EditEnvVariablesButton: React.FC<{ className?: string }> = () => {
 export const EditEnvVariablesModal: React.FC<{
   defaultDeployment: string;
   onClose: () => void;
-}> = ({defaultDeployment, onClose }) => {
+}> = ({ defaultDeployment, onClose }) => {
   const { data: deployments } = useListAllDeployments();
 
   const [deployment, setDeployment] = useState<string | undefined>(defaultDeployment);


### PR DESCRIPTION
Thank you for contributing to the Cohere Toolkit!

- [x] **PR title**: "area: description"
  - Where "area" is whichever of interface, frontend, model, tools, backend, etc. is being modified. Use "docs: ..." for purely docs changes, "infra: ..." for CI changes.
  - Example: "deployment: add Azure model option"


- rename enums here https://github.com/cohere-ai/cohere-toolkit/pull/189/files#diff-e8df845c69e9e2f234328ef155343e0603899cf22aa220a876a1c30362330debR6 to avoid naming conflicts during client generation. (deployment.ts is already a generated client file)
- ran `pnpm generate:client` and `pnpm format:write`

- [x] **Add tests and docs**: Please include testing and documentation for your changes
- [x] **Lint and test**: Run `make lint` and `make run-tests`

**AI Description**

<!-- begin-generated-description -->

This PR introduces the `Agent` model and related changes. 

The `Agent` model is defined with the following fields:
- `user_id`: A string.
- `id`: A string.
- `created_at`: A string.
- `updated_at`: A string.
- `version`: A number.
- `name`: A string.
- `description`: A string or null.
- `preamble`: A string or null.
- `temperature`: A number.
- `model`: An `AgentModel`.
- `deployment`: An `AgentDeployment`.

The `AgentDeployment` and `AgentModel` enums are also introduced, with the following values:
- `AgentDeployment`:
- `COHERE_PLATFORM`
- `SAGE_MAKER`
- `AZURE`
- `BEDROCK`
- `AgentModel`:
- `COMMAND_R`
- `COMMAND_R_PLUS`
- `COMMAND_LIGHT`
- `COMMAND`

To accommodate these changes, the following modifications have been made:
- The `Deployment` and `Model` classes have been renamed to `AgentDeployment` and `AgentModel`, respectively, in `src/backend/database_models/agent.py`.
- The necessary imports have been updated in `src/backend/schemas/agent.py`, `src/backend/tests/crud/test_agent.py`, `src/backend/tests/factories/agent.py`, and `src/backend/tests/routers/test_agent.py`.
- References to `Deployment` and `Model` have been replaced with `AgentDeployment` and `AgentModel` in the test functions of `src/backend/tests/crud/test_agent.py` and `src/backend/tests/routers/test_agent.py`.
- The `Agent` model and related types have been exported in `src/interfaces/coral_web/src/cohere-client/generated/index.ts`.
- The `CreateAgent` and `DeleteAgent` types have been added in `src/interfaces/coral_web/src/cohere-client/generated/models/CreateAgent.ts` and `src/interfaces/coral_web/src/cohere-client/generated/models/DeleteAgent.ts`, respectively.
- The `UpdateAgent` type has been modified in `src/interfaces/coral_web/src/cohere-client/generated/models/UpdateAgent.ts` to include optional `AgentModel` and `AgentDeployment` fields.
- The `DefaultService` class in `src/interfaces/coral_web/src/cohere-client/generated/services/DefaultService.ts` has been updated with new methods for creating, listing, retrieving, updating, and deleting agents.

<!-- end-generated-description -->
