### PR TITLE
Add error troubleshooting

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -45,6 +45,19 @@ brew install postgresql
 
 For other operating systems, you can check the [postgres documentation](https://www.postgresql.org/download/).
 
+## Error: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested
+
+Add `platform: linux/amd64` to docker_compose.yml for example: 
+
+```
+  terrarium:
+    platform: linux/amd64
+    image: ghcr.io/cohere-ai/terrarium:latest
+    ports:
+      - '8080:8080'
+    expose:
+      - '8080'
+```
 
 ##  Debugging locally
 


### PR DESCRIPTION
Add error troubleshooting

**AI Description**

<!-- begin-generated-description -->

This PR adds troubleshooting steps for an error that occurs when the requested image's platform (`linux/amd64`) doesn't match the detected host platform (`linux/arm64/v8`). 

To resolve this issue, the following changes are made:
- A new section titled "Error: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested" is added to the `docs/troubleshooting.md` file.
- It is suggested to add `platform: linux/amd64` to the `docker_compose.yml` file, with an example configuration provided.

These changes will help users troubleshoot and resolve the specific error by providing clear instructions and an example configuration.

<!-- end-generated-description -->
