### PR TITLE
Conversations: fix list conversations

### DIFF
--- a/src/backend/crud/conversation.py
+++ b/src/backend/crud/conversation.py
@@ -60,6 +60,7 @@ def get_conversations(
     return (
         db.query(Conversation)
         .filter(Conversation.user_id == user_id)
+        .order_by(Conversation.created_at.desc())
         .offset(offset)
         .limit(limit)
         .all()

--- a/src/backend/crud/conversation.py
+++ b/src/backend/crud/conversation.py
@@ -60,7 +60,7 @@ def get_conversations(
     return (
         db.query(Conversation)
         .filter(Conversation.user_id == user_id)
-        .order_by(Conversation.created_at.desc())
+        .order_by(Conversation.updated_at.desc())
         .offset(offset)
         .limit(limit)
         .all()

--- a/src/backend/tests/crud/test_conversation.py
+++ b/src/backend/tests/crud/test_conversation.py
@@ -58,7 +58,7 @@ def test_list_conversations_empty(session, user):
 def test_list_conversations_with_pagination(session, user):
     for i in range(10):
         get_factory("Conversation", session).create(
-            title=f"Conversation {i}", user_id=user.id
+            title=f"Conversation {i}", user_id=user.id, updated_at=f"2021-01-{31-i}"
         )
 
     conversations = conversation_crud.get_conversations(
@@ -67,6 +67,7 @@ def test_list_conversations_with_pagination(session, user):
     assert len(conversations) == 5
 
     for i, conversation in enumerate(conversations):
+        print(conversation.title)
         assert conversation.title == f"Conversation {i + 5}"
 
 

--- a/src/backend/tests/crud/test_conversation.py
+++ b/src/backend/tests/crud/test_conversation.py
@@ -67,7 +67,6 @@ def test_list_conversations_with_pagination(session, user):
     assert len(conversations) == 5
 
     for i, conversation in enumerate(conversations):
-        print(conversation.title)
         assert conversation.title == f"Conversation {i + 5}"
 
 


### PR DESCRIPTION
Listing conversations did not return the most recent ones, giving the impression that conversations were not persisted.

**AI Description**

<!-- begin-generated-description -->

The `get_conversations` function in `conversation.py` has been updated to sort conversations by their creation date in descending order. This ensures that the most recently created conversations are retrieved first.

**Code Changes:**
- The `.order_by(Conversation.created_at.desc())` line has been added to the `get_conversations` function, specifying the sorting order.

<!-- end-generated-description -->
