### PR TITLE
Split up display name and name for Tools 

### DIFF
--- a/src/backend/config/tools.py
+++ b/src/backend/config/tools.py
@@ -26,17 +26,18 @@ Don't forget to add the implementation to this AVAILABLE_TOOLS dictionary!
 
 
 class ToolName(StrEnum):
-    Wiki_Retriever_LangChain = "Wikipedia"
+    Wiki_Retriever_LangChain = "wikipedia"
     Search_File = "search_file"
     Read_File = "read_document"
-    Python_Interpreter = "Python_Interpreter"
-    Calculator = "Calculator"
-    Tavily_Internet_Search = "Internet_Search"
+    Python_Interpreter = "python_interpreter"
+    Calculator = "calculator"
+    Tavily_Internet_Search = "internet_search"
 
 
 ALL_TOOLS = {
     ToolName.Wiki_Retriever_LangChain: ManagedTool(
         name=ToolName.Wiki_Retriever_LangChain,
+        display_name="Wikipedia",
         implementation=LangChainWikiRetriever,
         parameter_definitions={
             "query": {
@@ -54,6 +55,7 @@ ALL_TOOLS = {
     ),
     ToolName.Search_File: ManagedTool(
         name=ToolName.Search_File,
+        display_name="Search File",
         implementation=SearchFileTool,
         parameter_definitions={
             "search_query": {
@@ -75,6 +77,7 @@ ALL_TOOLS = {
     ),
     ToolName.Read_File: ManagedTool(
         name=ToolName.Read_File,
+        display_name="Read Document",
         implementation=ReadFileTool,
         parameter_definitions={
             "filename": {
@@ -91,6 +94,7 @@ ALL_TOOLS = {
     ),
     ToolName.Python_Interpreter: ManagedTool(
         name=ToolName.Python_Interpreter,
+        display_name="Python Interpreter",
         implementation=PythonInterpreter,
         parameter_definitions={
             "code": {
@@ -107,6 +111,7 @@ ALL_TOOLS = {
     ),
     ToolName.Calculator: ManagedTool(
         name=ToolName.Calculator,
+        display_name="Calculator",
         implementation=Calculator,
         parameter_definitions={
             "code": {
@@ -123,6 +128,7 @@ ALL_TOOLS = {
     ),
     ToolName.Tavily_Internet_Search: ManagedTool(
         name=ToolName.Tavily_Internet_Search,
+        display_name="Web Search",
         implementation=TavilyInternetSearch,
         parameter_definitions={
             "query": {

--- a/src/backend/schemas/tool.py
+++ b/src/backend/schemas/tool.py
@@ -16,6 +16,7 @@ class ToolInput(BaseModel):
 
 class Tool(BaseModel):
     name: str
+    display_name: str = ""
     description: Optional[str] = ""
     parameter_definitions: Optional[dict] = {}
 

--- a/src/community/config/tools.py
+++ b/src/community/config/tools.py
@@ -13,17 +13,18 @@ from community.tools import (
 
 
 class CommunityToolName(StrEnum):
-    Arxiv = "Arxiv"
-    Connector = "Connector"
-    Pub_Med = "Pub Med"
-    File_Upload_LlamaIndex = "File Reader - LlamaIndex"
-    Wolfram_Alpha = "Wolfram_Alpha"
-    ClinicalTrials = "ClinicalTrials"
+    Arxiv = "arxiv"
+    Connector = "example_connector"
+    Pub_Med = "pub_med"
+    File_Upload_LlamaIndex = "file_reader_llamaindex"
+    Wolfram_Alpha = "wolfram_alpha"
+    ClinicalTrials = "clinical_trials"
 
 
 COMMUNITY_TOOLS = {
     CommunityToolName.Arxiv: ManagedTool(
         name=CommunityToolName.Arxiv,
+        display_name="Arxiv",
         implementation=ArxivRetriever,
         parameter_definitions={
             "query": {
@@ -40,6 +41,7 @@ COMMUNITY_TOOLS = {
     ),
     CommunityToolName.Connector: ManagedTool(
         name=CommunityToolName.Connector,
+        display_name="Example Connector",
         implementation=ConnectorRetriever,
         is_visible=True,
         is_available=ConnectorRetriever.is_available(),
@@ -49,6 +51,7 @@ COMMUNITY_TOOLS = {
     ),
     CommunityToolName.Pub_Med: ManagedTool(
         name=CommunityToolName.Pub_Med,
+        display_name="PubMed",
         implementation=PubMedRetriever,
         parameter_definitions={
             "query": {
@@ -65,6 +68,7 @@ COMMUNITY_TOOLS = {
     ),
     CommunityToolName.File_Upload_LlamaIndex: ManagedTool(
         name=CommunityToolName.File_Upload_LlamaIndex,
+        display_name="File Reader",
         implementation=LlamaIndexUploadPDFRetriever,
         is_visible=True,
         is_available=LlamaIndexUploadPDFRetriever.is_available(),
@@ -74,6 +78,7 @@ COMMUNITY_TOOLS = {
     ),
     CommunityToolName.Wolfram_Alpha: ManagedTool(
         name=CommunityToolName.Wolfram_Alpha,
+        display_name="Wolfram Alpha",
         implementation=WolframAlpha,
         is_visible=False,
         is_available=WolframAlpha.is_available(),
@@ -83,6 +88,7 @@ COMMUNITY_TOOLS = {
     ),
     CommunityToolName.ClinicalTrials: ManagedTool(
         name=CommunityToolName.ClinicalTrials,
+        display_name="Clinical Trials",
         implementation=ClinicalTrials,
         is_visible=True,
         is_available=ClinicalTrials.is_available(),

--- a/src/interfaces/coral_web/src/cohere-client/generated/models/ManagedTool.ts
+++ b/src/interfaces/coral_web/src/cohere-client/generated/models/ManagedTool.ts
@@ -9,6 +9,7 @@ import type { Category } from './Category';
 
 export type ManagedTool = {
   name: string;
+  display_name?: string;
   description?: string | null;
   parameter_definitions?: Record<string, any> | null;
   kwargs?: Record<string, any>;

--- a/src/interfaces/coral_web/src/cohere-client/generated/models/Tool.ts
+++ b/src/interfaces/coral_web/src/cohere-client/generated/models/Tool.ts
@@ -4,6 +4,7 @@
 /* eslint-disable */
 export type Tool = {
   name: string;
+  display_name?: string;
   description?: string | null;
   parameter_definitions?: Record<string, any> | null;
 };

--- a/src/interfaces/coral_web/src/cohere-client/generated/services/DefaultService.ts
+++ b/src/interfaces/coral_web/src/cohere-client/generated/services/DefaultService.ts
@@ -825,7 +825,7 @@ export class DefaultService {
     });
   }
   /**
-   * Get Agent By Id
+   * Get Agent
    * Args:
    * agent_id (str): Agent ID.
    * session (DBSessionDep): Database session.
@@ -838,7 +838,7 @@ export class DefaultService {
    * @returns Agent Successful Response
    * @throws ApiError
    */
-  public static getAgentByIdV1AgentsAgentIdGet({
+  public static getAgentV1AgentsAgentIdGet({
     agentId,
   }: {
     agentId: string;

--- a/src/interfaces/coral_web/src/cohere-client/generated/services/DefaultService.ts
+++ b/src/interfaces/coral_web/src/cohere-client/generated/services/DefaultService.ts
@@ -825,7 +825,7 @@ export class DefaultService {
     });
   }
   /**
-   * Get Agent
+   * Get Agent By Id
    * Args:
    * agent_id (str): Agent ID.
    * session (DBSessionDep): Database session.
@@ -838,7 +838,7 @@ export class DefaultService {
    * @returns Agent Successful Response
    * @throws ApiError
    */
-  public static getAgentV1AgentsAgentIdGet({
+  public static getAgentByIdV1AgentsAgentIdGet({
     agentId,
   }: {
     agentId: string;

--- a/src/interfaces/coral_web/src/components/Configuration/Tools.tsx
+++ b/src/interfaces/coral_web/src/components/Configuration/Tools.tsx
@@ -95,7 +95,7 @@ const ToolSection = () => {
             />
           </div>
           <div className="flex flex-col gap-y-5">
-            {tools.map(({ name, is_available, description, error_message }) => {
+            {tools.map(({ name, display_name, is_available, description, error_message }) => {
               const enabledTool = enabledTools.find(
                 (enabledTool) => enabledTool.name.toLocaleLowerCase() === name.toLocaleLowerCase()
               );
@@ -109,7 +109,7 @@ const ToolSection = () => {
                     onChange={(e) => {
                       handleToolToggle(name, e.target.checked);
                     }}
-                    label={name}
+                    label={display_name}
                     name={name}
                     theme="secondary"
                     dataTestId={`checkbox-tool-${name}`}


### PR DESCRIPTION
Add display name for tools 

**AI Description**

<!-- begin-generated-description -->

This pull request updates the naming convention for tool names and adds a new field, `display_name`, to the `Tool` and `ManagedTool` interfaces.

- The tool names in `ToolName` and `CommunityToolName` enums have been changed to use snake_case instead of camelCase.
- A new field, `display_name`, has been added to the `Tool` and `ManagedTool` interfaces in `tool.py, `Tool.ts`, and `ManagedTool.ts`.
- The `ToolSection` component in `Tools.tsx` has been updated to use the `display_name` field instead of the `name` field for rendering tool labels.
- The `display_name` field has been added to the `ToolName` and `CommunityToolName` enums in `tools.py` and `config/tools.py`.

<!-- end-generated-description -->
