### PR TITLE
coral-web: load tools from agent api

### DIFF
--- a/src/interfaces/coral_web/src/cohere-client/client.ts
+++ b/src/interfaces/coral_web/src/cohere-client/client.ts
@@ -12,6 +12,7 @@ import {
   FinishReason,
   ListAuthStrategy,
   ListFile,
+  ManagedTool,
   Tool,
   UpdateAgent,
   UpdateConversation,
@@ -356,7 +357,7 @@ export class CohereClient {
     return body as Conversation;
   }
 
-  public async listTools({ signal }: { signal?: AbortSignal }): Promise<Tool[]> {
+  public async listTools({ signal }: { signal?: AbortSignal }): Promise<ManagedTool[]> {
     const response = await this.fetch(`${this.getEndpoint('tools')}`, {
       method: 'GET',
       headers: this.getHeaders(),
@@ -376,7 +377,7 @@ export class CohereClient {
       );
     }
 
-    return body as Tool[];
+    return body as ManagedTool[];
   }
 
   public async listDeployments(): Promise<Deployment[]> {

--- a/src/interfaces/coral_web/src/components/Agents/Settings/SettingsDrawer.tsx
+++ b/src/interfaces/coral_web/src/components/Agents/Settings/SettingsDrawer.tsx
@@ -6,12 +6,11 @@ import { ToolsTab } from '@/components/Agents/Settings/ToolsTab';
 import { IconButton } from '@/components/IconButton';
 import { Icon, Tabs, Text } from '@/components/Shared';
 import { SETTINGS_DRAWER_ID } from '@/constants';
+import { useAgent } from '@/hooks/agents';
 import { useFilesInConversation } from '@/hooks/files';
+import { useSlugRoutes } from '@/hooks/slugRoutes';
 import { useCitationsStore, useConversationStore, useSettingsStore } from '@/stores';
 import { cn } from '@/utils';
-
-// TODO(@wujessica): grab these from the agents api
-const REQUIRED_TOOLS: string[] = [];
 
 /**
  * @description Renders the settings drawer of the main content.
@@ -30,15 +29,17 @@ export const SettingsDrawer: React.FC = () => {
     citations: { hasCitations },
   } = useCitationsStore();
   const { files } = useFilesInConversation();
+  const { agentId } = useSlugRoutes();
+  const { data: agent } = useAgent({ agentId });
 
   const tabs = useMemo(() => {
     return files.length > 0 && conversationId
       ? [
-          { name: 'Tools', component: <ToolsTab requiredTools={REQUIRED_TOOLS} /> },
+          { name: 'Tools', component: <ToolsTab requiredTools={agent?.tools} /> },
           { name: 'Files', component: <FilesTab /> },
         ]
-      : [{ name: 'Tools', component: <ToolsTab requiredTools={REQUIRED_TOOLS} /> }];
-  }, [files.length, conversationId]);
+      : [{ name: 'Tools', component: <ToolsTab requiredTools={agent?.tools} /> }];
+  }, [files.length, conversationId, agent?.tools]);
 
   return (
     <Transition

--- a/src/interfaces/coral_web/src/components/Agents/Settings/ToolsTab.tsx
+++ b/src/interfaces/coral_web/src/components/Agents/Settings/ToolsTab.tsx
@@ -15,7 +15,7 @@ import { cn } from '@/utils';
 /**
  * @description Tools tab content that shows a list of available tools and files
  */
-export const ToolsTab: React.FC<{ requiredTools: string[]; className?: string }> = ({
+export const ToolsTab: React.FC<{ requiredTools: string[] | undefined; className?: string }> = ({
   requiredTools,
   className = '',
 }) => {
@@ -28,8 +28,13 @@ export const ToolsTab: React.FC<{ requiredTools: string[]; className?: string }>
 
   const { unauthedTools } = useUnauthedTools();
   const availableTools = useMemo(() => {
-    return (data ?? []).filter((t) => t.is_visible && t.is_available);
-  }, [data]);
+    return (data ?? []).filter(
+      (t) =>
+        t.is_visible &&
+        t.is_available &&
+        (!requiredTools || requiredTools.some((rt) => rt === t.name))
+    );
+  }, [data, requiredTools]);
 
   const handleToggle = (name: string, checked: boolean) => {
     const newParams: Partial<ConfigurableParams> = {
@@ -80,7 +85,7 @@ export const ToolsTab: React.FC<{ requiredTools: string[]; className?: string }>
               {availableTools.map(({ name, display_name, description, error_message }) => {
                 const enabledTool = enabledTools.find((enabledTool) => enabledTool.name === name);
                 const checked = !!enabledTool;
-                const disabled = requiredTools.some((t) => t === name);
+                const disabled = !!requiredTools;
 
                 return (
                   <ToggleCard

--- a/src/interfaces/coral_web/src/components/Citations/CitationDocumentHeader.tsx
+++ b/src/interfaces/coral_web/src/components/Citations/CitationDocumentHeader.tsx
@@ -48,7 +48,7 @@ export const CitationDocumentHeader: React.FC<Props> = ({
   const isTool = !!toolId && !hasUrl && !!TOOL_ID_TO_DISPLAY_INFO[toolId];
   const toolDisplayInfo = toolId ? TOOL_ID_TO_DISPLAY_INFO[toolId] : undefined;
   // The title field is provided for web search documents and files, but not for tools.
-  const displayTitle = (title || toolDisplayInfo?.name) ?? toolId;
+  const displayTitle = title ?? toolId;
   const icon: IconName | undefined = hasUrl
     ? undefined
     : isFile

--- a/src/interfaces/coral_web/src/components/Conversation/Composer/ComposerToolbar.tsx
+++ b/src/interfaces/coral_web/src/components/Conversation/Composer/ComposerToolbar.tsx
@@ -7,10 +7,11 @@ import { ACCEPTED_FILE_TYPES } from '@/constants';
 import { cn } from '@/utils';
 
 type Props = {
+  canDisableDataSources: boolean;
   onUploadFile: (e: React.ChangeEvent<HTMLInputElement>) => void;
 };
 
-export const ComposerToolbar: React.FC<Props> = ({ onUploadFile }) => {
+export const ComposerToolbar: React.FC<Props> = ({ canDisableDataSources, onUploadFile }) => {
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   const handleOpenFileExplorer = () => {
@@ -32,7 +33,7 @@ export const ComposerToolbar: React.FC<Props> = ({ onUploadFile }) => {
         icon="clip"
         onClick={handleOpenFileExplorer}
       />
-      <EnabledDataSources isStreaming={false} />
+      <EnabledDataSources isStreaming={false} canDisable={canDisableDataSources} />
     </div>
   );
 };

--- a/src/interfaces/coral_web/src/components/Conversation/Composer/EnabledDataSources.tsx
+++ b/src/interfaces/coral_web/src/components/Conversation/Composer/EnabledDataSources.tsx
@@ -8,12 +8,13 @@ import { ConfigurableParams } from '@/stores/slices/paramsSlice';
 
 type Props = {
   isStreaming: boolean;
+  canDisable: boolean;
 };
 
 /**
  * @description Renders the enabled data sources in the composer toolbar.
  */
-export const EnabledDataSources: React.FC<Props> = ({ isStreaming }) => {
+export const EnabledDataSources: React.FC<Props> = ({ isStreaming, canDisable }) => {
   const {
     conversation: { id },
   } = useConversationStore();
@@ -61,6 +62,7 @@ export const EnabledDataSources: React.FC<Props> = ({ isStreaming }) => {
           label={d?.file_name ?? ''}
           onDelete={handleDeleteFile(d?.id ?? '')}
           disabled={isStreaming}
+          canDisable={canDisable}
         />
       ))}
       {enabledTools?.map((t, i) => (
@@ -69,6 +71,7 @@ export const EnabledDataSources: React.FC<Props> = ({ isStreaming }) => {
           iconName={TOOL_ID_TO_DISPLAY_INFO[t.name]?.icon ?? TOOL_FALLBACK_ICON}
           label={t.display_name ?? t.name}
           onDelete={handleDeleteTool(t.name ?? '')}
+          canDisable={canDisable}
         />
       ))}
     </div>
@@ -76,13 +79,22 @@ export const EnabledDataSources: React.FC<Props> = ({ isStreaming }) => {
 };
 
 const DataSourceChip: React.FC<{
+  canDisable: boolean;
   iconName: IconName;
   label: string;
   onDelete: React.MouseEventHandler;
   disabled?: boolean;
   hasEditableConfiguration?: boolean;
   onEditConfiguration?: VoidFunction;
-}> = ({ iconName, label, onDelete, disabled, hasEditableConfiguration, onEditConfiguration }) => {
+}> = ({
+  canDisable,
+  iconName,
+  label,
+  onDelete,
+  disabled,
+  hasEditableConfiguration,
+  onEditConfiguration,
+}) => {
   return (
     <div className="flex items-center justify-between gap-x-2 rounded border border-dashed border-secondary-200 bg-secondary-50 px-2 py-0.5">
       <div className="flex items-center gap-x-1">
@@ -94,9 +106,11 @@ const DataSourceChip: React.FC<{
           <Icon name="kebab" size="sm" />
         </button>
       )}
-      <button className="flex" onClick={onDelete} disabled={disabled}>
-        <Icon name="close" size="sm" />
-      </button>
+      {canDisable && (
+        <button className="flex" onClick={onDelete} disabled={disabled}>
+          <Icon name="close" size="sm" />
+        </button>
+      )}
     </div>
   );
 };

--- a/src/interfaces/coral_web/src/components/Conversation/Composer/index.tsx
+++ b/src/interfaces/coral_web/src/components/Conversation/Composer/index.tsx
@@ -18,6 +18,7 @@ import { cn } from '@/utils';
 type Props = {
   isFirstTurn: boolean;
   isStreaming: boolean;
+  canDisableDataSources: boolean;
   value: string;
   streamingMessage: ChatMessage | null;
   onStop: VoidFunction;
@@ -31,6 +32,7 @@ export const Composer: React.FC<Props> = ({
   isFirstTurn,
   value,
   isStreaming,
+  canDisableDataSources,
   onSend,
   onChange,
   onStop,
@@ -195,7 +197,10 @@ export const Composer: React.FC<Props> = ({
           </button>
         </div>
         <ComposerFiles />
-        <ComposerToolbar onUploadFile={onUploadFile} />
+        <ComposerToolbar
+          canDisableDataSources={canDisableDataSources}
+          onUploadFile={onUploadFile}
+        />
       </div>
       <ComposerError className="pt-2" />
     </div>

--- a/src/interfaces/coral_web/src/components/Conversation/index.tsx
+++ b/src/interfaces/coral_web/src/components/Conversation/index.tsx
@@ -10,16 +10,15 @@ import { HotKeysProvider } from '@/components/Shared/HotKeys';
 import { WelcomeGuideTooltip } from '@/components/WelcomeGuideTooltip';
 import { ReservedClasses } from '@/constants';
 import { useChatHotKeys } from '@/hooks/actions';
-import { useRecentAgents } from '@/hooks/agents';
+import { useAgent, useRecentAgents } from '@/hooks/agents';
 import { useChat } from '@/hooks/chat';
-import { useDefaultFileLoaderTool, useFileActions, useFilesInConversation } from '@/hooks/files';
+import { useDefaultFileLoaderTool, useFileActions } from '@/hooks/files';
 import { WelcomeGuideStep, useWelcomeGuideState } from '@/hooks/ftux';
 import { useRouteChange } from '@/hooks/route';
 import {
   useAgentsStore,
   useCitationsStore,
   useConversationStore,
-  useFilesStore,
   useParamsStore,
   useSettingsStore,
 } from '@/stores';
@@ -58,19 +57,14 @@ const Conversation: React.FC<Props> = ({
     citations: { selectedCitation },
     selectCitation,
   } = useCitationsStore();
-  const { files } = useFilesInConversation();
   const {
     params: { fileIds },
   } = useParamsStore();
-  const { addRecentAgentId } = useRecentAgents();
-  const {
-    files: { composerFiles },
-  } = useFilesStore();
-  const { defaultFileLoaderTool, enableDefaultFileLoaderTool } = useDefaultFileLoaderTool();
-
   const {
     agents: { isEditAgentPanelOpen },
   } = useAgentsStore();
+  const { addRecentAgentId } = useRecentAgents();
+  const { defaultFileLoaderTool, enableDefaultFileLoaderTool } = useDefaultFileLoaderTool();
 
   const {
     userMessage,
@@ -176,6 +170,7 @@ const Conversation: React.FC<Props> = ({
                 <WelcomeGuideTooltip step={3} className="absolute bottom-full mb-4" />
                 <Composer
                   isStreaming={isStreaming}
+                  canDisableDataSources={!agentId}
                   value={userMessage}
                   isFirstTurn={messages.length === 0}
                   streamingMessage={streamingMessage}

--- a/src/interfaces/coral_web/src/components/Settings/SettingsDrawer.tsx
+++ b/src/interfaces/coral_web/src/components/Settings/SettingsDrawer.tsx
@@ -11,9 +11,6 @@ import { useFilesInConversation } from '@/hooks/files';
 import { useCitationsStore, useConversationStore, useSettingsStore } from '@/stores';
 import { cn } from '@/utils';
 
-// TODO(@wujessica): grab these from the agents api
-const REQUIRED_TOOLS: string[] = [];
-
 /**
  * @description Renders the settings drawer of the main content.
  * It opens up on top of the citation panel/the main content.
@@ -35,12 +32,12 @@ export const SettingsDrawer: React.FC = () => {
   const tabs = useMemo(() => {
     return files.length > 0 && conversationId
       ? [
-          { name: 'Tools', component: <ToolsTab requiredTools={REQUIRED_TOOLS} /> },
+          { name: 'Tools', component: <ToolsTab /> },
           { name: 'Files', component: <FilesTab /> },
           { name: 'Settings', component: <SettingsTab /> },
         ]
       : [
-          { name: 'Tools', component: <ToolsTab requiredTools={REQUIRED_TOOLS} /> },
+          { name: 'Tools', component: <ToolsTab /> },
           { name: 'Settings', component: <SettingsTab /> },
         ];
   }, [files.length, conversationId]);

--- a/src/interfaces/coral_web/src/components/Settings/ToolsTab.tsx
+++ b/src/interfaces/coral_web/src/components/Settings/ToolsTab.tsx
@@ -15,10 +15,7 @@ import { cn } from '@/utils';
 /**
  * @description Tools tab content that shows a list of available tools and files
  */
-export const ToolsTab: React.FC<{ requiredTools: string[]; className?: string }> = ({
-  requiredTools,
-  className = '',
-}) => {
+export const ToolsTab: React.FC<{ className?: string }> = ({ className = '' }) => {
   const { params, setParams } = useParamsStore();
   const { data } = useListTools();
   const { tools: paramTools } = params;
@@ -113,12 +110,10 @@ export const ToolsTab: React.FC<{ requiredTools: string[]; className?: string }>
               {availableTools.map(({ name, display_name, description, error_message }) => {
                 const enabledTool = enabledTools.find((enabledTool) => enabledTool.name === name);
                 const checked = !!enabledTool;
-                const disabled = requiredTools.some((t) => t === name);
 
                 return (
                   <ToggleCard
                     key={name}
-                    disabled={disabled}
                     errorMessage={error_message}
                     checked={checked}
                     label={display_name ?? name}

--- a/src/interfaces/coral_web/src/components/Shared/Markdown/Markdown.tsx
+++ b/src/interfaces/coral_web/src/components/Shared/Markdown/Markdown.tsx
@@ -93,9 +93,11 @@ export const Markdown = ({
   // @ts-ignore
   const components: Components = useMemo(
     () => ({
+      // @ts-ignore
       pre: (props) => <Pre {...props} />,
       p: P,
       references: References,
+      // @ts-ignore
       iframe: Iframe,
       ...customComponents,
     }),

--- a/src/interfaces/coral_web/src/components/ToggleCard.tsx
+++ b/src/interfaces/coral_web/src/components/ToggleCard.tsx
@@ -4,11 +4,11 @@ import { Icon, IconName, Input, Switch, Text } from '@/components/Shared';
 
 type Props = {
   checked: boolean;
-  disabled: boolean;
   icon: IconName;
   label: string;
   description: string;
   onToggle: (checked: boolean) => void;
+  disabled?: boolean;
   errorMessage?: string | null;
   inputOptions?: {
     label: string;
@@ -26,7 +26,7 @@ type Props = {
  */
 export const ToggleCard: React.FC<Props> = ({
   checked,
-  disabled,
+  disabled = false,
   icon,
   label,
   description,

--- a/src/interfaces/coral_web/src/hooks/chat.ts
+++ b/src/interfaces/coral_web/src/hooks/chat.ts
@@ -469,14 +469,12 @@ export const useChat = (config?: { onSend?: (msg: string) => void }) => {
 
   const getChatRequest = (message: string, overrides?: ChatRequestOverrides): CohereChatRequest => {
     const { tools: overrideTools, ...restOverrides } = overrides ?? {};
+
+    const requestTools = overrideTools ?? tools ?? undefined;
     return {
       message,
       conversation_id: id,
-      tools: !!overrideTools?.length
-        ? overrideTools
-        : tools && tools.length > 0
-        ? tools
-        : undefined,
+      tools: requestTools?.map((tool) => ({ name: tool.name })),
       file_ids: fileIds && fileIds.length > 0 ? fileIds : undefined,
       temperature,
       model,


### PR DESCRIPTION
**Description:**
Use `tools` given by the `/agent` api to show tools specific to that agent. Also removes the ability to deselect tools from the composer if we are using the non-base agent.

https://github.com/cohere-ai/cohere-toolkit/assets/5898755/d3ceec49-6135-4fe1-bfe7-093deb506f20

**AI Description**

<!-- begin-generated-description -->

This PR introduces changes to the settings drawer and tools tab in the user interface. It also updates the `CohereClient` class to use the new `ManagedTool` type.

- The `SettingsDrawer` component now uses the `useAgent` hook to fetch the agent data and dynamically render the tools tab based on the available tools.
- The `ToolsTab` component now accepts an optional `requiredTools` prop, allowing for more flexible rendering of available and unavailable tools.
- The `ComposerToolbar` and `EnabledDataSources` components have been updated to include a `canDisableDataSources` prop, providing more control over data source disabling.
- The `ToggleCard` component now has an optional `disabled` prop, with a default value of `false`.
- The `useChat` hook has been modified to handle `requestTools` and correctly format the tools for the chat request.
- The `ManagedTool` type has been added to the `CohereClient` class, and the `listTools` method now returns a promise of `ManagedTool[]` instead of `Tool[]`].
- The `Composer` component now includes a `canDisableDataSources` prop, allowing for dynamic disabling of data sources.
- The `AgentsPage` component now uses the `useListTools` hook to fetch the available tools and sets the agent tools as parameters.

<!-- end-generated-description -->
