### PR TITLE
coral-web: remove tab header in config drawer when only 1 tab is available

### DIFF
--- a/src/interfaces/coral_web/src/components/Agents/Settings/SettingsDrawer.tsx
+++ b/src/interfaces/coral_web/src/components/Agents/Settings/SettingsDrawer.tsx
@@ -74,21 +74,25 @@ export const SettingsDrawer: React.FC = () => {
       </header>
 
       <section id={SETTINGS_DRAWER_ID} className="h-full w-full overflow-y-auto rounded-b-lg">
-        <Tabs
-          tabs={tabs.map((t) => t.name)}
-          selectedIndex={selectedTabIndex}
-          onChange={setSelectedTabIndex}
-          tabGroupClassName="h-full"
-          tabClassName="pt-2.5"
-          panelsClassName="pt-7 lg:pt-7 px-0 flex flex-col rounded-b-lg bg-marble-100 md:rounded-b-none"
-          fitTabsContent={true}
-        >
-          {tabs.map((t) => (
-            <div key={t.name} className="h-full w-full">
-              {t.component}
-            </div>
-          ))}
-        </Tabs>
+        {tabs.length === 1 ? (
+          <div className="pt-5">{tabs[0].component}</div>
+        ) : (
+          <Tabs
+            tabs={tabs.map((t) => t.name)}
+            selectedIndex={selectedTabIndex}
+            onChange={setSelectedTabIndex}
+            tabGroupClassName="h-full"
+            tabClassName="pt-2.5"
+            panelsClassName="pt-7 lg:pt-7 px-0 flex flex-col rounded-b-lg bg-marble-100 md:rounded-b-none"
+            fitTabsContent={true}
+          >
+            {tabs.map((t) => (
+              <div key={t.name} className="h-full w-full">
+                {t.component}
+              </div>
+            ))}
+          </Tabs>
+        )}
       </section>
     </Transition>
   );


### PR DESCRIPTION
## Before
![Screenshot 2024-06-25 at 14 14 42](https://github.com/cohere-ai/cohere-toolkit/assets/140425731/6f416042-c659-44a6-aa07-7d7bf624d602)


## After
![Screenshot 2024-06-25 at 14 14 29](https://github.com/cohere-ai/cohere-toolkit/assets/140425731/a850fb07-4547-453f-8d08-c5ee6961b2b1)


**AI Description**

<!-- begin-generated-description -->

This pull request makes changes to the rendering of tabs in the `SettingsDrawer` component. 

## Summary
The `SettingsDrawer` component now conditionally renders its content based on the length of the `tabs` array. If there is only one tab, it is rendered directly within a `div`, without the wrapping `Tabs` component. When there are multiple tabs, the existing behavior of rendering each tab within the `Tabs` component remains unchanged.

## Changes
- The code now checks the length of the `tabs` array before rendering its content.
- If there is only one tab, it is rendered within a `div` with the class name "pt-5".
- For multiple tabs, the existing rendering logic within the `Tabs` component is retained.

<!-- end-generated-description -->
