### PR TITLE
fix(toolkit): remove settings tab and fixes bug

### DIFF
--- a/src/interfaces/coral_web/src/components/Agents/AgentCard.tsx
+++ b/src/interfaces/coral_web/src/components/Agents/AgentCard.tsx
@@ -3,6 +3,7 @@ import { useRouter } from 'next/router';
 
 import { KebabMenu } from '@/components/KebabMenu';
 import { CoralLogo, Text, Tooltip } from '@/components/Shared';
+import { useRecentAgents } from '@/hooks/agents';
 import { getIsTouchDevice } from '@/hooks/breakpoint';
 import { useAgentsStore, useCitationsStore, useConversationStore, useParamsStore } from '@/stores';
 import { cn } from '@/utils';
@@ -24,9 +25,9 @@ export const AgentCard: React.FC<Props> = ({ name, id, isBaseAgent, isExpanded }
   const isTouchDevice = getIsTouchDevice();
   const { query } = useRouter();
   const isActive = isBaseAgent ? !query.agentId : query.agentId === id;
-  const { removeRecentAgentId } = useAgentsStore();
   const router = useRouter();
 
+  const { removeRecentAgentId } = useRecentAgents();
   const { setEditAgentPanelOpen } = useAgentsStore();
   const { resetConversation } = useConversationStore();
   const { resetCitations } = useCitationsStore();

--- a/src/interfaces/coral_web/src/components/Agents/AgentCard.tsx
+++ b/src/interfaces/coral_web/src/components/Agents/AgentCard.tsx
@@ -4,13 +4,7 @@ import { useRouter } from 'next/router';
 import { KebabMenu } from '@/components/KebabMenu';
 import { CoralLogo, Text, Tooltip } from '@/components/Shared';
 import { getIsTouchDevice } from '@/hooks/breakpoint';
-import {
-  useAgentsStore,
-  useCitationsStore,
-  useConversationStore,
-  useParamsStore,
-  useSettingsStore,
-} from '@/stores';
+import { useAgentsStore, useCitationsStore, useConversationStore, useParamsStore } from '@/stores';
 import { cn } from '@/utils';
 import { getCohereColor } from '@/utils/getCohereColor';
 
@@ -33,7 +27,7 @@ export const AgentCard: React.FC<Props> = ({ name, id, isBaseAgent, isExpanded }
   const { removeRecentAgentId } = useAgentsStore();
   const router = useRouter();
 
-  const { setSettings } = useSettingsStore();
+  const { setEditAgentPanelOpen } = useAgentsStore();
   const { resetConversation } = useConversationStore();
   const { resetCitations } = useCitationsStore();
   const { resetFileParams } = useParamsStore();
@@ -41,7 +35,7 @@ export const AgentCard: React.FC<Props> = ({ name, id, isBaseAgent, isExpanded }
   const handleNewChat = () => {
     const url = id ? `/agents/${id}` : '/agents';
     router.push(url, undefined, { shallow: true });
-    setSettings({ isEditAgentPanelOpen: false });
+    setEditAgentPanelOpen(false);
     resetConversation();
     resetCitations();
     resetFileParams();

--- a/src/interfaces/coral_web/src/components/Agents/AgentsList.tsx
+++ b/src/interfaces/coral_web/src/components/Agents/AgentsList.tsx
@@ -13,7 +13,7 @@ export const AgentsList: React.FC = () => {
   const {
     agents: { isAgentsSidePanelOpen },
   } = useAgentsStore();
-  const recentAgents = useRecentAgents();
+  const { recentAgents } = useRecentAgents();
 
   return (
     <div className="flex flex-col gap-3">
@@ -30,7 +30,7 @@ export const AgentsList: React.FC = () => {
       </Transition>
 
       <AgentCard isExpanded={isAgentsSidePanelOpen} name="Command R+" isBaseAgent />
-      {recentAgents?.map((agent) => (
+      {recentAgents.map((agent) => (
         <AgentCard
           key={agent.id}
           isExpanded={isAgentsSidePanelOpen}

--- a/src/interfaces/coral_web/src/components/Agents/AgentsList.tsx
+++ b/src/interfaces/coral_web/src/components/Agents/AgentsList.tsx
@@ -3,7 +3,7 @@ import { Transition } from '@headlessui/react';
 import { AgentCard } from '@/components/Agents/AgentCard';
 import { Text } from '@/components/Shared';
 import { useRecentAgents } from '@/hooks/agents';
-import { useSettingsStore } from '@/stores';
+import { useAgentsStore } from '@/stores';
 
 /**
  * @description This component renders a list of agents.
@@ -11,8 +11,8 @@ import { useSettingsStore } from '@/stores';
  */
 export const AgentsList: React.FC = () => {
   const {
-    settings: { isAgentsSidePanelOpen },
-  } = useSettingsStore();
+    agents: { isAgentsSidePanelOpen },
+  } = useAgentsStore();
   const recentAgents = useRecentAgents();
 
   return (

--- a/src/interfaces/coral_web/src/components/Agents/AgentsSidePanel.tsx
+++ b/src/interfaces/coral_web/src/components/Agents/AgentsSidePanel.tsx
@@ -5,7 +5,7 @@ import { IconButton } from '@/components/IconButton';
 import { Button, Icon, IconProps, Logo, Tooltip } from '@/components/Shared';
 import { env } from '@/env.mjs';
 import { useIsDesktop } from '@/hooks/breakpoint';
-import { useSettingsStore } from '@/stores';
+import { useAgentsStore, useSettingsStore } from '@/stores';
 import { cn } from '@/utils';
 
 /**
@@ -14,18 +14,18 @@ import { cn } from '@/utils';
  * It also renders the children components that are passed to it.
  */
 export const AgentsSidePanel: React.FC<React.PropsWithChildren> = ({ children }) => {
+  const { setSettings, setIsConvListPanelOpen } = useSettingsStore();
   const {
-    settings: { isAgentsSidePanelOpen },
-    setSettings,
-    setIsConvListPanelOpen,
-  } = useSettingsStore();
-
+    agents: { isAgentsSidePanelOpen },
+    setAgentsSidePanelOpen,
+  } = useAgentsStore();
   const isDesktop = useIsDesktop();
   const isMobile = !isDesktop;
 
   const handleToggleAgentsSidePanel = () => {
     setIsConvListPanelOpen(false);
-    setSettings({ isConfigDrawerOpen: false, isAgentsSidePanelOpen: !isAgentsSidePanelOpen });
+    setSettings({ isConfigDrawerOpen: false });
+    setAgentsSidePanelOpen(!isAgentsSidePanelOpen);
   };
 
   const navigationItems: {

--- a/src/interfaces/coral_web/src/components/Agents/CreateAgentForm.tsx
+++ b/src/interfaces/coral_web/src/components/Agents/CreateAgentForm.tsx
@@ -5,9 +5,8 @@ import { AgentForm, AgentFormFieldKeys, AgentFormFields } from '@/components/Age
 import { Button, Text } from '@/components/Shared';
 import { DEFAULT_AGENT_MODEL, DEPLOYMENT_COHERE_PLATFORM } from '@/constants';
 import { ModalContext } from '@/context/ModalContext';
-import { useCreateAgent, useIsAgentNameUnique } from '@/hooks/agents';
+import { useCreateAgent, useIsAgentNameUnique, useRecentAgents } from '@/hooks/agents';
 import { useNotify } from '@/hooks/toast';
-import { useAgentsStore } from '@/stores';
 
 /**
  * @description Form to create a new agent.
@@ -17,7 +16,7 @@ export const CreateAgentForm: React.FC = () => {
   const { open, close } = useContext(ModalContext);
   const { error } = useNotify();
   const { mutateAsync: createAgent } = useCreateAgent();
-  const { addRecentAgentId } = useAgentsStore();
+  const { addRecentAgentId } = useRecentAgents();
   const isAgentNameUnique = useIsAgentNameUnique();
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [fields, setFields] = useState<AgentFormFields>({

--- a/src/interfaces/coral_web/src/components/Agents/CreateAgentForm.tsx
+++ b/src/interfaces/coral_web/src/components/Agents/CreateAgentForm.tsx
@@ -84,7 +84,7 @@ export const CreateAgentForm: React.FC = () => {
       });
       close();
       setIsSubmitting(false);
-      router.push(`/agents?assistantId=${agent.id}`, undefined, { shallow: true });
+      router.push(`/agents/${agent.id}`, undefined, { shallow: true });
     } catch (e) {
       setIsSubmitting(false);
       close();

--- a/src/interfaces/coral_web/src/components/Agents/DiscoverAgentCard.tsx
+++ b/src/interfaces/coral_web/src/components/Agents/DiscoverAgentCard.tsx
@@ -42,7 +42,7 @@ export const DiscoverAgentCard: React.FC<Props> = ({ id, name, description, isBa
         <Text className="line-clamp-2 flex-grow break-all text-left">{description}</Text>
         <Button
           className="ml-auto"
-          href={isBaseAgent ? '/agents' : `/agents?assistantId=${id}`}
+          href={isBaseAgent ? '/agents' : `/agents/${id}`}
           label={<Text className="text-green-700">Try now</Text>}
           kind="secondary"
           endIcon={<Icon name="arrow-up-right" className="text-green-700" />}

--- a/src/interfaces/coral_web/src/components/Agents/Layout.tsx
+++ b/src/interfaces/coral_web/src/components/Agents/Layout.tsx
@@ -3,7 +3,7 @@ import React, { Children, PropsWithChildren } from 'react';
 
 import { AgentsSidePanel } from '@/components/Agents/AgentsSidePanel';
 import { MobileHeader } from '@/components/Agents/MobileHeader';
-import { SettingsDrawer } from '@/components/Settings/SettingsDrawer';
+import { SettingsDrawer } from '@/components/Agents/Settings/SettingsDrawer';
 import { PageHead } from '@/components/Shared/PageHead';
 import { cn } from '@/utils/cn';
 

--- a/src/interfaces/coral_web/src/components/Agents/MobileHeader.tsx
+++ b/src/interfaces/coral_web/src/components/Agents/MobileHeader.tsx
@@ -1,14 +1,14 @@
 import { Logo } from '@/components/Shared';
-import { useSettingsStore } from '@/stores';
+import { useAgentsStore } from '@/stores';
 
 export const MobileHeader: React.FC = () => {
   const {
-    settings: { isAgentsSidePanelOpen },
-    setIsAgentsSidePanelOpen,
-  } = useSettingsStore();
+    agents: { isAgentsSidePanelOpen },
+    setAgentsSidePanelOpen,
+  } = useAgentsStore();
 
   const onToggleAgentsSidePanel = () => {
-    setIsAgentsSidePanelOpen(!isAgentsSidePanelOpen);
+    setAgentsSidePanelOpen(!isAgentsSidePanelOpen);
   };
 
   return (

--- a/src/interfaces/coral_web/src/components/Agents/Settings/FilesTab.tsx
+++ b/src/interfaces/coral_web/src/components/Agents/Settings/FilesTab.tsx
@@ -1,0 +1,144 @@
+import React, { Fragment, useEffect, useMemo } from 'react';
+
+import { ListFile } from '@/cohere-client';
+import { Checkbox, Text, Tooltip } from '@/components/Shared';
+import { useFocusFileInput } from '@/hooks/actions';
+import { useDefaultFileLoaderTool, useFilesInConversation } from '@/hooks/files';
+import { useFilesStore, useParamsStore } from '@/stores';
+import { cn, formatFileSize, getWeeksAgo } from '@/utils';
+
+interface UploadedFile extends ListFile {
+  checked: boolean;
+}
+
+/**
+ * @description Files tab content that shows a list of available files
+ * File upload is not supported for conversations without an id
+ */
+export const FilesTab: React.FC<{ className?: string }> = ({ className = '' }) => {
+  const {
+    params: { fileIds },
+    setParams,
+  } = useParamsStore();
+  const {
+    files: { composerFiles },
+    deleteComposerFile,
+  } = useFilesStore();
+  const { isFileInputQueuedToFocus, focusFileInput } = useFocusFileInput();
+  const { files } = useFilesInConversation();
+  const { enableDefaultFileLoaderTool, disableDefaultFileLoaderTool } = useDefaultFileLoaderTool();
+
+  useEffect(() => {
+    if (isFileInputQueuedToFocus) {
+      focusFileInput();
+    }
+  }, [isFileInputQueuedToFocus]);
+
+  const uploadedFiles: UploadedFile[] = useMemo(() => {
+    if (!files) return [];
+
+    return files
+      .map((document: ListFile) => ({
+        ...document,
+        checked: (fileIds ?? []).some((id) => id === document.id),
+      }))
+      .sort(
+        (a, b) => new Date(b.created_at || '').getTime() - new Date(a.created_at || '').getTime()
+      );
+  }, [files, fileIds]);
+
+  const dateGroupedUploadedFiles = uploadedFiles.reduce<{
+    [title: string]: UploadedFile[];
+  }>((groupedFiles, file) => {
+    const uploadDate = new Date(file.created_at);
+    if (!file.created_at) return groupedFiles;
+    const { weeksAgo, weeksAgoStr } = getWeeksAgo(uploadDate);
+    const title = weeksAgo <= 1 ? 'Most recent' : weeksAgoStr;
+
+    if (!groupedFiles[title]) {
+      groupedFiles[title] = [];
+    }
+    groupedFiles[title].push(file);
+
+    return groupedFiles;
+  }, {});
+
+  const handleToggle = (fileId?: string) => {
+    if (!fileId) return;
+
+    let newFileIds: string[] = [];
+    if (fileIds?.some((id) => id === fileId)) {
+      newFileIds = fileIds.filter((id) => id !== fileId);
+
+      if (composerFiles.some((file) => file.id === fileId)) {
+        deleteComposerFile(fileId);
+      }
+    } else {
+      newFileIds = [...(fileIds ?? []), fileId];
+    }
+
+    if (newFileIds.length === 0) {
+      disableDefaultFileLoaderTool();
+    } else {
+      enableDefaultFileLoaderTool();
+    }
+
+    setParams({ fileIds: newFileIds });
+  };
+
+  return (
+    <article className={cn('flex flex-col pb-10', className)}>
+      <section className="relative flex flex-col gap-y-8 px-5">
+        <div className="flex gap-x-2">
+          <Text styleAs="label" className="font-medium">
+            Files in conversation
+          </Text>
+          <Tooltip label="To use uploaded files, at least 1 File Upload tool must be enabled" />
+        </div>
+
+        {uploadedFiles.length > 0 && (
+          <div className="flex w-full flex-col gap-y-14 pb-2">
+            <div className="flex flex-col gap-y-4">
+              {Object.keys(dateGroupedUploadedFiles).map(
+                (title) =>
+                  dateGroupedUploadedFiles[title].length > 0 && (
+                    <Fragment key={title}>
+                      <Text styleAs="label" className="text-volcanic-100">
+                        {title}
+                      </Text>
+                      {dateGroupedUploadedFiles[title].map(
+                        ({ file_name: name, file_size: size, id, checked }) => (
+                          <div key={id} className="group flex w-full flex-col gap-y-2">
+                            <div className="flex w-full items-center justify-between gap-x-2">
+                              <div className={cn('flex w-[60%] overflow-hidden lg:w-[70%]')}>
+                                <Checkbox
+                                  checked={checked}
+                                  onChange={() => handleToggle(id)}
+                                  label={name}
+                                  name={name}
+                                  theme="secondary"
+                                  className="w-full"
+                                  labelClassName="ml-0 truncate w-full"
+                                  labelSubContainerClassName="w-full"
+                                  labelContainerClassName="w-full"
+                                />
+                              </div>
+                              <div className="flex h-5 w-32 grow items-center justify-end gap-x-1">
+                                <Text styleAs="caption" className="text-volcanic-700">
+                                  {formatFileSize(size ?? 0)}
+                                </Text>
+                              </div>
+                            </div>
+                          </div>
+                        )
+                      )}
+                    </Fragment>
+                  )
+              )}
+            </div>
+          </div>
+        )}
+      </section>
+    </article>
+  );
+};

--- a/src/interfaces/coral_web/src/components/Agents/Settings/SettingsDrawer.tsx
+++ b/src/interfaces/coral_web/src/components/Agents/Settings/SettingsDrawer.tsx
@@ -1,0 +1,91 @@
+import { Transition } from '@headlessui/react';
+import React, { useMemo, useState } from 'react';
+
+import { FilesTab } from '@/components/Agents/Settings/FilesTab';
+import { ToolsTab } from '@/components/Agents/Settings/ToolsTab';
+import { IconButton } from '@/components/IconButton';
+import { Icon, Tabs, Text } from '@/components/Shared';
+import { SETTINGS_DRAWER_ID } from '@/constants';
+import { useFilesInConversation } from '@/hooks/files';
+import { useCitationsStore, useConversationStore, useSettingsStore } from '@/stores';
+import { cn } from '@/utils';
+
+// TODO(@wujessica): grab these from the agents api
+const REQUIRED_TOOLS: string[] = [];
+
+/**
+ * @description Renders the settings drawer of the main content.
+ * It opens up on top of the citation panel/the main content.
+ */
+export const SettingsDrawer: React.FC = () => {
+  const [selectedTabIndex, setSelectedTabIndex] = useState(0);
+  const {
+    conversation: { id: conversationId },
+  } = useConversationStore();
+  const {
+    settings: { isConfigDrawerOpen },
+    setSettings,
+  } = useSettingsStore();
+  const {
+    citations: { hasCitations },
+  } = useCitationsStore();
+  const { files } = useFilesInConversation();
+
+  const tabs = useMemo(() => {
+    return files.length > 0 && conversationId
+      ? [
+          { name: 'Tools', component: <ToolsTab requiredTools={REQUIRED_TOOLS} /> },
+          { name: 'Files', component: <FilesTab /> },
+        ]
+      : [{ name: 'Tools', component: <ToolsTab requiredTools={REQUIRED_TOOLS} /> }];
+  }, [files.length, conversationId]);
+
+  return (
+    <Transition
+      as="section"
+      show={isConfigDrawerOpen}
+      className={cn(
+        'absolute right-0 z-configuration-drawer',
+        'flex h-full flex-col',
+        'w-full md:max-w-drawer lg:max-w-drawer-lg',
+        'rounded-lg md:rounded-l-none',
+        'bg-marble-100 md:shadow-drawer',
+        'border border-marble-400',
+        { 'xl:border-l-0': hasCitations }
+      )}
+      enter="transition-transform ease-in-out duration-200"
+      enterFrom="translate-x-full"
+      enterTo="translate-x-0"
+      leave="transition-transform ease-in-out duration-200"
+      leaveFrom="translate-x-0"
+      leaveTo="translate-x-full"
+    >
+      <header className="flex h-header items-center gap-2 border-b border-marble-400 p-5">
+        <IconButton
+          iconName="close-drawer"
+          tooltip={{ label: 'Close drawer', size: 'md' }}
+          isDefaultOnHover={false}
+          onClick={() => setSettings({ isConfigDrawerOpen: false })}
+        />
+        <span className="flex items-center gap-2">
+          <Icon name="settings" className="text-volcanic-700" kind="outline" />
+          <Text styleAs="p-lg">Settings</Text>
+        </span>
+      </header>
+
+      <section id={SETTINGS_DRAWER_ID} className="h-full w-full overflow-y-auto rounded-b-lg">
+        <Tabs
+          tabs={tabs.map((t) => t.name)}
+          selectedIndex={selectedTabIndex}
+          onChange={setSelectedTabIndex}
+          tabGroupClassName="h-full"
+          tabClassName="pt-2.5"
+          panelsClassName="pt-7 lg:pt-7 px-0 flex flex-col rounded-b-lg bg-marble-100 md:rounded-b-none"
+          fitTabsContent={true}
+        >
+          {tabs.map((t) => t.component)}
+        </Tabs>
+      </section>
+    </Transition>
+  );
+};

--- a/src/interfaces/coral_web/src/components/Agents/Settings/ToolsInfoBox.tsx
+++ b/src/interfaces/coral_web/src/components/Agents/Settings/ToolsInfoBox.tsx
@@ -1,0 +1,44 @@
+import { Transition } from '@headlessui/react';
+
+import { Button, Text } from '@/components/Shared';
+import { useShowToolsInfoBox } from '@/hooks/ftux';
+import { useSettingsStore } from '@/stores';
+
+export const ToolsInfoBox: React.FC = () => {
+  const {
+    settings: { isConfigDrawerOpen },
+  } = useSettingsStore();
+  const { show, onDismissed } = useShowToolsInfoBox();
+
+  return (
+    <Transition
+      show={show && isConfigDrawerOpen}
+      appear
+      as="article"
+      role="note"
+      className="flex flex-col gap-y-3 rounded bg-primary-50 px-3.5 py-3"
+      leave="transition-opacity ease-in-out"
+      leaveFrom="opacity-100"
+      leaveTo="opacity-0"
+    >
+      <Text>
+        Tools are functions that the model can access, such as searching Wikipedia or summarizing an
+        uploaded PDF. Follow the documentation to add custom available tools.
+        <br />
+        <br />
+        Tools can be turned on or off at any time in your conversation.
+      </Text>
+      <Button
+        label={
+          <Text styleAs="label" className="font-medium text-primary-800">
+            Got it
+          </Text>
+        }
+        kind="secondary"
+        animate={false}
+        className="self-end"
+        onClick={onDismissed}
+      />
+    </Transition>
+  );
+};

--- a/src/interfaces/coral_web/src/components/Agents/Settings/ToolsTab.tsx
+++ b/src/interfaces/coral_web/src/components/Agents/Settings/ToolsTab.tsx
@@ -1,0 +1,129 @@
+import React, { useMemo } from 'react';
+
+import { ManagedTool } from '@/cohere-client';
+import { ToolsInfoBox } from '@/components/Agents/Settings/ToolsInfoBox';
+import { Text } from '@/components/Shared';
+import { ToggleCard } from '@/components/ToggleCard';
+import { WelcomeGuideTooltip } from '@/components/WelcomeGuideTooltip';
+import { TOOL_FALLBACK_ICON, TOOL_ID_TO_DISPLAY_INFO } from '@/constants';
+import { useDefaultFileLoaderTool } from '@/hooks/files';
+import { useListTools } from '@/hooks/tools';
+import { useFilesStore, useParamsStore } from '@/stores';
+import { ConfigurableParams } from '@/stores/slices/paramsSlice';
+import { cn } from '@/utils';
+
+/**
+ * @description Tools tab content that shows a list of available tools and files
+ */
+export const ToolsTab: React.FC<{ requiredTools: string[]; className?: string }> = ({
+  requiredTools,
+  className = '',
+}) => {
+  const { params, setParams } = useParamsStore();
+  const { data } = useListTools();
+  const { tools: paramTools } = params;
+  const enabledTools = paramTools ?? [];
+  const { defaultFileLoaderTool } = useDefaultFileLoaderTool();
+  const { clearComposerFiles } = useFilesStore();
+
+  const { availableTools, unavailableTools } = useMemo(() => {
+    return (data ?? [])
+      .filter((t) => t.is_visible)
+      .reduce<{ availableTools: ManagedTool[]; unavailableTools: ManagedTool[] }>(
+        (acc, tool) => {
+          if (tool.is_available) {
+            acc.availableTools.push(tool);
+          } else {
+            acc.unavailableTools.push(tool);
+          }
+          return acc;
+        },
+        { availableTools: [], unavailableTools: [] }
+      );
+  }, [data]);
+
+  const handleToggle = (name: string, checked: boolean) => {
+    const newParams: Partial<ConfigurableParams> = {
+      tools: checked
+        ? [...enabledTools, { name }]
+        : enabledTools.filter((enabledTool) => enabledTool.name !== name),
+    };
+
+    if (name === defaultFileLoaderTool?.name) {
+      newParams.fileIds = [];
+      clearComposerFiles();
+    }
+
+    setParams(newParams);
+  };
+
+  return (
+    <section className={cn('relative flex flex-col gap-y-5 px-5 pb-10', className)}>
+      <ToolsInfoBox />
+      <article className={cn('flex flex-col gap-y-5 pb-10')}>
+        <Text styleAs="p-sm" className="text-secondary-800">
+          Tools are data sources the assistant can search such as databases or the internet.
+        </Text>
+
+        {unavailableTools.length > 0 && (
+          <>
+            <Text as="span" styleAs="label" className="font-medium">
+              Action Required
+            </Text>
+
+            <div className="flex flex-col gap-y-5">
+              {unavailableTools.map(({ name, display_name, description, error_message }) => {
+                return (
+                  <ToggleCard
+                    key={name}
+                    disabled
+                    errorMessage={error_message}
+                    checked={false}
+                    label={display_name ?? name}
+                    icon={TOOL_ID_TO_DISPLAY_INFO[name]?.icon ?? TOOL_FALLBACK_ICON}
+                    description={description ?? ''}
+                    onToggle={(checked) => handleToggle(name, checked)}
+                  />
+                );
+              })}
+            </div>
+          </>
+        )}
+
+        {unavailableTools.length > 0 && availableTools.length > 0 && (
+          <hr className="border-t border-marble-400" />
+        )}
+
+        {availableTools.length > 0 && (
+          <>
+            <Text as="span" styleAs="label" className="font-medium">
+              Ready to Use
+            </Text>
+
+            <div className="flex flex-col gap-y-5">
+              {availableTools.map(({ name, display_name, description, error_message }) => {
+                const enabledTool = enabledTools.find((enabledTool) => enabledTool.name === name);
+                const checked = !!enabledTool;
+                const disabled = requiredTools.some((t) => t === name);
+
+                return (
+                  <ToggleCard
+                    key={name}
+                    disabled={disabled}
+                    errorMessage={error_message}
+                    checked={checked}
+                    label={display_name ?? name}
+                    icon={TOOL_ID_TO_DISPLAY_INFO[name]?.icon ?? TOOL_FALLBACK_ICON}
+                    description={description ?? ''}
+                    onToggle={(checked) => handleToggle(name, checked)}
+                  />
+                );
+              })}
+            </div>
+          </>
+        )}
+      </article>
+      <WelcomeGuideTooltip step={2} className="fixed right-0 mr-3 mt-12 md:right-full md:mt-0" />
+    </section>
+  );
+};

--- a/src/interfaces/coral_web/src/components/Agents/UpdateAgentPanel.tsx
+++ b/src/interfaces/coral_web/src/components/Agents/UpdateAgentPanel.tsx
@@ -6,7 +6,7 @@ import { Banner, Button, Spinner, Text } from '@/components/Shared';
 import { useAgent, useIsAgentNameUnique, useUpdateAgent } from '@/hooks/agents';
 import { useSession } from '@/hooks/session';
 import { useNotify } from '@/hooks/toast';
-import { useSettingsStore } from '@/stores';
+import { useAgentsStore } from '@/stores';
 import { cn } from '@/utils';
 
 type Props = {
@@ -15,7 +15,8 @@ type Props = {
 
 export const UpdateAgentPanel: React.FC<Props> = ({ agentId }) => {
   const { error, success } = useNotify();
-  const { setSettings } = useSettingsStore();
+
+  const { setEditAgentPanelOpen } = useAgentsStore();
   const { data: agent, isLoading } = useAgent({ agentId });
   const { mutateAsync: updateAgent } = useUpdateAgent();
   const isAgentNameUnique = useIsAgentNameUnique();
@@ -64,7 +65,7 @@ export const UpdateAgentPanel: React.FC<Props> = ({ agentId }) => {
   }, [agent]);
 
   const handleClose = () => {
-    setSettings({ isEditAgentPanelOpen: false });
+    setEditAgentPanelOpen(false);
   };
 
   const handleChange = (key: Omit<AgentFormFieldKeys, 'tools'>, value: string) => {

--- a/src/interfaces/coral_web/src/components/Conversation/Header.tsx
+++ b/src/interfaces/coral_web/src/components/Conversation/Header.tsx
@@ -10,6 +10,7 @@ import { useIsDesktop } from '@/hooks/breakpoint';
 import { WelcomeGuideStep, useWelcomeGuideState } from '@/hooks/ftux';
 import { useSession } from '@/hooks/session';
 import {
+  useAgentsStore,
   useCitationsStore,
   useConversationStore,
   useParamsStore,
@@ -30,10 +31,11 @@ const useHeaderMenu = ({
   const { data: agent } = useAgent({ agentId });
   const isAgentCreator = userId === agent?.user_id;
 
+  const { setSettings } = useSettingsStore();
   const {
-    settings: { isEditAgentPanelOpen },
-    setSettings,
-  } = useSettingsStore();
+    agents: { isEditAgentPanelOpen },
+    setEditAgentPanelOpen,
+  } = useAgentsStore();
   const { resetFileParams } = useParamsStore();
   const router = useRouter();
   const { welcomeGuideState, progressWelcomeGuideStep, finishWelcomeGuide } =
@@ -64,7 +66,7 @@ const useHeaderMenu = ({
   };
 
   const handleOpenAgentDrawer = () => {
-    setSettings({ isEditAgentPanelOpen: !isEditAgentPanelOpen });
+    setEditAgentPanelOpen(!isEditAgentPanelOpen);
   };
 
   const menuItems: KebabMenuItem[] = [
@@ -107,6 +109,7 @@ export const Header: React.FC<Props> = ({ isStreaming, agentId }) => {
     setSettings,
     setIsConvListPanelOpen,
   } = useSettingsStore();
+  const { setAgentsSidePanelOpen } = useAgentsStore();
 
   const { welcomeGuideState } = useWelcomeGuideState();
 
@@ -143,7 +146,8 @@ export const Header: React.FC<Props> = ({ isStreaming, agentId }) => {
               <IconButton
                 iconName="side-panel"
                 onClick={() => {
-                  setSettings({ isConfigDrawerOpen: false, isAgentsSidePanelOpen: false });
+                  setSettings({ isConfigDrawerOpen: false });
+                  setAgentsSidePanelOpen(false);
                   setIsConvListPanelOpen(true);
                 }}
               />

--- a/src/interfaces/coral_web/src/components/Conversation/MessagingContainer.tsx
+++ b/src/interfaces/coral_web/src/components/Conversation/MessagingContainer.tsx
@@ -10,7 +10,7 @@ import { Welcome } from '@/components/Welcome';
 import { ReservedClasses } from '@/constants';
 import { MESSAGE_LIST_CONTAINER_ID, useCalculateCitationStyles } from '@/hooks/citations';
 import { useFixCopyBug } from '@/hooks/fixCopyBug';
-import { useCitationsStore, useSettingsStore } from '@/stores';
+import { useAgentsStore, useCitationsStore } from '@/stores';
 import { ChatMessage, MessageType, StreamingMessage, isFulfilledMessage } from '@/types/message';
 import { cn } from '@/utils';
 
@@ -62,8 +62,8 @@ const Content: React.FC<Props> = (props) => {
   const { isStreaming, messages, composer, streamingMessage } = props;
   const scrollToBottom = useScrollToBottom();
   const {
-    settings: { isEditAgentPanelOpen },
-  } = useSettingsStore();
+    agents: { isEditAgentPanelOpen },
+  } = useAgentsStore();
   const {
     citations: { hasCitations },
   } = useCitationsStore();

--- a/src/interfaces/coral_web/src/components/Conversation/index.tsx
+++ b/src/interfaces/coral_web/src/components/Conversation/index.tsx
@@ -60,15 +60,16 @@ const Conversation: React.FC<Props> = ({
   const {
     params: { fileIds },
   } = useParamsStore();
-  const {
-    settings: { isEditAgentPanelOpen },
-  } = useSettingsStore();
+
   const {
     files: { composerFiles },
   } = useFilesStore();
   const { defaultFileLoaderTool, enableDefaultFileLoaderTool } = useDefaultFileLoaderTool();
 
-  const { addRecentAgentId } = useAgentsStore();
+  const {
+    agents: { isEditAgentPanelOpen },
+    addRecentAgentId,
+  } = useAgentsStore();
 
   const {
     userMessage,

--- a/src/interfaces/coral_web/src/components/Conversation/index.tsx
+++ b/src/interfaces/coral_web/src/components/Conversation/index.tsx
@@ -10,6 +10,7 @@ import { HotKeysProvider } from '@/components/Shared/HotKeys';
 import { WelcomeGuideTooltip } from '@/components/WelcomeGuideTooltip';
 import { ReservedClasses } from '@/constants';
 import { useChatHotKeys } from '@/hooks/actions';
+import { useRecentAgents } from '@/hooks/agents';
 import { useChat } from '@/hooks/chat';
 import { useDefaultFileLoaderTool, useFileActions, useFilesInConversation } from '@/hooks/files';
 import { WelcomeGuideStep, useWelcomeGuideState } from '@/hooks/ftux';
@@ -60,7 +61,7 @@ const Conversation: React.FC<Props> = ({
   const {
     params: { fileIds },
   } = useParamsStore();
-
+  const { addRecentAgentId } = useRecentAgents();
   const {
     files: { composerFiles },
   } = useFilesStore();
@@ -68,7 +69,6 @@ const Conversation: React.FC<Props> = ({
 
   const {
     agents: { isEditAgentPanelOpen },
-    addRecentAgentId,
   } = useAgentsStore();
 
   const {

--- a/src/interfaces/coral_web/src/constants.ts
+++ b/src/interfaces/coral_web/src/constants.ts
@@ -43,6 +43,7 @@ export const LOCAL_STORAGE_KEYS = {
   welcomeGuideState: 'onboarding/welcome/onboardState',
   welcomeGuideInfoBox: 'onboarding/welcome/infoBox',
   authToken: 'authToken',
+  recentAgents: 'recentAgents',
 };
 
 /**

--- a/src/interfaces/coral_web/src/stores/index.ts
+++ b/src/interfaces/coral_web/src/stores/index.ts
@@ -2,6 +2,7 @@ import { create } from 'zustand';
 import { shallow } from 'zustand/shallow';
 
 import { Tool } from '@/cohere-client';
+import { AgentsStore, createAgentsSlice } from '@/stores/slices/agentsSlice';
 import { CitationsStore, createCitationsSlice } from '@/stores/slices/citationsSlice';
 import { ConversationStore, createConversationSlice } from '@/stores/slices/conversationSlice';
 import { FilesStore, createFilesSlice } from '@/stores/slices/filesSlice';
@@ -14,13 +15,14 @@ export type ChatSettingsDefaultsValue = {
   tools?: Tool[];
 };
 
-export type StoreState = CitationsStore & ConversationStore & FilesStore & ParamStore;
+export type StoreState = CitationsStore & ConversationStore & FilesStore & ParamStore & AgentsStore;
 
 const useStore = create<StoreState>((...a) => ({
   ...createCitationsSlice(...a),
   ...createConversationSlice(...a),
   ...createFilesSlice(...a),
   ...createParamsSlice(...a),
+  ...createAgentsSlice(...a),
 }));
 
 export const useCitationsStore = () => {
@@ -33,6 +35,7 @@ export const useCitationsStore = () => {
       hoverCitation: state.hoverCitation,
       resetCitations: state.resetCitations,
       saveOutputFiles: state.saveOutputFiles,
+      agents: state.agents,
     }),
     shallow
   );
@@ -78,4 +81,15 @@ export const useParamsStore = () => {
   );
 };
 
-export { useSettingsStore, useAgentsStore } from '@/stores/persistedStore';
+export const useAgentsStore = () => {
+  return useStore(
+    (state) => ({
+      agents: state.agents,
+      setAgentsSidePanelOpen: state.setAgentsSidePanelOpen,
+      setEditAgentPanelOpen: state.setEditAgentPanelOpen,
+    }),
+    shallow
+  );
+};
+
+export { useSettingsStore } from '@/stores/persistedStore';

--- a/src/interfaces/coral_web/src/stores/persistedStore.ts
+++ b/src/interfaces/coral_web/src/stores/persistedStore.ts
@@ -3,21 +3,18 @@ import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 import { shallow } from 'zustand/shallow';
 
-import { AgentsStore, createAgentsSlice } from '@/stores/slices/agentsSlice';
 import { SettingsStore, createSettingsSlice } from '@/stores/slices/settingsSlice';
 
-type PersistedStore = SettingsStore & AgentsStore;
+type PersistedStore = SettingsStore;
 
 const useEmptyPersistedStore = create<PersistedStore>((...a) => ({
   ...createSettingsSlice(...a),
-  ...createAgentsSlice(...a),
 }));
 
 const usePersistedStore = create<PersistedStore>()(
   persist(
     (...a) => ({
       ...createSettingsSlice(...a),
-      ...createAgentsSlice(...a),
     }),
     {
       name: 'persisted-store',
@@ -51,19 +48,6 @@ export const useSettingsStore = () => {
       settings: state.settings,
       setSettings: state.setSettings,
       setIsConvListPanelOpen: state.setIsConvListPanelOpen,
-    }),
-    shallow
-  );
-};
-
-export const useAgentsStore = () => {
-  return usePersistedStoresWithHydration(
-    (state) => ({
-      agents: state.agents,
-      addRecentAgentId: state.addRecentAgentId,
-      removeRecentAgentId: state.removeRecentAgentId,
-      setAgentsSidePanelOpen: state.setAgentsSidePanelOpen,
-      setEditAgentPanelOpen: state.setEditAgentPanelOpen,
     }),
     shallow
   );

--- a/src/interfaces/coral_web/src/stores/persistedStore.ts
+++ b/src/interfaces/coral_web/src/stores/persistedStore.ts
@@ -21,7 +21,7 @@ const usePersistedStore = create<PersistedStore>()(
     }),
     {
       name: 'persisted-store',
-      version: 1,
+      version: 2,
     }
   )
 );
@@ -51,7 +51,6 @@ export const useSettingsStore = () => {
       settings: state.settings,
       setSettings: state.setSettings,
       setIsConvListPanelOpen: state.setIsConvListPanelOpen,
-      setIsAgentsSidePanelOpen: state.setIsAgentsSidePanelOpen,
     }),
     shallow
   );
@@ -63,6 +62,8 @@ export const useAgentsStore = () => {
       agents: state.agents,
       addRecentAgentId: state.addRecentAgentId,
       removeRecentAgentId: state.removeRecentAgentId,
+      setAgentsSidePanelOpen: state.setAgentsSidePanelOpen,
+      setEditAgentPanelOpen: state.setEditAgentPanelOpen,
     }),
     shallow
   );

--- a/src/interfaces/coral_web/src/stores/slices/agentsSlice.ts
+++ b/src/interfaces/coral_web/src/stores/slices/agentsSlice.ts
@@ -2,12 +2,18 @@ import { StateCreator } from 'zustand';
 
 const INITIAL_STATE = {
   recentAgentsIds: [],
+  isEditAgentPanelOpen: false,
+  isAgentsSidePanelOpen: true,
 };
 
 type State = {
   recentAgentsIds: string[];
+  isAgentsSidePanelOpen: boolean;
+  isEditAgentPanelOpen: boolean;
 };
 type Actions = {
+  setAgentsSidePanelOpen: (isOpen: boolean) => void;
+  setEditAgentPanelOpen: (isOpen: boolean) => void;
   addRecentAgentId: (agentId: string) => void;
   removeRecentAgentId: (agentId: string) => void;
 };
@@ -33,6 +39,22 @@ export const createAgentsSlice: StateCreator<AgentsStore, [], [], AgentsStore> =
       agents: {
         ...state.agents,
         recentAgentsIds: state.agents.recentAgentsIds.filter((id) => id !== agentId),
+      },
+    }));
+  },
+  setAgentsSidePanelOpen(isOpen) {
+    set((state) => ({
+      agents: {
+        ...state.agents,
+        isAgentsSidePanelOpen: isOpen,
+      },
+    }));
+  },
+  setEditAgentPanelOpen(isOpen) {
+    set((state) => ({
+      agents: {
+        ...state.agents,
+        isEditAgentPanelOpen: isOpen,
       },
     }));
   },

--- a/src/interfaces/coral_web/src/stores/slices/agentsSlice.ts
+++ b/src/interfaces/coral_web/src/stores/slices/agentsSlice.ts
@@ -1,47 +1,26 @@
 import { StateCreator } from 'zustand';
 
+import { StoreState } from '@/stores';
+
 const INITIAL_STATE = {
-  recentAgentsIds: [],
   isEditAgentPanelOpen: false,
   isAgentsSidePanelOpen: true,
 };
 
 type State = {
-  recentAgentsIds: string[];
   isAgentsSidePanelOpen: boolean;
   isEditAgentPanelOpen: boolean;
 };
 type Actions = {
   setAgentsSidePanelOpen: (isOpen: boolean) => void;
   setEditAgentPanelOpen: (isOpen: boolean) => void;
-  addRecentAgentId: (agentId: string) => void;
-  removeRecentAgentId: (agentId: string) => void;
 };
 
 export type AgentsStore = {
   agents: State;
 } & Actions;
 
-export const createAgentsSlice: StateCreator<AgentsStore, [], [], AgentsStore> = (set) => ({
-  addRecentAgentId(agentId) {
-    set((state) => ({
-      agents: {
-        ...state.agents,
-        recentAgentsIds: [
-          ...state.agents.recentAgentsIds,
-          ...(state.agents.recentAgentsIds.includes(agentId) ? [] : [agentId]),
-        ],
-      },
-    }));
-  },
-  removeRecentAgentId(agentId) {
-    set((state) => ({
-      agents: {
-        ...state.agents,
-        recentAgentsIds: state.agents.recentAgentsIds.filter((id) => id !== agentId),
-      },
-    }));
-  },
+export const createAgentsSlice: StateCreator<StoreState, [], [], AgentsStore> = (set) => ({
   setAgentsSidePanelOpen(isOpen) {
     set((state) => ({
       agents: {

--- a/src/interfaces/coral_web/src/stores/slices/settingsSlice.ts
+++ b/src/interfaces/coral_web/src/stores/slices/settingsSlice.ts
@@ -1,27 +1,22 @@
 import { StateCreator } from 'zustand';
 
 const INITIAL_STATE: Required<State> = {
-  isAgentsSidePanelOpen: true,
   isConfigDrawerOpen: false,
   activeConfigDrawerTab: '',
   isConvListPanelOpen: true,
   isMobileConvListPanelOpen: false,
-  isEditAgentPanelOpen: false,
 };
 
 type State = {
-  isAgentsSidePanelOpen: boolean;
   isConfigDrawerOpen: boolean;
   activeConfigDrawerTab: string;
   isConvListPanelOpen: boolean;
   isMobileConvListPanelOpen: boolean;
-  isEditAgentPanelOpen: boolean;
 };
 
 type Actions = {
   setSettings: (settings: Partial<State>) => void;
   setIsConvListPanelOpen: (isOpen: boolean) => void;
-  setIsAgentsSidePanelOpen: (isOpen: boolean) => void;
 };
 
 export type SettingsStore = {
@@ -34,14 +29,6 @@ export const createSettingsSlice: StateCreator<SettingsStore, [], [], SettingsSt
       settings: {
         ...state.settings,
         ...settings,
-      },
-    }));
-  },
-  setIsAgentsSidePanelOpen(isOpen) {
-    set((state) => ({
-      settings: {
-        ...state.settings,
-        isAgentsSidePanelOpen: isOpen,
       },
     }));
   },


### PR DESCRIPTION


**AI Description**

<!-- begin-generated-description -->

This PR makes changes to the Agents component, including:

- Renaming `isAgentsSidePanelOpen` to `isAgentsSidePanel` in `AgentsList.tsx` and `AgentsSidePanel.tsx`.
- Replacing `useSettingsStore` with `useAgentsStore` in `AgentsList.tsx`, `AgentsSidePanel.tsx`, `MobileHeader.tsx`, and `Settings/SettingsDrawer.tsx`.
- Adding `useRecentAgents` from '@/hooks/agents'` in `AgentCard.tsx`, `CreateAgentForm.tsx`, and `DiscoverAgentCard.tsx`.
- Replacing `useAgentsStore` with `useRecentAgents` in `AgentCard.tsx`.
- Replacing `useAgentsStore` with `useSettingsStore` in `UpdateAgentPanel.tsx`.
- Adding `useAgentsStore` in `Conversation/index.tsx` and `Conversation/MessagingContainer.tsx`.
- Replacing `useSettingsStore` with `useAgentsStore` in `Conversation/Header.tsx`.
- Adding `useLocalStorageValue` from '@react-hookz/web'` in `hooks/agents.ts`.
- Adding `LOCAL_STORAGE_KEYS` from '@/constants'` in `hooks/agents.ts`.
- Replacing `useAgentsStore` with `useLocalStorageValue` and `LOCAL_STORAGE_KEYS` in `hooks/agents.ts`.
- Adding `useAgentsStore` in `stores/index.ts`.
- Removing `useAgentsStore` from `stores/persistedStore.ts`.
- Adding `isEditAgentPanelOpen` and `isAgentsSidePanelOpen` to the `INITIAL_STATE` in `stores/slices/agentsSlice.ts`.
- Replacing `isEditAgentPanelOpen` with `setEditAgentPanelOpen` in `stores/slices/settingsSlice.ts`.
- Removing `isAgentsSidePanelOpen` from `State` and `Actions` in `stores/slices/settingsSlice.ts`.
- Removing `setIsAgentsSidePanelOpen` from `Actions` in `stores/slices/settingsSlice.ts`.
- Adding `useAgentsStore` in `stores/slices/settingsSlice.ts`.

<!-- end-generated-description -->
