### PR TITLE
[Backen, Tests]: Fixed 'make run-tests' 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,6 @@ ruff = "^0.0.94"
 isort = "^5.12.0"
 black = "24.3.0"
 
-
 [tool.poetry.group.setup]
 optional = true
 
@@ -78,7 +77,6 @@ optional = true
 
 [tool.poetry.group.community.dependencies]
 wolframalpha = "^5.0.0"
-
 torch = "^2.3.0"
 llama-index = "^0.10.11"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ bcrypt = "^4.1.2"
 pypdf = "^4.2.0"
 pyjwt = "^2.8.0"
 pydantic-settings = "^2.3.1"
+transformers = "^4.3.3"
 
 [tool.poetry.group.dev]
 optional = true
@@ -53,6 +54,7 @@ pre-commit = "^2.20.0"
 ruff = "^0.0.94"
 isort = "^5.12.0"
 black = "24.3.0"
+
 
 [tool.poetry.group.setup]
 optional = true
@@ -76,7 +78,7 @@ optional = true
 
 [tool.poetry.group.community.dependencies]
 wolframalpha = "^5.0.0"
-transformers = "^4.3.3"
+
 torch = "^2.3.0"
 llama-index = "^0.10.11"
 


### PR DESCRIPTION
Tests failed to run in `main`'s default state due to a misplaced dependency, `transformers`.  This PR fixes the issue by moving the dep into the main project dependencies so the module can be installed at image build time.  

End result: `make run-tests` works after cloning and initializing (`make first-run`) the repository. 

This PR does NOT address the broken community tests. 