### PR TITLE
fix: html preview with citations

### DIFF
--- a/src/interfaces/coral_web/src/components/Shared/Markdown/directives/cite.ts
+++ b/src/interfaces/coral_web/src/components/Shared/Markdown/directives/cite.ts
@@ -17,7 +17,7 @@ import { visit } from 'unist-util-visit';
 
 export const renderRemarkCites: Plugin<void[], Root> = () => {
   return (tree, file) => {
-    visit(tree, (node: any, index, parent) => {
+    visit(tree, (node: any) => {
       if (
         node.type === 'textDirective' ||
         node.type === 'leafDirective' ||

--- a/src/interfaces/coral_web/src/components/Shared/Markdown/tags/Iframe.tsx
+++ b/src/interfaces/coral_web/src/components/Shared/Markdown/tags/Iframe.tsx
@@ -1,4 +1,4 @@
-import type { Component, ExtraProps } from 'hast-util-to-jsx-runtime/lib/components';
+import type { Component } from 'hast-util-to-jsx-runtime/lib/components';
 import { useEffect } from 'react';
 import { useRef } from 'react';
 import { useState } from 'react';

--- a/src/interfaces/coral_web/src/pages/c/[id]/index.tsx
+++ b/src/interfaces/coral_web/src/pages/c/[id]/index.tsx
@@ -18,7 +18,6 @@ import { appSSR } from '@/pages/_app';
 import { useCitationsStore, useConversationStore, useParamsStore } from '@/stores';
 import { OutputFiles } from '@/stores/slices/citationsSlice';
 import { createStartEndKey, mapHistoryToMessages } from '@/utils';
-import { replaceCodeBlockWithIframe } from '@/utils/preview';
 import { parsePythonInterpreterToolFields } from '@/utils/tools';
 
 type Props = {
@@ -77,13 +76,9 @@ const ConversationPage: NextPage<Props> = () => {
     if (!conversation) return;
 
     const messages = mapHistoryToMessages(
-      conversation?.messages
-        ?.sort((a, b) => a.position - b.position)
-        .map((message) => ({
-          ...message,
-          text: replaceCodeBlockWithIframe(message.text),
-        }))
+      conversation?.messages?.sort((a, b) => a.position - b.position)
     );
+
     setConversation({ name: conversation.title, messages });
 
     let documentsMap: { [documentId: string]: Document } = {};

--- a/src/interfaces/coral_web/src/utils/conversation.ts
+++ b/src/interfaces/coral_web/src/utils/conversation.ts
@@ -1,16 +1,22 @@
 import { Message, MessageAgent } from '@/cohere-client';
 import { BotMessage, BotState, MessageType, UserMessage } from '@/types/message';
 import { replaceTextWithCitations } from '@/utils/citations';
+import { replaceCodeBlockWithIframe } from '@/utils/preview';
 
 export const mapHistoryToMessages = (history?: Message[]) => {
   return history
     ? history.map<UserMessage | BotMessage>((message) => {
+        const isBotMessage = message.agent === MessageAgent.CHATBOT;
+        let text = message.text;
+        if (isBotMessage) {
+          text = replaceCodeBlockWithIframe(message.text);
+        }
         return {
-          ...(message.agent === MessageAgent.CHATBOT
+          ...(isBotMessage
             ? { type: MessageType.BOT, state: BotState.FULFILLED, originalText: message.text ?? '' }
             : { type: MessageType.USER }),
           text: replaceTextWithCitations(
-            message.text ?? '',
+            text ?? '',
             message.citations ?? [],
             message.generation_id ?? ''
           ),


### PR DESCRIPTION
### Description

Fix inline citations in code blocks

- New logic for `replaceTextWithCitations`. If a citation start index is greater than the length of the `replacedText` it will be added at the top(1) of the message as shown in the picture. 

[1] I couldn't make it work at the bottom, looks like remark/rehype takes the whole text as `html` instead of `html` + `markdown`


### Screenshots

<img width="2642" alt="image" src="https://github.com/cohere-ai/cohere-toolkit/assets/10562610/c1bc4007-c194-41f6-9ff1-01653a96ecc7">

<img width="2642" alt="image" src="https://github.com/cohere-ai/cohere-toolkit/assets/10562610/693ee4ee-f35f-4631-82e9-0ebb84a337c6">

<img width="2642" alt="image" src="https://github.com/cohere-ai/cohere-toolkit/assets/10562610/e1ff6e4c-46ab-41f4-929d-7e72c3e76431">


