### PR TITLE
coral-web: adds agent id to chat request

### DIFF
--- a/src/interfaces/coral_web/src/cohere-client/client.ts
+++ b/src/interfaces/coral_web/src/cohere-client/client.ts
@@ -182,6 +182,7 @@ export class CohereClient {
   public async chat({
     request,
     headers,
+    agentId,
     signal,
     onOpen,
     onMessage,
@@ -190,6 +191,7 @@ export class CohereClient {
   }: {
     request: CohereChatRequest;
     headers?: Record<string, string>;
+    agentId?: string;
     signal?: AbortSignal;
     onOpen?: FetchEventSourceInit['onopen'];
     onMessage?: FetchEventSourceInit['onmessage'];
@@ -200,7 +202,9 @@ export class CohereClient {
     const requestBody = JSON.stringify({
       ...chatRequest,
     });
-    return await fetchEventSource(this.getEndpoint('chat-stream'), {
+
+    const endpoint = `${this.getEndpoint('chat-stream')}${agentId ? `?agent_id=${agentId}` : ''}`;
+    return await fetchEventSource(endpoint, {
       method: 'POST',
       headers: { ...this.getHeaders(), ...headers },
       body: requestBody,

--- a/src/interfaces/coral_web/src/hooks/chat.ts
+++ b/src/interfaces/coral_web/src/hooks/chat.ts
@@ -1,4 +1,5 @@
 import { UseMutateAsyncFunction, useQueryClient } from '@tanstack/react-query';
+import { useRouter } from 'next/router';
 import { useState } from 'react';
 
 import {
@@ -38,6 +39,7 @@ import {
 import {
   createStartEndKey,
   fixMarkdownImagesInText,
+  getQueryString,
   isAbortError,
   isGroundingOn,
   replaceTextWithCitations,
@@ -68,6 +70,7 @@ export type HandleSendChat = (
 ) => Promise<void>;
 
 export const useChat = (config?: { onSend?: (msg: string) => void }) => {
+  const router = useRouter();
   const { chatMutation, abortController } = useStreamChat();
   const { mutateAsync: streamChat } = chatMutation;
 
@@ -94,6 +97,7 @@ export const useChat = (config?: { onSend?: (msg: string) => void }) => {
   const [userMessage, setUserMessage] = useState('');
   const [isStreaming, setIsStreaming] = useState(false);
   const [streamingMessage, setStreamingMessage] = useState<StreamingMessage | null>(null);
+  const agentId = getQueryString(router.query.agentId);
 
   useRouteChange({
     onRouteChangeStart: () => {
@@ -177,6 +181,7 @@ export const useChat = (config?: { onSend?: (msg: string) => void }) => {
     newMessages: ChatMessage[];
     request: CohereChatRequest;
     headers: Record<string, string>;
+    agentId?: string;
     streamConverse: UseMutateAsyncFunction<
       StreamEnd | undefined,
       CohereNetworkError,
@@ -207,6 +212,7 @@ export const useChat = (config?: { onSend?: (msg: string) => void }) => {
       await streamConverse({
         request,
         headers,
+        agentId,
         onRead: (eventData: ChatResponseEvent) => {
           switch (eventData.event) {
             case StreamEvent.STREAM_START: {
@@ -509,7 +515,13 @@ export const useChat = (config?: { onSend?: (msg: string) => void }) => {
       files: composerFiles,
     });
 
-    await handleStreamConverse({ newMessages, request, headers, streamConverse: streamChat });
+    await handleStreamConverse({
+      newMessages,
+      request,
+      headers,
+      agentId,
+      streamConverse: streamChat,
+    });
   };
 
   const handleRetry = () => {

--- a/src/interfaces/coral_web/src/hooks/streamChat.ts
+++ b/src/interfaces/coral_web/src/hooks/streamChat.ts
@@ -26,6 +26,7 @@ interface StreamingParams {
 export interface StreamingChatParams extends StreamingParams {
   request: CohereChatRequest;
   headers: Record<string, string>;
+  agentId?: string;
 }
 
 const getUpdatedConversations =
@@ -115,7 +116,7 @@ export const useStreamChat = () => {
         if (experimentalFeatures?.USE_EXPERIMENTAL_LANGCHAIN) {
           await cohereClient.langchainChat(chatStreamParams);
         } else {
-          await cohereClient.chat(chatStreamParams);
+          await cohereClient.chat({ ...chatStreamParams, agentId: params.agentId });
         }
       } catch (e) {
         if (isUnauthorizedError(e)) {


### PR DESCRIPTION
Thank you for contributing to the Cohere Toolkit!



https://github.com/cohere-ai/cohere-toolkit/assets/140425731/e145c1da-67d0-47ae-a227-f110753eeae0


- [ ] **PR title**: "area: description"
  - Where "area" is whichever of interface, frontend, model, tools, backend, etc. is being modified. Use "docs: ..." for purely docs changes, "infra: ..." for CI changes.
  - Example: "deployment: add Azure model option"


- [ ] **PR message**: ***Delete this entire checklist*** and replace with
    - **Description:** a description of the change
    - **Issue:** the issue # it fixes, if applicable
    - **Dependencies:** any dependencies required for this change


- [ ] **Add tests and docs**: Please include testing and documentation for your changes
- [ ] **Lint and test**: Run `make lint` and `make run-tests`

**AI Description**

<!-- begin-generated-description -->

This pull request introduces changes to the `src/interfaces/coral_web/src` module, specifically the `client.ts`, `chat.ts`, and `streamChat.ts` files. 

The changes are related to adding an `agentId` parameter to the `CohereClient` class and updating dependent functions.

- In `client.ts`, the `CohereClient` class now includes an `agentId` parameter in its constructor. This is used to construct the `endpoint` URL when making fetch requests.
- In `chat.ts`, the `useChat` function now imports `useRouter` from 'next/router' and uses `getQueryString` to extract the `agentId` from `router.query.` This `agentId` is then used in the `handleStreamConverse` function call.
- In `streamChat.ts`, the `StreamingChatParams` interface has been updated to include an optional `agentId` field. The `useStreamChat` function now passes the `agentId` parameter to the `cohereClient.chat` function call.

These changes allow the `agentId` to be included in relevant API requests and enable its usage in dependent functions.

<!-- end-generated-description -->
