### PR TITLE
coral-web: show no tools message for agents who use 0 tools

### DIFF
--- a/src/interfaces/coral_web/src/components/Agents/Settings/ToolsTab.tsx
+++ b/src/interfaces/coral_web/src/components/Agents/Settings/ToolsTab.tsx
@@ -6,7 +6,9 @@ import { Button, Icon, Text } from '@/components/Shared';
 import { ToggleCard } from '@/components/ToggleCard';
 import { WelcomeGuideTooltip } from '@/components/WelcomeGuideTooltip';
 import { TOOL_FALLBACK_ICON, TOOL_ID_TO_DISPLAY_INFO } from '@/constants';
+import { useAgent } from '@/hooks/agents';
 import { useDefaultFileLoaderTool } from '@/hooks/files';
+import { useSlugRoutes } from '@/hooks/slugRoutes';
 import { useListTools, useUnauthedTools } from '@/hooks/tools';
 import { useFilesStore, useParamsStore } from '@/stores';
 import { ConfigurableParams } from '@/stores/slices/paramsSlice';
@@ -19,6 +21,8 @@ export const ToolsTab: React.FC<{ requiredTools: string[] | undefined; className
   requiredTools,
   className = '',
 }) => {
+  const { agentId } = useSlugRoutes();
+  const { data: agent } = useAgent({ agentId });
   const { params, setParams } = useParamsStore();
   const { data } = useListTools();
   const { tools: paramTools } = params;
@@ -56,7 +60,9 @@ export const ToolsTab: React.FC<{ requiredTools: string[] | undefined; className
       <ToolsInfoBox />
       <article className={cn('flex flex-col gap-y-5 pb-10')}>
         <Text styleAs="p-sm" className="text-secondary-800">
-          Tools are data sources the assistant can search such as databases or the internet.
+          {availableTools.length === 0
+            ? `${agent?.name} does not use any tools.`
+            : 'Tools are data sources the assistant can search such as databases or the internet.'}
         </Text>
 
         {unauthedTools.length > 0 && (

--- a/src/interfaces/coral_web/src/components/Conversation/index.tsx
+++ b/src/interfaces/coral_web/src/components/Conversation/index.tsx
@@ -10,7 +10,7 @@ import { HotKeysProvider } from '@/components/Shared/HotKeys';
 import { WelcomeGuideTooltip } from '@/components/WelcomeGuideTooltip';
 import { ReservedClasses } from '@/constants';
 import { useChatHotKeys } from '@/hooks/actions';
-import { useAgent, useRecentAgents } from '@/hooks/agents';
+import { useRecentAgents } from '@/hooks/agents';
 import { useChat } from '@/hooks/chat';
 import { useDefaultFileLoaderTool, useFileActions } from '@/hooks/files';
 import { WelcomeGuideStep, useWelcomeGuideState } from '@/hooks/ftux';


### PR DESCRIPTION


https://github.com/cohere-ai/cohere-toolkit/assets/140425731/fb658268-eeea-4cff-96f5-9b6ad93d334e



**AI Description**

<!-- begin-generated-description -->

This pull request updates the `ToolsTab` component in the `src/interfaces/coral_web/src/components/Agents/Settings` directory. 

## Summary
The changes in this PR aim to enhance the `ToolsTab` component by importing additional hooks and updating the component's logic to display tool information more effectively. 

## Changes
- **New Imports**: 
  - `useAgent` hook from `'@/hooks/agents'.
  - `useSlugRoutes` hook from `'@/hooks/slugRoutes'.
- **Updated Logic**: 
  - The component now uses the `agentId` from the `useSlugRoutes` hook to retrieve agent data using the `useAgent` hook.
  - The tool information displayed now includes a conditional check to show a message if the agent does not use any tools.

<!-- end-generated-description -->
