### PR TITLE
metrics: configure secrets

### DIFF
--- a/src/backend/schemas/metrics.py
+++ b/src/backend/schemas/metrics.py
@@ -12,7 +12,7 @@ class MetricsDataBase(BaseModel):
     endpoint_name: str
     success: bool
     timestamp: float = time.time()
-    secret: str
+    secret: str = ""
 
 
 class MetricsData(MetricsDataBase):

--- a/src/backend/schemas/metrics.py
+++ b/src/backend/schemas/metrics.py
@@ -12,7 +12,7 @@ class MetricsDataBase(BaseModel):
     endpoint_name: str
     success: bool
     timestamp: float = time.time()
-    secret: str = "secret"
+    secret: str
 
 
 class MetricsData(MetricsDataBase):


### PR DESCRIPTION
Thank you for contributing to the Cohere Toolkit!

- [ ] **PR title**: "area: description"
  - Where "area" is whichever of interface, frontend, model, tools, backend, etc. is being modified. Use "docs: ..." for purely docs changes, "infra: ..." for CI changes.
  - Example: "deployment: add Azure model option"


- [ ] **PR message**: ***Delete this entire checklist*** and replace with
    - **Description:** a description of the change
    - **Issue:** the issue # it fixes, if applicable
    - **Dependencies:** any dependencies required for this change


- [ ] **Add tests and docs**: Please include testing and documentation for your changes
- [ ] **Lint and test**: Run `make lint` and `make run-tests`

**AI Description**

<!-- begin-generated-description -->

This pull request updates the `MetricsDataBase` class in the module to include a new field, `secret`, which is assigned the value `"secret"`. This change is reflected in both the `src/backend/schemas/metrics.py` and `src/backend/services/metrics.py` files.

Additionally, the following modifications are made:

- The `REPORT_SECRET` environment variable is introduced in `src/backend/services/metrics.py`, retrieving its value via `os.getenv`.
- In the `report_metrics` function, a check for `REPORT_SECRET` is added before verifying the `signal` type. If `REPORT_SECRET` is not set, an error message is logged, and the function returns early.
- The hardcoded value assignment to `data.secret` is replaced with the use of the `REPORT_SECRET` environment variable in the `wrap_and_log_data` function.

<!-- end-generated-description -->
