### PR TITLE
Add v1 to docs

### DIFF
--- a/docs/custom_tool_guides/tool_guide.md
+++ b/docs/custom_tool_guides/tool_guide.md
@@ -179,7 +179,7 @@ Remember, you can also access your tools via the API.
 - List tools:
 
 ```bash
-curl --location --request GET 'http://localhost:8000/tools' \
+curl --location --request GET 'http://localhost:8000/v1/tools' \
 --header 'User-Id: me' \
 --header 'Content-Type: application/json' \
 --data '{}'
@@ -188,7 +188,7 @@ curl --location --request GET 'http://localhost:8000/tools' \
 - Chat turns with tools:
 
 ```bash
-curl --location 'http://localhost:8000/chat-stream' \
+curl --location 'http://localhost:8000/v1/chat-stream' \
 --header 'User-Id: me' \
 --header 'Content-Type: application/json' \
 --data '{

--- a/docs/how_to_guides.md
+++ b/docs/how_to_guides.md
@@ -84,7 +84,7 @@ curl --location 'http://localhost:8000/v1/langchain-chat' \
 --header 'Content-Type: application/json' \
 --data '{
     "message": "Tell me about the aya model",
-    "tools": [{"name": "Python_Interpreter"},{"name": "Internet_Search"},]
+    "tools": [{"name": "Python_Interpreter"},{"name": "Internet_Search"}]
 }'
 ```
 

--- a/docs/how_to_guides.md
+++ b/docs/how_to_guides.md
@@ -19,10 +19,10 @@ To add your own deployment:
 
 ## How to call the backend as an API
 
-It is possible to just run the backend service, and call it in the same manner as the Cohere API. Note streaming and non streaming endpoints are split into 'http://localhost:8000/chat-stream' and 'http://localhost:8000/chat' compared to the API. For example, to stream:
+It is possible to just run the backend service, and call it in the same manner as the Cohere API. Note streaming and non streaming endpoints are split into 'http://localhost:8000/v1/chat-stream' and 'http://localhost:8000/v1/chat' compared to the API. For example, to stream:
 
 ```bash
-curl --location 'http://localhost:8000/chat-stream' \
+curl --location 'http://localhost:8000/v1/chat-stream' \
 --header 'User-Id: me' \
 --header 'Content-Type: application/json' \
 --data '{
@@ -79,7 +79,7 @@ Python interpreter and Tavily Internet search are provided in the toolkit by def
 
 Example API call:
 ```bash
-curl --location 'http://localhost:8000/langchain-chat' \
+curl --location 'http://localhost:8000/v1/langchain-chat' \
 --header 'User-Id: me' \
 --header 'Content-Type: application/json' \
 --data '{

--- a/docs/how_to_guides.md
+++ b/docs/how_to_guides.md
@@ -84,7 +84,7 @@ curl --location 'http://localhost:8000/v1/langchain-chat' \
 --header 'Content-Type: application/json' \
 --data '{
     "message": "Tell me about the aya model",
-    "tools": [{"name": "Python_Interpreter"},{"name": "Internet Search"},]
+    "tools": [{"name": "Python_Interpreter"},{"name": "Internet_Search"},]
 }'
 ```
 

--- a/src/backend/cli/main.py
+++ b/src/backend/cli/main.py
@@ -189,7 +189,7 @@ def show_examples():
         bcolors.OKCYAN,
     )
     print_styled(
-        """\tcurl --location 'http://localhost:8000/chat-stream' --header 'User-Id: test-user' --header 'Content-Type: application/json' --data '{"message": "hey"}'""",
+        """\tcurl --location 'http://localhost:8000/v1/chat-stream' --header 'User-Id: test-user' --header 'Content-Type: application/json' --data '{"message": "hey"}'""",
         bcolors.OKCYAN,
     )
 
@@ -198,7 +198,7 @@ def show_examples():
         bcolors.OKCYAN,
     )
     print_styled(
-        """\tcurl --location 'http://localhost:8000/chat-stream' --header 'User-Id: test-user' --header 'Deployment-Name: SageMaker' --header 'Content-Type: application/json' --data '{"message": "hey"}'""",
+        """\tcurl --location 'http://localhost:8000/v1/chat-stream' --header 'User-Id: test-user' --header 'Deployment-Name: SageMaker' --header 'Content-Type: application/json' --data '{"message": "hey"}'""",
         bcolors.OKCYAN,
     )
 


### PR DESCRIPTION
<!-- begin-generated-description -->

This PR updates the API endpoint paths in the documentation and the `main.py` file. 

The changes include:
- Updating the API endpoint paths by adding `/v1` before the specific endpoint, such as `/tools`, `/chat-stream`, and `/langchain-chat`.
- Modifying the example commands to use the updated API endpoint paths, ensuring consistency and accuracy in the documentation.

<!-- end-generated-description -->