### PR TITLE
coral-web: move update agent info banner above form on mobile

### DIFF
--- a/src/interfaces/coral_web/src/components/Agents/UpdateAgentPanel.tsx
+++ b/src/interfaces/coral_web/src/components/Agents/UpdateAgentPanel.tsx
@@ -126,6 +126,7 @@ export const UpdateAgentPanel: React.FC<Props> = ({ agentId }) => {
         <IconButton iconName="close" onClick={handleClose} />
       </header>
       <div className="flex flex-col gap-y-5 overflow-y-auto px-14 py-8">
+        {isAgentCreator && <InfoBanner agentName={agent.name} className="flex md:hidden" />}
         <AgentForm
           fields={fields}
           errors={fieldErrors}
@@ -135,10 +136,8 @@ export const UpdateAgentPanel: React.FC<Props> = ({ agentId }) => {
         />
       </div>
       {isAgentCreator && (
-        <div className="flex flex-col gap-y-12 px-14 py-8">
-          <Banner className="w-full" theme="secondary" size="sm">
-            Updating {agent.name} will affect everyone using the assistant
-          </Banner>
+        <div className="flex flex-col gap-y-12 px-14 py-4 md:pb-8 md:pt-0">
+          <InfoBanner agentName={agent.name} className="hidden md:flex" />
           <Button
             className="self-end"
             splitIcon="check-mark"
@@ -151,3 +150,12 @@ export const UpdateAgentPanel: React.FC<Props> = ({ agentId }) => {
     </div>
   );
 };
+
+const InfoBanner: React.FC<{ agentName: string; className?: string }> = ({
+  agentName,
+  className,
+}) => (
+  <Banner theme="secondary" size="sm" className={cn('w-full', className)}>
+    Updating {agentName} will affect everyone using the assistant
+  </Banner>
+);

--- a/src/interfaces/coral_web/src/components/Agents/UpdateAgentPanel.tsx
+++ b/src/interfaces/coral_web/src/components/Agents/UpdateAgentPanel.tsx
@@ -125,7 +125,7 @@ export const UpdateAgentPanel: React.FC<Props> = ({ agentId }) => {
         <Text>{isAgentCreator ? `Update ${agent.name}` : `About ${agent.name}`}</Text>
         <IconButton iconName="close" onClick={handleClose} />
       </header>
-      <div className="flex flex-col gap-y-5 overflow-y-auto px-14 py-8">
+      <div className="flex flex-col gap-y-5 overflow-y-auto px-8 py-8 md:px-14">
         {isAgentCreator && <InfoBanner agentName={agent.name} className="flex md:hidden" />}
         <AgentForm
           fields={fields}
@@ -136,7 +136,7 @@ export const UpdateAgentPanel: React.FC<Props> = ({ agentId }) => {
         />
       </div>
       {isAgentCreator && (
-        <div className="flex flex-col gap-y-12 px-14 py-4 md:pb-8 md:pt-0">
+        <div className="flex flex-col gap-y-12 px-8 py-4 md:px-14 md:pb-8 md:pt-0">
           <InfoBanner agentName={agent.name} className="hidden md:flex" />
           <Button
             className="self-end"


### PR DESCRIPTION
Save some vertical space on mobile and still ensure the user sees the info banner when the update panel is opened
 
## Before

https://github.com/cohere-ai/cohere-toolkit/assets/140425731/6cee9e13-a381-4528-846d-d6fcae828b25


## After

https://github.com/cohere-ai/cohere-toolkit/assets/140425731/3daebacf-908d-431e-acf5-5bf7d377cdee



**AI Description**

<!-- begin-generated-description -->

This pull request makes changes to the `UpdateAgentPanel` component in the `src/interfaces/coral_web/src/components/Agents/UpdateAgentPanel.tsx` file. 

## Summary
The `UpdateAgentPanel` component now includes an `InfoBanner` displaying a message that updating the agent will impact all assistant users. This message was previously displayed using a `Banner` component. 

## Changes
- Adds an `InfoBanner` component to display the message about the impact of agent updates.
- Updates the styling of the `InfoBanner` component using the `className` prop.
- Moves the message about the impact of agent updates from the `Banner` to the `InfoBanner` component.
- Adjusts the padding and margin values for the `div` containing the `InfoBanner` and `Button` components.

<!-- end-generated-description -->
