### PR TITLE
[backend] agent chat fixes

### DIFF
--- a/src/backend/config/tools.py
+++ b/src/backend/config/tools.py
@@ -29,9 +29,9 @@ class ToolName(StrEnum):
     Wiki_Retriever_LangChain = "wikipedia"
     Search_File = "search_file"
     Read_File = "read_document"
-    Python_Interpreter = "python_interpreter"
+    Python_Interpreter = "toolkit_python_interpreter"
     Calculator = "calculator"
-    Tavily_Internet_Search = "internet_search"
+    Tavily_Internet_Search = "web_search"
 
 
 ALL_TOOLS = {

--- a/src/backend/services/chat.py
+++ b/src/backend/services/chat.py
@@ -85,6 +85,15 @@ def process_chat(
                 status_code=404, detail=f"Agent with ID {agent_id} not found."
             )
 
+        tool_names = [tool.name for tool in chat_request.tools]
+        if chat_request.tools:
+            for tool in chat_request.tools:
+                if tool.name not in agent.tools:
+                    raise HTTPException(
+                        status_code=400,
+                        detail=f"Tool {tool.name} not found in agent {agent.id}",
+                    )
+
         # Set the agent settings in the chat request
         chat_request.preamble = agent.preamble
         chat_request.tools = [Tool(name=tool) for tool in agent.tools]


### PR DESCRIPTION
previously the tools were just overwritten with all of the tools in the agent
now, we dont overwrite them but rather check if the tools selected are assigned to the agent

also fixing renaming of tools to not clash with cohere platform API tools.

**AI Description**

<!-- begin-generated-description -->

This pull request makes changes to the tool names and adds a test for tool validation.

## Summary
- Renames `Python_Interpreter` to `toolkit_python_interpreter` and `Tavily_Internet_Search` to `web_search` in `src/backend/config/tools.py`.
- Adds validation to check if tools in the `chat_request` are present in the agent's tools in `src/backend/services/chat.py`.
- Adds a test `test_streaming_chat_with_tools_not_in_agent_tools` to verify the behavior when tools in the chat request are not present in the agent's tools in `src/backend/tests/routers/test_chat.py`.

## Details

### Tool Name Changes
- `src/backend/config/tools.py`:
  - Renames `Python_Interpreter` to `toolkit_python_interpreter`.
  - Renames `Tavily_Internet_Search` to `web_search`.

### Tool Validation
- `src/backend/services/chat.py`:
  - Adds a check to iterate over the tools in the `chat_request` and verify if each tool is present in the agent's tools.
  - If a tool is not found in the agent's tools, raises an `HTTPException` with a status code of `400` and a detail message indicating the missing tool and agent ID.

### Test for Tool Validation
- `src/backend/tests/routers/test_chat.py`:
  - Adds a new test function `test_streaming_chat_with_tools_not_in_agent_tools` to test the scenario where the tools in the chat request are not present in the agent's tools.
  - Creates an agent with an empty list of tools and sends a chat request with the tool `web_search`.
  - Asserts that the response status code is `400` and the response JSON contains the expected detail message indicating the missing tool and agent ID.

<!-- end-generated-description -->
