### PR TITLE
coral-web: add missing 'as' prop to transition component

### DIFF
--- a/src/interfaces/coral_web/src/components/MessageContent.tsx
+++ b/src/interfaces/coral_web/src/components/MessageContent.tsx
@@ -68,6 +68,7 @@ export const MessageContent: React.FC<Props> = ({ isLast, message, onRetry }) =>
       <Text className={cn('flex min-w-0 text-volcanic-700')} as="span">
         {hasLoadingMessage && (
           <Transition
+            as="div"
             appear={true}
             show={true}
             enterFrom="opacity-0"


### PR DESCRIPTION
Thank you for contributing to the Cohere Toolkit!

- [ ] **PR title**: "area: description"
  - Where "area" is whichever of interface, frontend, model, tools, backend, etc. is being modified. Use "docs: ..." for purely docs changes, "infra: ..." for CI changes.
  - Example: "deployment: add Azure model option"


- [ ] **PR message**: ***Delete this entire checklist*** and replace with
    - **Description:** a description of the change
    - **Issue:** the issue # it fixes, if applicable
    - **Dependencies:** any dependencies required for this change


- [ ] **Add tests and docs**: Please include testing and documentation for your changes
- [ ] **Lint and test**: Run `make lint` and `make run-tests`

**AI Description**

<!-- begin-generated-description -->

This pull request makes changes to the `MessageContent` component in the `src/interfaces/coral_web/src/components/MessageContent.tsx` file. 

## Summary
The `MessageContent` component is updated to wrap its content in a `div` element when the `hasLoadingMessage` prop is `true`. This is achieved by adding an `as="div"` prop to the `Transition` element within the `MessageContent` component.

## Changes
- Adds an `as="div"` prop to the `Transition` element when `hasLoadingMessage` is `true`.

<!-- end-generated-description -->
