### PR TITLE
[backend] adding web scrape tool

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2350,6 +2350,21 @@ rtd = ["jupyter_sphinx", "mdit-py-plugins", "myst-parser", "pyyaml", "sphinx", "
 testing = ["coverage", "pytest", "pytest-cov", "pytest-regressions"]
 
 [[package]]
+name = "markdownify"
+version = "0.12.1"
+description = "Convert HTML to markdown."
+optional = false
+python-versions = "*"
+files = [
+    {file = "markdownify-0.12.1-py3-none-any.whl", hash = "sha256:a3805abd8166dbb7b27783c5599d91f54f10d79894b2621404d85b333c7ce561"},
+    {file = "markdownify-0.12.1.tar.gz", hash = "sha256:1fb08c618b30e0ee7a31a39b998f44a18fb28ab254f55f4af06b6d35a2179e27"},
+]
+
+[package.dependencies]
+beautifulsoup4 = ">=4.9,<5"
+six = ">=1.15,<2"
+
+[[package]]
 name = "markupsafe"
 version = "2.1.5"
 description = "Safely add untrusted strings to HTML/XML markup."
@@ -2737,6 +2752,31 @@ extra = ["lxml (>=4.6)", "pydot (>=2.0)", "pygraphviz (>=1.12)", "sympy (>=1.10)
 test = ["pytest (>=7.2)", "pytest-cov (>=4.0)"]
 
 [[package]]
+name = "nh3"
+version = "0.2.17"
+description = "Python bindings to the ammonia HTML sanitization library."
+optional = false
+python-versions = "*"
+files = [
+    {file = "nh3-0.2.17-cp37-abi3-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:551672fd71d06cd828e282abdb810d1be24e1abb7ae2543a8fa36a71c1006fe9"},
+    {file = "nh3-0.2.17-cp37-abi3-macosx_10_12_x86_64.whl", hash = "sha256:c551eb2a3876e8ff2ac63dff1585236ed5dfec5ffd82216a7a174f7c5082a78a"},
+    {file = "nh3-0.2.17-cp37-abi3-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:66f17d78826096291bd264f260213d2b3905e3c7fae6dfc5337d49429f1dc9f3"},
+    {file = "nh3-0.2.17-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0316c25b76289cf23be6b66c77d3608a4fdf537b35426280032f432f14291b9a"},
+    {file = "nh3-0.2.17-cp37-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:22c26e20acbb253a5bdd33d432a326d18508a910e4dcf9a3316179860d53345a"},
+    {file = "nh3-0.2.17-cp37-abi3-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:85cdbcca8ef10733bd31f931956f7fbb85145a4d11ab9e6742bbf44d88b7e351"},
+    {file = "nh3-0.2.17-cp37-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:40015514022af31975c0b3bca4014634fa13cb5dc4dbcbc00570acc781316dcc"},
+    {file = "nh3-0.2.17-cp37-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ba73a2f8d3a1b966e9cdba7b211779ad8a2561d2dba9674b8a19ed817923f65f"},
+    {file = "nh3-0.2.17-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c21bac1a7245cbd88c0b0e4a420221b7bfa838a2814ee5bb924e9c2f10a1120b"},
+    {file = "nh3-0.2.17-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:d7a25fd8c86657f5d9d576268e3b3767c5cd4f42867c9383618be8517f0f022a"},
+    {file = "nh3-0.2.17-cp37-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:c790769152308421283679a142dbdb3d1c46c79c823008ecea8e8141db1a2062"},
+    {file = "nh3-0.2.17-cp37-abi3-musllinux_1_2_i686.whl", hash = "sha256:b4427ef0d2dfdec10b641ed0bdaf17957eb625b2ec0ea9329b3d28806c153d71"},
+    {file = "nh3-0.2.17-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a3f55fabe29164ba6026b5ad5c3151c314d136fd67415a17660b4aaddacf1b10"},
+    {file = "nh3-0.2.17-cp37-abi3-win32.whl", hash = "sha256:1a814dd7bba1cb0aba5bcb9bebcc88fd801b63e21e2450ae6c52d3b3336bc911"},
+    {file = "nh3-0.2.17-cp37-abi3-win_amd64.whl", hash = "sha256:1aa52a7def528297f256de0844e8dd680ee279e79583c76d6fa73a978186ddfb"},
+    {file = "nh3-0.2.17.tar.gz", hash = "sha256:40d0741a19c3d645e54efba71cb0d8c475b59135c1e3c580f879ad5514cbf028"},
+]
+
+[[package]]
 name = "nltk"
 version = "3.8.1"
 description = "Natural Language Toolkit"
@@ -2944,6 +2984,7 @@ description = "Nvidia JIT LTO Library"
 optional = false
 python-versions = ">=3"
 files = [
+    {file = "nvidia_nvjitlink_cu12-12.5.40-py3-none-manylinux2014_aarch64.whl", hash = "sha256:004186d5ea6a57758fd6d57052a123c73a4815adf365eb8dd6a85c9eaa7535ff"},
     {file = "nvidia_nvjitlink_cu12-12.5.40-py3-none-manylinux2014_x86_64.whl", hash = "sha256:d9714f27c1d0f0895cd8915c07a87a1d0029a0aa36acaf9156952ec2a8a12189"},
     {file = "nvidia_nvjitlink_cu12-12.5.40-py3-none-win_amd64.whl", hash = "sha256:c3401dc8543b52d3a8158007a0c1ab4e9c768fcbd24153a48c86972102197ddd"},
 ]
@@ -5708,4 +5749,4 @@ test = ["big-O", "importlib-resources", "jaraco.functools", "jaraco.itertools", 
 [metadata]
 lock-version = "2.0"
 python-versions = "~3.11"
-content-hash = "f94665294e5fbe36b64efdd31b719f6e919c9a9be9c3f7f445839a7b5db11c26"
+content-hash = "77b8047c004740646c4717a9ef7c53b6482978f9af820309f96743644ad0f406"

--- a/poetry.lock
+++ b/poetry.lock
@@ -2350,21 +2350,6 @@ rtd = ["jupyter_sphinx", "mdit-py-plugins", "myst-parser", "pyyaml", "sphinx", "
 testing = ["coverage", "pytest", "pytest-cov", "pytest-regressions"]
 
 [[package]]
-name = "markdownify"
-version = "0.12.1"
-description = "Convert HTML to markdown."
-optional = false
-python-versions = "*"
-files = [
-    {file = "markdownify-0.12.1-py3-none-any.whl", hash = "sha256:a3805abd8166dbb7b27783c5599d91f54f10d79894b2621404d85b333c7ce561"},
-    {file = "markdownify-0.12.1.tar.gz", hash = "sha256:1fb08c618b30e0ee7a31a39b998f44a18fb28ab254f55f4af06b6d35a2179e27"},
-]
-
-[package.dependencies]
-beautifulsoup4 = ">=4.9,<5"
-six = ">=1.15,<2"
-
-[[package]]
 name = "markupsafe"
 version = "2.1.5"
 description = "Safely add untrusted strings to HTML/XML markup."
@@ -2750,31 +2735,6 @@ developer = ["changelist (==0.5)", "mypy (>=1.1)", "pre-commit (>=3.2)", "rtoml"
 doc = ["myst-nb (>=1.0)", "numpydoc (>=1.7)", "pillow (>=9.4)", "pydata-sphinx-theme (>=0.14)", "sphinx (>=7)", "sphinx-gallery (>=0.14)", "texext (>=0.6.7)"]
 extra = ["lxml (>=4.6)", "pydot (>=2.0)", "pygraphviz (>=1.12)", "sympy (>=1.10)"]
 test = ["pytest (>=7.2)", "pytest-cov (>=4.0)"]
-
-[[package]]
-name = "nh3"
-version = "0.2.17"
-description = "Python bindings to the ammonia HTML sanitization library."
-optional = false
-python-versions = "*"
-files = [
-    {file = "nh3-0.2.17-cp37-abi3-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:551672fd71d06cd828e282abdb810d1be24e1abb7ae2543a8fa36a71c1006fe9"},
-    {file = "nh3-0.2.17-cp37-abi3-macosx_10_12_x86_64.whl", hash = "sha256:c551eb2a3876e8ff2ac63dff1585236ed5dfec5ffd82216a7a174f7c5082a78a"},
-    {file = "nh3-0.2.17-cp37-abi3-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:66f17d78826096291bd264f260213d2b3905e3c7fae6dfc5337d49429f1dc9f3"},
-    {file = "nh3-0.2.17-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0316c25b76289cf23be6b66c77d3608a4fdf537b35426280032f432f14291b9a"},
-    {file = "nh3-0.2.17-cp37-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:22c26e20acbb253a5bdd33d432a326d18508a910e4dcf9a3316179860d53345a"},
-    {file = "nh3-0.2.17-cp37-abi3-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:85cdbcca8ef10733bd31f931956f7fbb85145a4d11ab9e6742bbf44d88b7e351"},
-    {file = "nh3-0.2.17-cp37-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:40015514022af31975c0b3bca4014634fa13cb5dc4dbcbc00570acc781316dcc"},
-    {file = "nh3-0.2.17-cp37-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ba73a2f8d3a1b966e9cdba7b211779ad8a2561d2dba9674b8a19ed817923f65f"},
-    {file = "nh3-0.2.17-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c21bac1a7245cbd88c0b0e4a420221b7bfa838a2814ee5bb924e9c2f10a1120b"},
-    {file = "nh3-0.2.17-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:d7a25fd8c86657f5d9d576268e3b3767c5cd4f42867c9383618be8517f0f022a"},
-    {file = "nh3-0.2.17-cp37-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:c790769152308421283679a142dbdb3d1c46c79c823008ecea8e8141db1a2062"},
-    {file = "nh3-0.2.17-cp37-abi3-musllinux_1_2_i686.whl", hash = "sha256:b4427ef0d2dfdec10b641ed0bdaf17957eb625b2ec0ea9329b3d28806c153d71"},
-    {file = "nh3-0.2.17-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a3f55fabe29164ba6026b5ad5c3151c314d136fd67415a17660b4aaddacf1b10"},
-    {file = "nh3-0.2.17-cp37-abi3-win32.whl", hash = "sha256:1a814dd7bba1cb0aba5bcb9bebcc88fd801b63e21e2450ae6c52d3b3336bc911"},
-    {file = "nh3-0.2.17-cp37-abi3-win_amd64.whl", hash = "sha256:1aa52a7def528297f256de0844e8dd680ee279e79583c76d6fa73a978186ddfb"},
-    {file = "nh3-0.2.17.tar.gz", hash = "sha256:40d0741a19c3d645e54efba71cb0d8c475b59135c1e3c580f879ad5514cbf028"},
-]
 
 [[package]]
 name = "nltk"
@@ -5749,4 +5709,4 @@ test = ["big-O", "importlib-resources", "jaraco.functools", "jaraco.itertools", 
 [metadata]
 lock-version = "2.0"
 python-versions = "~3.11"
-content-hash = "77b8047c004740646c4717a9ef7c53b6482978f9af820309f96743644ad0f406"
+content-hash = "7112448d04ac115bbc6ac2d0df74d1d6cb492f37ce3406dd410aae424ebe7021"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,9 @@ pypdf = "^4.2.0"
 pyjwt = "^2.8.0"
 pydantic-settings = "^2.3.1"
 transformers = "^4.41.2"
+nh3 = "^0.2.17"
+markdownify = "^0.12.1"
+beautifulsoup4 = "^4.12.3"
 
 [tool.poetry.group.dev]
 optional = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,8 +41,6 @@ pypdf = "^4.2.0"
 pyjwt = "^2.8.0"
 pydantic-settings = "^2.3.1"
 transformers = "^4.41.2"
-nh3 = "^0.2.17"
-markdownify = "^0.12.1"
 beautifulsoup4 = "^4.12.3"
 
 [tool.poetry.group.dev]

--- a/src/backend/config/tools.py
+++ b/src/backend/config/tools.py
@@ -11,6 +11,7 @@ from backend.tools import (
     ReadFileTool,
     SearchFileTool,
     TavilyInternetSearch,
+    WebScrapeTool,
 )
 
 """
@@ -31,7 +32,8 @@ class ToolName(StrEnum):
     Read_File = "read_document"
     Python_Interpreter = "python_interpreter"
     Calculator = "calculator"
-    Tavily_Internet_Search = "internet_search"
+    Tavily_Internet_Search = "web_search"
+    Web_Scrape = "web_scrape"
 
 
 ALL_TOOLS = {
@@ -142,6 +144,28 @@ ALL_TOOLS = {
         error_message="TavilyInternetSearch not available, please make sure to set the TAVILY_API_KEY environment variable.",
         category=Category.DataLoader,
         description="Returns a list of relevant document snippets for a textual query retrieved from the internet using Tavily.",
+    ),
+    ToolName.Web_Scrape: ManagedTool(
+        name=ToolName.Web_Scrape,
+        display_name="Web Scrape",
+        implementation=WebScrapeTool,
+        parameter_definitions={
+            "url": {
+                "description": "URL to scrape.",
+                "type": "str",
+                "required": True,
+            },
+            "query": {
+                "description": "Query to search the webpage for.",
+                "type": "str",
+                "required": False,
+            }
+        },
+        is_visible=True,
+        is_available=WebScrapeTool.is_available(),
+        error_message="WebScrapeTool not available.",
+        category=Category.DataLoader,
+        description="Scrapes the content of a webpage, chunks and ranks the content by relevance to the query.",
     ),
 }
 

--- a/src/backend/config/tools.py
+++ b/src/backend/config/tools.py
@@ -159,7 +159,7 @@ ALL_TOOLS = {
                 "description": "Query to search the webpage for.",
                 "type": "str",
                 "required": False,
-            }
+            },
         },
         is_visible=True,
         is_available=WebScrapeTool.is_available(),

--- a/src/backend/tools/__init__.py
+++ b/src/backend/tools/__init__.py
@@ -3,6 +3,8 @@ from backend.tools.files import ReadFileTool, SearchFileTool
 from backend.tools.lang_chain import LangChainVectorDBRetriever, LangChainWikiRetriever
 from backend.tools.python_interpreter import PythonInterpreter
 from backend.tools.tavily import TavilyInternetSearch
+from backend.tools.web_scrape import WebScrapeTool
+
 
 __all__ = [
     "Calculator",
@@ -12,4 +14,5 @@ __all__ = [
     "TavilyInternetSearch",
     "ReadFileTool",
     "SearchFileTool",
+    "WebScrapeTool"
 ]

--- a/src/backend/tools/__init__.py
+++ b/src/backend/tools/__init__.py
@@ -5,7 +5,6 @@ from backend.tools.python_interpreter import PythonInterpreter
 from backend.tools.tavily import TavilyInternetSearch
 from backend.tools.web_scrape import WebScrapeTool
 
-
 __all__ = [
     "Calculator",
     "PythonInterpreter",
@@ -14,5 +13,5 @@ __all__ = [
     "TavilyInternetSearch",
     "ReadFileTool",
     "SearchFileTool",
-    "WebScrapeTool"
+    "WebScrapeTool",
 ]

--- a/src/backend/tools/web_scrape.py
+++ b/src/backend/tools/web_scrape.py
@@ -1,11 +1,11 @@
 import os
-import nh3
-
 from typing import Any, Dict, List
-from requests import get
-from bs4 import BeautifulSoup
-from backend.chat.collate import chunk
 
+import nh3
+from bs4 import BeautifulSoup
+from requests import get
+
+from backend.chat.collate import chunk
 from backend.tools.base import BaseTool
 
 
@@ -16,14 +16,16 @@ class WebScrapeTool(BaseTool):
 
     def call(self, parameters: dict, **kwargs: Any) -> List[Dict[str, Any]]:
         url = parameters.get("url")
-        
+
         page_content = get(url).text
         soup = BeautifulSoup(page_content, "html.parser")
         text = soup.get_text(separator="\n")
 
-        return [(
-            {
-                "text": text,
-                "url": url,
-            }
-        )]
+        return [
+            (
+                {
+                    "text": text,
+                    "url": url,
+                }
+            )
+        ]

--- a/src/backend/tools/web_scrape.py
+++ b/src/backend/tools/web_scrape.py
@@ -1,0 +1,29 @@
+import os
+import nh3
+
+from typing import Any, Dict, List
+from requests import get
+from bs4 import BeautifulSoup
+from backend.chat.collate import chunk
+
+from backend.tools.base import BaseTool
+
+
+class WebScrapeTool(BaseTool):
+    @classmethod
+    def is_available(cls) -> bool:
+        return True
+
+    def call(self, parameters: dict, **kwargs: Any) -> List[Dict[str, Any]]:
+        url = parameters.get("url")
+        
+        page_content = get(url).text
+        soup = BeautifulSoup(page_content, "html.parser")
+        text = soup.get_text(separator="\n")
+
+        return [(
+            {
+                "text": text,
+                "url": url,
+            }
+        )]

--- a/src/backend/tools/web_scrape.py
+++ b/src/backend/tools/web_scrape.py
@@ -1,11 +1,8 @@
-import os
 from typing import Any, Dict, List
 
-import nh3
 from bs4 import BeautifulSoup
 from requests import get
 
-from backend.chat.collate import chunk
 from backend.tools.base import BaseTool
 
 


### PR DESCRIPTION
Proposing to do page scrape, chunk, and rerank using python libraries instead of using other APIs. Since we have rerank and chunking we can just scrape ourselves and not have to rely on an API where we would need to provide a key

PR Items:
- Renamed `internet_search` -> `web_search`. Conflicts with Cohere Platform managed tool name. Will error out.
- Added new `web_scrape` tool. Gets HTML page and uses `bs4` to clean it and pass in string as tool result

Issues found and to follow up on:
- Chunking and reranking in `collate.py` used in `custom_chat.py` seems kinda hit or miss. Sometimes doesn't chunk at all.
- Better formatting for results, `bs4` cleans the text completely of markdown, but it is possible to include markdown, we just need FE to support it!


https://github.com/cohere-ai/cohere-toolkit/assets/146760070/e5fa767d-ad78-48d3-9cf3-7e7fa1a8bf3d



**AI Description**

<!-- begin-generated-description -->

This PR introduces a new `WebScrapeTool` class, enabling web scraping functionality. 

**Changes:**
- Added WebScrapeTool to the list of imports in `__init__.py`.>
- Modified ToolName enum in `tools.py` to include `Web_Scrape` and updated the associated values.
- Created a new module `web_scrape.py` to define the `WebScrapeTool` class, inheriting from `BaseTool`.
- Added beautifulsoup4 to the list of dependencies in `pyproject.toml`.

<!-- end-generated-description -->
