### PR TITLE
fix: citations being removed on last stream chunk

### DIFF
--- a/src/interfaces/coral_web/src/components/MessageContent.tsx
+++ b/src/interfaces/coral_web/src/components/MessageContent.tsx
@@ -105,7 +105,7 @@ export const MessageContent: React.FC<Props> = ({ isLast, message, onRetry }) =>
     let md = message.text;
     if (isFulfilledMessage(message)) {
       // replace the code block with an iframe
-      md = replaceCodeBlockWithIframe(message.originalText);
+      md = replaceCodeBlockWithIframe(message.text);
     }
     content = (
       <>


### PR DESCRIPTION
This PR fixes a bug recently introduced where we used `originalText` instead of `text` which contains citations to render the message content.

**AI Description**

<!-- begin-generated-description -->

This pull request updates the `MessageContent` component in the `src/interfaces/coral_web/src/components/MessageContent.tsx` file. Specifically, it modifies how the component handles displaying code blocks within messages.

## Changes
- Updates the `md` variable assignment when handling fulfilled messages. Instead of using `message.originalText`, it now uses `message.text` to replace the code block with an iframe.

<!-- end-generated-description -->
