### PR TITLE
Propagate should_store logic to the File upload logic

### DIFF
--- a/src/backend/services/chat.py
+++ b/src/backend/services/chat.py
@@ -105,9 +105,10 @@ def process_chat(
     file_paths = None
     if isinstance(chat_request, CohereChatRequest):
         file_paths = handle_file_retrieval(session, user_id, chat_request.file_ids)
-        attach_files_to_messages(
-            session, user_id, user_message.id, chat_request.file_ids
-        )
+        if should_store:
+            attach_files_to_messages(
+                session, user_id, user_message.id, chat_request.file_ids
+            )
 
     chat_history = create_chat_history(
         conversation, next_message_position, chat_request


### PR DESCRIPTION
**AI Description**

<!-- begin-generated-description -->

The `process_chat` function in `chat.py` has been modified to include an additional check before attaching files to messages. 

- Previously, the code directly called the `attach_files_to_messages` function to attach files to the chat session. 
- Now, an `if should_store:` condition has been added to control whether files are attached to messages. 

This change allows for more flexibility in handling file attachments, potentially based on specific conditions or user preferences.

<!-- end-generated-description -->
