### PR TITLE
coral-web: reset conversation on route change

### DIFF
--- a/src/interfaces/coral_web/src/components/Agents/Settings/SettingsDrawer.tsx
+++ b/src/interfaces/coral_web/src/components/Agents/Settings/SettingsDrawer.tsx
@@ -83,7 +83,11 @@ export const SettingsDrawer: React.FC = () => {
           panelsClassName="pt-7 lg:pt-7 px-0 flex flex-col rounded-b-lg bg-marble-100 md:rounded-b-none"
           fitTabsContent={true}
         >
-          {tabs.map((t) => t.component)}
+          {tabs.map((t) => (
+            <div key={t.name} className="h-full w-full">
+              {t.component}
+            </div>
+          ))}
         </Tabs>
       </section>
     </Transition>

--- a/src/interfaces/coral_web/src/components/Conversation/index.tsx
+++ b/src/interfaces/coral_web/src/components/Conversation/index.tsx
@@ -52,6 +52,7 @@ const Conversation: React.FC<Props> = ({
   } = useSettingsStore();
   const {
     conversation: { messages },
+    resetConversation,
   } = useConversationStore();
   const {
     citations: { selectedCitation },
@@ -125,7 +126,11 @@ const Conversation: React.FC<Props> = ({
     };
   }, [handleClickOutside]);
 
-  const [isRouteChanging] = useRouteChange();
+  const [isRouteChanging] = useRouteChange({
+    onRouteChangeStart: () => {
+      resetConversation();
+    },
+  });
 
   if (isRouteChanging) {
     return (

--- a/src/interfaces/coral_web/src/components/Settings/SettingsDrawer.tsx
+++ b/src/interfaces/coral_web/src/components/Settings/SettingsDrawer.tsx
@@ -88,7 +88,11 @@ export const SettingsDrawer: React.FC = () => {
           panelsClassName="pt-7 lg:pt-7 px-0 flex flex-col rounded-b-lg bg-marble-100 md:rounded-b-none"
           fitTabsContent={true}
         >
-          {tabs.map((t) => t.component)}
+          {tabs.map((t) => (
+            <div key={t.name} className="h-full w-full">
+              {t.component}
+            </div>
+          ))}
         </Tabs>
       </section>
     </Transition>

--- a/src/interfaces/coral_web/src/hooks/chat.ts
+++ b/src/interfaces/coral_web/src/hooks/chat.ts
@@ -1,5 +1,4 @@
 import { UseMutateAsyncFunction, useQueryClient } from '@tanstack/react-query';
-import { useRouter } from 'next/router';
 import { useState } from 'react';
 
 import {
@@ -70,7 +69,6 @@ export type HandleSendChat = (
 ) => Promise<void>;
 
 export const useChat = (config?: { onSend?: (msg: string) => void }) => {
-  const router = useRouter();
   const { chatMutation, abortController } = useStreamChat();
   const { mutateAsync: streamChat } = chatMutation;
 


### PR DESCRIPTION

**AI Description**

<!-- begin-generated-description -->

This pull request makes changes to the `SettingsDrawer` and `Conversation` components in the `coral_web` interface, and also updates the `chat.ts` file. 

## Summary
- The `SettingsDrawer` component in `SettingsDrawer.tsx` has been modified to include a `key` prop for each tab's `div` element, ensuring a unique identifier for efficient React rendering and reconciliation.
- The `Conversation` component in `index.tsx` now includes the `resetConversation` property from the `useConversationStore` hook. It also updates the `useRouteChange` hook to invoke `resetConversation` when the route changes.
- The `chat.ts` file has removed the `useRouter` import from 'next/router' and the associated usage of `useRouter` in the `useChat` function.

## Details

### `SettingsDrawer.tsx` and `SettingsDrawer.tsx`
- The `tabs.map` function now returns a `div` element with a unique `key` prop set to `t.name`. This ensures that each tab's content is wrapped in a distinct HTML element with a unique identifier, facilitating efficient rendering and updates in React.

### `index.tsx`
- The `resetConversation` property is now destructured from the `useConversationStore` hook.
- The `useRouteChange` hook now takes an options object as an argument, with an `onRouteChangeStart` property that resets the conversation when the route changes.

### `chat.ts`
- The `useRouter` import from 'next/router' has been removed, along with the usage of `useRouter` in the `useChat` function.

<!-- end-generated-description -->
