### PR TITLE
[backend] enforce agent update with user-id

### DIFF
--- a/src/backend/config/routers.py
+++ b/src/backend/config/routers.py
@@ -36,8 +36,8 @@ ROUTER_DEPENDENCIES = {
     RouterName.CHAT: {
         "default": [
             Depends(get_session),
-            Depends(validate_chat_request),
             Depends(validate_user_header),
+            Depends(validate_chat_request),
         ],
         "auth": [
             Depends(get_session),

--- a/src/backend/routers/agent.py
+++ b/src/backend/routers/agent.py
@@ -134,9 +134,11 @@ async def update_agent(
         )
 
     try:
-        return agent_crud.update_agent(session, agent, new_agent)
+        agent = agent_crud.update_agent(session, agent, new_agent)
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
+
+    return agent
 
 
 @router.delete("/{agent_id}")
@@ -166,6 +168,8 @@ async def delete_agent(
         )
 
     try:
-        return agent_crud.delete_agent(session, agent_id)
+        agent_crud.delete_agent(session, agent_id)
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
+
+    return DeleteAgent()

--- a/src/backend/routers/agent.py
+++ b/src/backend/routers/agent.py
@@ -90,7 +90,7 @@ async def get_agent_by_id(
 
     if not agent:
         raise HTTPException(
-            status_code=404,
+            status_code=400,
             detail=f"Agent with ID: {agent_id} not found.",
         )
 
@@ -127,19 +127,16 @@ async def update_agent(
         HTTPException: If the agent with the given ID is not found.
     """
     agent = agent_crud.get_agent_by_id(session, agent_id)
-
     if not agent:
         raise HTTPException(
-            status_code=404,
-            detail=f"Agent with ID: {agent_id} not found.",
+            status_code=400,
+            detail=f"Agent with ID {agent_id} not found.",
         )
 
     try:
-        agent = agent_crud.update_agent(session, agent, new_agent)
+        return agent_crud.update_agent(session, agent, new_agent)
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
-
-    return agent
 
 
 @router.delete("/{agent_id}")
@@ -164,13 +161,11 @@ async def delete_agent(
 
     if not agent:
         raise HTTPException(
-            status_code=404,
-            detail=f"Agent with ID: {agent_id} not found.",
+            status_code=400,
+            detail=f"Agent with ID {agent_id} not found.",
         )
 
     try:
-        agent_crud.delete_agent(session, agent_id)
+        return agent_crud.delete_agent(session, agent_id)
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
-
-    return DeleteAgent()

--- a/src/backend/services/request_validators.py
+++ b/src/backend/services/request_validators.py
@@ -22,7 +22,7 @@ def validate_user_header(request: Request):
 
     """
 
-    user_id = request.headers.get(request)
+    user_id = request.headers.get("User-Id")
     if not user_id:
         raise HTTPException(
             status_code=401, detail="User-Id required in request headers."

--- a/src/backend/services/request_validators.py
+++ b/src/backend/services/request_validators.py
@@ -6,6 +6,7 @@ from backend.config.deployments import AVAILABLE_MODEL_DEPLOYMENTS
 from backend.config.tools import AVAILABLE_TOOLS
 from backend.crud import agent as agent_crud
 from backend.database_models.database import DBSessionDep
+from backend.services.auth.utils import get_header_user_id
 
 
 def validate_user_header(request: Request):
@@ -21,7 +22,7 @@ def validate_user_header(request: Request):
 
     """
 
-    user_id = request.headers.get("User-Id")
+    user_id = get_header_user_id(request)
     if not user_id:
         raise HTTPException(
             status_code=401, detail="User-Id required in request headers."
@@ -184,7 +185,7 @@ async def validate_update_agent_request(session: DBSessionDep, request: Request)
             status_code=400, detail=f"Agent with ID {agent_id} not found."
         )
 
-    if agent.user_id != request.headers.get("User-Id"):
+    if agent.user_id != get_header_user_id(request):
         raise HTTPException(
             status_code=401, detail=f"Agent with ID {agent_id} does not belong to user."
         )

--- a/src/backend/services/request_validators.py
+++ b/src/backend/services/request_validators.py
@@ -22,7 +22,7 @@ def validate_user_header(request: Request):
 
     """
 
-    user_id = get_header_user_id(request)
+    user_id = request.headers.get(request)
     if not user_id:
         raise HTTPException(
             status_code=401, detail="User-Id required in request headers."

--- a/src/backend/tests/routers/test_agent.py
+++ b/src/backend/tests/routers/test_agent.py
@@ -368,8 +368,6 @@ def test_update_agent_invalid_model(
     response = session_client.put(
         f"/v1/agents/{agent.id}", json=request_json, headers={"User-Id": "123"}
     )
-    print("debug")
-    print(response.json())
     assert response.status_code == 400
     assert response.json() == {
         "detail": "Model not a real model not found for deployment Cohere Platform."

--- a/src/backend/tests/routers/test_agent.py
+++ b/src/backend/tests/routers/test_agent.py
@@ -242,7 +242,7 @@ def test_get_agent(session_client: TestClient, session: Session) -> None:
 
 def test_get_nonexistent_agent(session_client: TestClient, session: Session) -> None:
     response = session_client.get("/v1/agents/456", headers={"User-Id": "123"})
-    assert response.status_code == 404
+    assert response.status_code == 400
     assert response.json() == {"detail": "Agent with ID: 456 not found."}
 
 
@@ -255,6 +255,7 @@ def test_update_agent(session_client: TestClient, session: Session) -> None:
         temperature=0.5,
         model="command-r-plus",
         deployment=ModelDeploymentName.CoherePlatform,
+        user_id="123",
     )
 
     request_json = {
@@ -268,7 +269,9 @@ def test_update_agent(session_client: TestClient, session: Session) -> None:
     }
 
     response = session_client.put(
-        f"/v1/agents/{agent.id}", json=request_json, headers={"User-Id": "123"}
+        f"/v1/agents/{agent.id}",
+        json=request_json,
+        headers={"User-Id": "123"},
     )
 
     assert response.status_code == 200
@@ -292,6 +295,7 @@ def test_partial_update_agent(session_client: TestClient, session: Session) -> N
         model="command-r-plus",
         deployment=ModelDeploymentName.CoherePlatform,
         tools=[ToolName.Calculator],
+        user_id="123",
     )
 
     request_json = {
@@ -300,7 +304,9 @@ def test_partial_update_agent(session_client: TestClient, session: Session) -> N
     }
 
     response = session_client.put(
-        f"/v1/agents/{agent.id}", json=request_json, headers={"User-Id": "123"}
+        f"/v1/agents/{agent.id}",
+        json=request_json,
+        headers={"User-Id": "123"},
     )
     assert response.status_code == 200
     updated_agent = response.json()
@@ -321,8 +327,21 @@ def test_update_nonexistent_agent(session_client: TestClient, session: Session) 
     response = session_client.put(
         "/v1/agents/456", json=request_json, headers={"User-Id": "123"}
     )
-    assert response.status_code == 404
-    assert response.json() == {"detail": "Agent with ID: 456 not found."}
+    assert response.status_code == 400
+    assert response.json() == {"detail": "Agent with ID 456 not found."}
+
+
+def test_update_agent_wrong_user(session_client: TestClient, session: Session) -> None:
+    agent = get_factory("Agent", session).create(user_id="123")
+    request_json = {
+        "name": "updated name",
+    }
+
+    response = session_client.put(
+        f"/v1/agents/{agent.id}", json=request_json, headers={"User-Id": "456"}
+    )
+    assert response.status_code == 401
+    assert response.json() == {"detail": f"Agent with ID {agent.id} does not belong to user."}
 
 
 def test_update_agent_invalid_model(
@@ -336,6 +355,7 @@ def test_update_agent_invalid_model(
         temperature=0.5,
         model="command-r-plus",
         deployment=ModelDeploymentName.CoherePlatform,
+        user_id="123",
     )
 
     request_json = {
@@ -346,6 +366,8 @@ def test_update_agent_invalid_model(
     response = session_client.put(
         f"/v1/agents/{agent.id}", json=request_json, headers={"User-Id": "123"}
     )
+    print("debug")
+    print(response.json())
     assert response.status_code == 400
     assert response.json() == {
         "detail": "Model not a real model not found for deployment Cohere Platform."
@@ -363,6 +385,7 @@ def test_update_agent_invalid_deployment(
         temperature=0.5,
         model="command-r-plus",
         deployment=ModelDeploymentName.CoherePlatform,
+        user_id="123",
     )
 
     request_json = {
@@ -390,6 +413,7 @@ def test_update_agent_model_without_deployment(
         temperature=0.5,
         model="command-r-plus",
         deployment=ModelDeploymentName.CoherePlatform,
+        user_id="123",
     )
 
     request_json = {
@@ -416,6 +440,7 @@ def test_update_agent_deployment_without_model(
         temperature=0.5,
         model="command-r-plus",
         deployment=ModelDeploymentName.CoherePlatform,
+        user_id="123",
     )
 
     request_json = {
@@ -442,6 +467,7 @@ def test_update_agent_invalid_tool(
         temperature=0.5,
         model="command-r-plus",
         deployment=ModelDeploymentName.CoherePlatform,
+        user_id="123",
     )
 
     request_json = {
@@ -458,7 +484,7 @@ def test_update_agent_invalid_tool(
 
 
 def test_delete_agent(session_client: TestClient, session: Session) -> None:
-    agent = get_factory("Agent", session).create()
+    agent = get_factory("Agent", session).create(user_id="123")
     response = session_client.delete(
         f"/v1/agents/{agent.id}", headers={"User-Id": "123"}
     )
@@ -472,6 +498,8 @@ def test_delete_agent(session_client: TestClient, session: Session) -> None:
 def test_fail_delete_nonexistent_agent(
     session_client: TestClient, session: Session
 ) -> None:
-    response = session_client.delete("/v1/agents/456", headers={"User-Id": "123"})
-    assert response.status_code == 404
-    assert response.json() == {"detail": "Agent with ID: 456 not found."}
+    response = session_client.delete(
+        "/v1/agents/456", headers={"User-Id": "123"}
+    )
+    assert response.status_code == 400
+    assert response.json() == {"detail": "Agent with ID 456 not found."}

--- a/src/backend/tests/routers/test_agent.py
+++ b/src/backend/tests/routers/test_agent.py
@@ -341,7 +341,9 @@ def test_update_agent_wrong_user(session_client: TestClient, session: Session) -
         f"/v1/agents/{agent.id}", json=request_json, headers={"User-Id": "456"}
     )
     assert response.status_code == 401
-    assert response.json() == {"detail": f"Agent with ID {agent.id} does not belong to user."}
+    assert response.json() == {
+        "detail": f"Agent with ID {agent.id} does not belong to user."
+    }
 
 
 def test_update_agent_invalid_model(
@@ -498,8 +500,6 @@ def test_delete_agent(session_client: TestClient, session: Session) -> None:
 def test_fail_delete_nonexistent_agent(
     session_client: TestClient, session: Session
 ) -> None:
-    response = session_client.delete(
-        "/v1/agents/456", headers={"User-Id": "123"}
-    )
+    response = session_client.delete("/v1/agents/456", headers={"User-Id": "123"})
     assert response.status_code == 400
     assert response.json() == {"detail": "Agent with ID 456 not found."}


### PR DESCRIPTION
Only allow creator of agent to update the agent.

in this PR:
- Update some HTTP codes to be more accurate to the actual error
- Update minor string formatting for errors to be more consistent
- Update the validator for update agent request to cross check the user ID is the creator of the agent
- Update unit tests

**AI Description**

<!-- begin-generated-description -->

This pull request makes changes to the backend code, specifically related to agent management and validation. 

**Summary:**
- Updates the `status_code` from `404` to `400` for more accurate error handling when an agent is not found.
- Enhances the `validate_update_agent_request` function to include additional checks for the agent ID and user ID, ensuring requests are properly validated.
- Adjusts test cases to reflect the updated status codes and error messages.

**Code Changes:**
- **src/backend/routers/agent.py:**
  - Modified the `status_code` in the `HTTPException` raised when an agent is not found to `400` for more accurate error handling.
- **src/backend/services/request_validators.py:**
  - Added `session: DBSessionDep` as a parameter to the `validate_update_agent_request` function for improved validation.
  - Introduced additional checks to ensure the presence of an agent ID and that the agent belongs to the user making the request.
  - Updated the `status_code` in the `HTTPException` raised when the agent is not found to `400`.
- **src/backend/tests/routers/test_agent.py:**
  - Adjusted the expected status codes and error messages in test cases to reflect the updates made in the code.
  - Added a new test case, `test_update_agent_wrong_user`, to verify that an unauthorized user cannot update an agent.

<!-- end-generated-description -->
