### PR TITLE
coral-web: fix agent info panel opening by default

### DIFF
--- a/src/interfaces/coral_web/src/components/Conversation/index.tsx
+++ b/src/interfaces/coral_web/src/components/Conversation/index.tsx
@@ -186,7 +186,7 @@ const Conversation: React.FC<Props> = ({
       </div>
 
       <Transition
-        show={isEditAgentPanelOpen}
+        show={!!isEditAgentPanelOpen}
         as="div"
         className="z-configuration-drawer h-auto border-l border-marble-400"
         enter="transition-all ease-in-out duration-300"


### PR DESCRIPTION
`isEditAgentPanelOpen` was being set to `undefined` by the persisted store (?) after app mount
This was causing the agent info panel to show on page load

## Before:

https://github.com/cohere-ai/cohere-toolkit/assets/140425731/fe972bfc-9d88-4c17-add3-3aa83a4decd9


## After

https://github.com/cohere-ai/cohere-toolkit/assets/140425731/8c495945-30e0-4c6b-b083-a0dd669d41b8

