### PR TITLE
coral-web: add composer @ actions

### DIFF
--- a/src/interfaces/coral_web/src/components/Conversation/Composer/ComposerToolbar.tsx
+++ b/src/interfaces/coral_web/src/components/Conversation/Composer/ComposerToolbar.tsx
@@ -1,17 +1,25 @@
 import React, { useRef } from 'react';
 
+import {
+  DataSourceMenu,
+  Props as DataSourceMenuProps,
+} from '@/components/Conversation/Composer/DataSourceMenu';
 import { EnabledDataSources } from '@/components/Conversation/Composer/EnabledDataSources';
 import { IconButton } from '@/components/IconButton';
-import { IconName } from '@/components/Shared';
 import { ACCEPTED_FILE_TYPES } from '@/constants';
 import { cn } from '@/utils';
 
 type Props = {
-  canDisableDataSources: boolean;
+  isStreaming: boolean;
   onUploadFile: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  onDataSourceMenuToggle: VoidFunction;
+  menuProps: DataSourceMenuProps;
 };
 
-export const ComposerToolbar: React.FC<Props> = ({ canDisableDataSources, onUploadFile }) => {
+/**
+ * @description Renders the bottom toolbar of the composer that shows available and selected data sources.
+ */
+export const ComposerToolbar: React.FC<Props> = ({ isStreaming, onUploadFile, menuProps }) => {
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   const handleOpenFileExplorer = () => {
@@ -28,22 +36,15 @@ export const ComposerToolbar: React.FC<Props> = ({ canDisableDataSources, onUplo
         className="hidden"
         onChange={onUploadFile}
       />
-      <ToolbarActionButton
-        tooltipLabel="Attach file (.PDF, .TXT Max 20 MB)"
-        icon="clip"
+      <IconButton
+        iconName="clip"
+        tooltip={{ label: 'Attach file (.PDF, .TXT Max 20 MB)', size: 'sm' }}
+        size="sm"
         onClick={handleOpenFileExplorer}
       />
-      <EnabledDataSources isStreaming={false} canDisable={canDisableDataSources} />
+      <DataSourceMenu {...menuProps} />
+      <div className="h-7 w-px bg-marble-300" />
+      <EnabledDataSources isStreaming={isStreaming} />
     </div>
-  );
-};
-
-const ToolbarActionButton: React.FC<{
-  tooltipLabel: string;
-  icon: IconName;
-  onClick: React.MouseEventHandler<HTMLButtonElement>;
-}> = ({ tooltipLabel, icon, onClick }) => {
-  return (
-    <IconButton iconName={icon} tooltip={{ label: tooltipLabel }} onClick={onClick} size="sm" />
   );
 };

--- a/src/interfaces/coral_web/src/components/Conversation/Composer/DataSourceMenu.tsx
+++ b/src/interfaces/coral_web/src/components/Conversation/Composer/DataSourceMenu.tsx
@@ -64,7 +64,7 @@ export const DataSourceMenu: React.FC<Props> = ({
     params: { fileIds, tools },
     setParams,
   } = useParamsStore();
-  const optionsRef = useRef<HTMLDivElement>(null);
+  const buttonAndMenuRef = useRef<HTMLDivElement>(null);
   const [menuMode, setMenuMode] = useState<MenuMode>(MenuMode.OVERVIEW);
 
   const overviewTools = useMemo(() => {
@@ -212,10 +212,10 @@ export const DataSourceMenu: React.FC<Props> = ({
     }
   }, [show]);
 
-  useClickOutside(optionsRef, hideMenu);
+  useClickOutside(buttonAndMenuRef, hideMenu);
 
   return (
-    <div>
+    <div ref={buttonAndMenuRef}>
       <IconButton
         iconName="at"
         tooltip={{ label: 'Use data source', size: 'sm' }}
@@ -226,7 +226,6 @@ export const DataSourceMenu: React.FC<Props> = ({
         <div
           role="listbox"
           aria-multiselectable="true"
-          ref={optionsRef}
           className={cn(
             'absolute bottom-[85%] left-[1%] z-tag-suggestions max-h-[200px] md:w-[468px]',
             'w-full overflow-y-scroll rounded bg-marble-100 p-2 shadow-menu focus:outline-none'

--- a/src/interfaces/coral_web/src/components/Conversation/Composer/DataSourceMenu.tsx
+++ b/src/interfaces/coral_web/src/components/Conversation/Composer/DataSourceMenu.tsx
@@ -1,0 +1,369 @@
+import { useClickOutside } from '@react-hookz/web';
+import { uniq, uniqBy } from 'lodash';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+import { ManagedTool } from '@/cohere-client';
+import { ListboxOption, ListboxOptions } from '@/components/Conversation/Composer/ListboxOptions';
+import { IconButton } from '@/components/IconButton';
+import { IconName, Text } from '@/components/Shared';
+import { CHAT_COMPOSER_TEXTAREA_ID, TOOL_FALLBACK_ICON } from '@/constants';
+import { useParamsStore } from '@/stores';
+import { cn } from '@/utils';
+
+export const OVERVIEW_START_MAX_ITEMS = 3;
+
+export enum TagType {
+  TOOL = 'tool',
+  FILE = 'file',
+}
+
+enum MenuMode {
+  OVERVIEW = 'overview',
+  TOOLS = 'tools',
+  FILES = 'files',
+}
+
+type TagValue = { tag: Tag; type: TagType };
+export type Tag = {
+  id: string;
+  name: string;
+  getValue: () => ManagedTool | string;
+  disabled?: boolean;
+  icon?: IconName;
+  description?: string;
+  metadata?: React.ReactNode;
+};
+
+export type Props = {
+  show: boolean;
+  tagQuery: string;
+  tags: { fileIds: Tag[]; tools: Tag[] };
+  totalTags: { fileIds: number };
+  onChange: (tag: TagValue) => void;
+  onHide: VoidFunction;
+  onToggle: VoidFunction;
+  onSeeAll: VoidFunction;
+};
+
+/**
+ * @description Displays a list of available tools and data sources that the user can select from.
+ * These can be filtered by the tagQuery, which starts with '@' and ends when a space character is found
+ */
+export const DataSourceMenu: React.FC<Props> = ({
+  show,
+  tagQuery,
+  onChange,
+  tags,
+  totalTags,
+  onHide,
+  onToggle,
+  onSeeAll,
+}) => {
+  const [focusedTag, setFocusedTag] = useState<TagValue | undefined>();
+  const {
+    params: { fileIds, tools },
+    setParams,
+  } = useParamsStore();
+  const optionsRef = useRef<HTMLDivElement>(null);
+  const [menuMode, setMenuMode] = useState<MenuMode>(MenuMode.OVERVIEW);
+
+  const overviewTools = useMemo(() => {
+    if (tagQuery.length <= 1) return tags.tools.slice(0, OVERVIEW_START_MAX_ITEMS);
+    return tags.tools;
+  }, [tagQuery, tags.tools]);
+  const overviewFiles = useMemo(() => {
+    if (tagQuery.length <= 1) return tags.fileIds.slice(0, OVERVIEW_START_MAX_ITEMS);
+    return tags.fileIds;
+  }, [tagQuery, tags.fileIds]);
+
+  const scrollToTag = (tag?: Tag) => {
+    if (!tag) return;
+
+    const el = document.getElementById(`listbox-option-${tag.id}`);
+    if (el) {
+      el.scrollIntoView({ block: 'nearest' });
+    }
+  };
+
+  const focusFirstTag = () => {
+    if (!focusedTag || !focusedTag.tag || tags.tools.every((t) => t.name !== focusedTag.tag.name)) {
+      if (menuMode === MenuMode.OVERVIEW || menuMode === MenuMode.TOOLS) {
+        if (!tags.tools[0]) return;
+
+        setFocusedTag({ tag: tags.tools[0], type: TagType.TOOL });
+        scrollToTag(tags.tools[0]);
+      } else {
+        if (!tags.fileIds[0]) return;
+
+        setFocusedTag({ tag: tags.fileIds[0], type: TagType.FILE });
+        scrollToTag(tags.fileIds[0]);
+      }
+    } else {
+      scrollToTag(focusedTag.tag);
+    }
+  };
+
+  const hideMenu = useCallback(() => {
+    if (menuMode !== MenuMode.OVERVIEW) {
+      setMenuMode(MenuMode.OVERVIEW);
+    }
+    onHide();
+  }, [menuMode, onHide]);
+
+  const handleChange = useCallback(
+    (value: { tag: Tag; type: TagType }) => {
+      switch (value.type) {
+        case TagType.TOOL: {
+          setParams({
+            tools: uniqBy([...(tools ?? []), value.tag.getValue() as ManagedTool], 'name'),
+          });
+          break;
+        }
+        case TagType.FILE: {
+          setParams({ fileIds: uniq([...(fileIds ?? []), value.tag.getValue() as string]) });
+          break;
+        }
+      }
+
+      setFocusedTag(undefined);
+      onChange(value);
+      hideMenu();
+    },
+    [fileIds, onChange, setParams, tools, hideMenu]
+  );
+
+  const handleArrowKey = useCallback(
+    (e: KeyboardEvent | React.KeyboardEvent) => {
+      setFocusedTag((prev) => {
+        const toolsToSearch = menuMode === MenuMode.OVERVIEW ? overviewTools : tags.tools;
+        const filesToSearch = menuMode === MenuMode.OVERVIEW ? overviewFiles : tags.fileIds;
+        const tagsToSearch = toolsToSearch.concat(filesToSearch);
+        const lastToolIndex = toolsToSearch.length - 1;
+        const curIndex = tagsToSearch.findIndex((t) => t.id === prev?.tag.id);
+
+        if (curIndex !== -1) {
+          const nextIndex = curIndex + (e.key === 'ArrowUp' ? -1 : 1);
+          if (nextIndex === tagsToSearch.length || nextIndex === -1) {
+            return prev;
+          }
+          return {
+            tag: tagsToSearch[nextIndex],
+            type: nextIndex <= lastToolIndex ? TagType.TOOL : TagType.FILE,
+          };
+        }
+        return prev;
+      });
+      e.preventDefault();
+      e.stopPropagation();
+      return;
+    },
+    [menuMode, overviewTools, overviewFiles, tags.tools, tags.fileIds]
+  );
+
+  const handleEnter = useCallback(
+    (e: KeyboardEvent | React.KeyboardEvent) => {
+      if (focusedTag) {
+        handleChange(focusedTag);
+        e.preventDefault();
+        e.stopPropagation();
+      }
+    },
+    [focusedTag, handleChange]
+  );
+
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent | React.KeyboardEvent) => {
+      if (!show) return;
+      if (e.key === 'Escape' || e.code === 'Space') {
+        hideMenu();
+        return;
+      }
+
+      if (e.key === 'ArrowDown' || e.key === 'ArrowUp') {
+        handleArrowKey(e);
+        return;
+      }
+
+      if (e.key === 'Enter') {
+        handleEnter(e);
+        return;
+      }
+    },
+    [handleArrowKey, handleEnter, hideMenu, show]
+  );
+
+  useEffect(() => {
+    const composer = document.getElementById(CHAT_COMPOSER_TEXTAREA_ID);
+    if (!composer) return;
+    composer.addEventListener('keydown', handleKeyDown);
+
+    return () => composer.removeEventListener('keydown', handleKeyDown);
+  }, [handleKeyDown]);
+
+  useEffect(() => {
+    focusFirstTag();
+  }, [focusedTag, tags.tools, tagQuery]);
+
+  useEffect(() => {
+    if (show) {
+      focusFirstTag();
+    } else if (menuMode !== MenuMode.OVERVIEW) {
+      setMenuMode(MenuMode.OVERVIEW);
+    }
+  }, [show]);
+
+  useClickOutside(optionsRef, hideMenu);
+
+  return (
+    <div>
+      <IconButton
+        iconName="at"
+        tooltip={{ label: 'Use data source', size: 'sm' }}
+        onClick={onToggle}
+        size="sm"
+      />
+      {show && (
+        <div
+          role="listbox"
+          aria-multiselectable="true"
+          ref={optionsRef}
+          className={cn(
+            'absolute bottom-[85%] left-[1%] z-tag-suggestions max-h-[200px] md:w-[468px]',
+            'w-full overflow-y-scroll rounded bg-marble-100 p-2 shadow-menu focus:outline-none'
+          )}
+        >
+          {menuMode === MenuMode.TOOLS && (
+            <ToolOptions
+              tags={tags.tools}
+              selectedTagIds={(tools ?? []).map((c) => c.name ?? '')}
+              focusedTag={focusedTag}
+              onOptionSelect={handleChange}
+            />
+          )}
+
+          {menuMode === MenuMode.FILES && (
+            <FileOptions
+              tags={tags.fileIds}
+              selectedTagIds={fileIds ?? []}
+              focusedTag={focusedTag}
+              onOptionSelect={handleChange}
+            />
+          )}
+
+          {menuMode === MenuMode.OVERVIEW && (
+            <>
+              <ToolOptions
+                isOverview
+                tags={overviewTools}
+                focusedTag={focusedTag}
+                onOptionSelect={handleChange}
+                selectedTagIds={(tools ?? []).map((c) => c.name ?? '')}
+                onSeeAll={() => {
+                  setMenuMode(MenuMode.TOOLS);
+                  setFocusedTag({ tag: tags.tools[0], type: TagType.TOOL });
+                  focusFirstTag();
+                  onSeeAll();
+                }}
+              />
+
+              <FileOptions
+                isOverview
+                totalTags={totalTags.fileIds}
+                tags={overviewFiles}
+                focusedTag={focusedTag}
+                onOptionSelect={handleChange}
+                selectedTagIds={fileIds ?? []}
+                onSeeAll={() => {
+                  setMenuMode(MenuMode.FILES);
+                  setFocusedTag({ tag: tags.fileIds[0], type: TagType.FILE });
+                  focusFirstTag();
+                  onSeeAll();
+                }}
+              />
+            </>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};
+
+const ToolOptions: React.FC<{
+  tags: Tag[];
+  isOverview?: boolean;
+  selectedTagIds: string[];
+  focusedTag?: { tag: Tag; type: TagType };
+  onOptionSelect: (tag: { tag: Tag; type: TagType }) => void;
+  onSeeAll?: VoidFunction;
+}> = ({ tags, selectedTagIds, isOverview, focusedTag, onSeeAll, onOptionSelect }) => {
+  return (
+    <ListboxOptions title={isOverview ? 'Tools' : undefined} onSeeAll={onSeeAll}>
+      {tags.map((tag) => {
+        let selected = selectedTagIds.some((t) => t === tag.id);
+
+        return (
+          <ListboxOption
+            key={tag.id}
+            value={{ type: TagType.TOOL, tag }}
+            icon={tag.icon ?? TOOL_FALLBACK_ICON}
+            disabled={tag.disabled}
+            name={tag.name}
+            description={tag.description}
+            selected={selected}
+            focus={tag.id === (focusedTag?.tag?.id ?? '')}
+            onSelect={() => onOptionSelect({ type: TagType.TOOL, tag })}
+            metadata={
+              selected ? (
+                <Text as="span" className="text-volcanic-600">
+                  Selected
+                </Text>
+              ) : undefined
+            }
+          />
+        );
+      })}
+    </ListboxOptions>
+  );
+};
+
+const FileOptions: React.FC<{
+  tags: Tag[];
+  isOverview?: boolean;
+  totalTags?: number;
+  focusedTag?: { tag: Tag; type: TagType };
+  selectedTagIds: string[];
+  onOptionSelect: (tag: { tag: Tag; type: TagType }) => void;
+  onSeeAll?: VoidFunction;
+}> = ({ totalTags, tags, selectedTagIds, isOverview, onSeeAll, focusedTag, onOptionSelect }) => {
+  const hasFiles = totalTags !== 0;
+
+  return (
+    <ListboxOptions
+      title={isOverview ? 'Files' : undefined}
+      onSeeAll={hasFiles ? onSeeAll : undefined}
+    >
+      {hasFiles ? (
+        tags.map((tag) => (
+          <ListboxOption
+            key={tag.id}
+            value={{ type: TagType.FILE, tag }}
+            focus={tag.id === (focusedTag?.tag?.id ?? '')}
+            selected={selectedTagIds.some((t) => t === tag.id)}
+            onSelect={() => onOptionSelect({ type: TagType.FILE, tag })}
+            icon="clip"
+            name={tag.name}
+            metadata={
+              <Text as="span" className="flex-shrink-0 whitespace-nowrap text-volcanic-600">
+                {selectedTagIds.some((t) => t === tag.id) ? 'Selected' : tag.metadata}
+              </Text>
+            }
+          />
+        ))
+      ) : (
+        <Text as="span" className="p-1.5 text-volcanic-700">
+          You don&apos;t have any files, upload one to use with the assistant.
+        </Text>
+      )}
+    </ListboxOptions>
+  );
+};

--- a/src/interfaces/coral_web/src/components/Conversation/Composer/EnabledDataSources.tsx
+++ b/src/interfaces/coral_web/src/components/Conversation/Composer/EnabledDataSources.tsx
@@ -8,13 +8,12 @@ import { ConfigurableParams } from '@/stores/slices/paramsSlice';
 
 type Props = {
   isStreaming: boolean;
-  canDisable: boolean;
 };
 
 /**
  * @description Renders the enabled data sources in the composer toolbar.
  */
-export const EnabledDataSources: React.FC<Props> = ({ isStreaming, canDisable }) => {
+export const EnabledDataSources: React.FC<Props> = ({ isStreaming }) => {
   const {
     conversation: { id },
   } = useConversationStore();
@@ -62,7 +61,6 @@ export const EnabledDataSources: React.FC<Props> = ({ isStreaming, canDisable })
           label={d?.file_name ?? ''}
           onDelete={handleDeleteFile(d?.id ?? '')}
           disabled={isStreaming}
-          canDisable={canDisable}
         />
       ))}
       {enabledTools?.map((t, i) => (
@@ -71,7 +69,6 @@ export const EnabledDataSources: React.FC<Props> = ({ isStreaming, canDisable })
           iconName={TOOL_ID_TO_DISPLAY_INFO[t.name]?.icon ?? TOOL_FALLBACK_ICON}
           label={t.display_name ?? t.name}
           onDelete={handleDeleteTool(t.name ?? '')}
-          canDisable={canDisable}
         />
       ))}
     </div>
@@ -79,22 +76,13 @@ export const EnabledDataSources: React.FC<Props> = ({ isStreaming, canDisable })
 };
 
 const DataSourceChip: React.FC<{
-  canDisable: boolean;
   iconName: IconName;
   label: string;
   onDelete: React.MouseEventHandler;
   disabled?: boolean;
   hasEditableConfiguration?: boolean;
   onEditConfiguration?: VoidFunction;
-}> = ({
-  canDisable,
-  iconName,
-  label,
-  onDelete,
-  disabled,
-  hasEditableConfiguration,
-  onEditConfiguration,
-}) => {
+}> = ({ iconName, label, onDelete, disabled, hasEditableConfiguration, onEditConfiguration }) => {
   return (
     <div className="flex items-center justify-between gap-x-2 rounded border border-dashed border-secondary-200 bg-secondary-50 px-2 py-0.5">
       <div className="flex items-center gap-x-1">
@@ -106,11 +94,9 @@ const DataSourceChip: React.FC<{
           <Icon name="kebab" size="sm" />
         </button>
       )}
-      {canDisable && (
-        <button className="flex" onClick={onDelete} disabled={disabled}>
-          <Icon name="close" size="sm" />
-        </button>
-      )}
+      <button className="flex" onClick={onDelete} disabled={disabled}>
+        <Icon name="close" size="sm" />
+      </button>
     </div>
   );
 };

--- a/src/interfaces/coral_web/src/components/Conversation/Composer/ListboxOptions.tsx
+++ b/src/interfaces/coral_web/src/components/Conversation/Composer/ListboxOptions.tsx
@@ -1,0 +1,109 @@
+import React, { PropsWithChildren } from 'react';
+
+import { IconButton } from '@/components/IconButton';
+import { Icon, IconName, Text } from '@/components/Shared';
+import { cn } from '@/utils';
+
+import { Tag, TagType } from './DataSourceMenu';
+
+/**
+ * @description Listbox options wrapper with a title and see all button.
+ */
+export const ListboxOptions: React.FC<
+  PropsWithChildren<{
+    title?: string;
+    onSeeAll?: VoidFunction;
+  }>
+> = ({ title, onSeeAll, children }) => {
+  return (
+    <>
+      {title && (
+        <Text
+          as="div"
+          styleAs="label"
+          className={cn(
+            'group flex w-full items-center justify-between gap-x-1 pl-1.5 pt-1.5 font-medium'
+          )}
+        >
+          {title}
+
+          <IconButton
+            iconName="chevron-right"
+            tooltip={{ label: 'See all', size: 'sm' }}
+            size="sm"
+            className={cn({
+              invisible: !onSeeAll,
+            })}
+            onClick={onSeeAll}
+          />
+        </Text>
+      )}
+
+      {children}
+    </>
+  );
+};
+
+type ListboxOptionProps = {
+  focus: boolean;
+  selected: boolean;
+  icon: IconName;
+  value: { tag: Tag; type: TagType };
+  name: string;
+  onSelect: VoidFunction;
+  disabled?: boolean;
+  description?: string;
+  metadata?: React.ReactNode;
+};
+export const ListboxOption: React.FC<ListboxOptionProps> = ({
+  icon,
+  value,
+  name,
+  disabled,
+  description,
+  metadata,
+  focus,
+  selected,
+  onSelect,
+}) => {
+  return (
+    <div id={`listbox-option-${value.tag.id}`} role="option" tabIndex={-1} aria-selected={selected}>
+      <button
+        disabled={disabled}
+        tabIndex={-1}
+        className={cn(
+          'flex w-full items-start justify-between gap-x-2 rounded p-1.5 hover:bg-secondary-50 active:bg-secondary-50',
+          'focus:outline focus:outline-volcanic-800',
+          { 'bg-secondary-50': focus, 'cursor-not-allowed': disabled }
+        )}
+        onClick={onSelect}
+      >
+        <div className="flex flex-1 gap-x-1">
+          <Icon
+            name={icon}
+            size="sm"
+            kind="outline"
+            className="flex h-[21px] items-center text-volcanic-500"
+          />
+          <div className="flex flex-col text-left">
+            <Text
+              as="span"
+              className={cn({
+                'text-volcanic-700': disabled,
+              })}
+            >
+              {name}
+            </Text>
+            {description && (
+              <Text as="span" className="text-volcanic-700">
+                {description}
+              </Text>
+            )}
+          </div>
+        </div>
+
+        {metadata}
+      </button>
+    </div>
+  );
+};

--- a/src/interfaces/coral_web/src/components/Conversation/Composer/WebSearchConfigurationModal.tsx
+++ b/src/interfaces/coral_web/src/components/Conversation/Composer/WebSearchConfigurationModal.tsx
@@ -1,0 +1,55 @@
+import { useEffect, useRef, useState } from 'react';
+
+import { Button, Input } from '@/components/Shared';
+import { TOOL_INTERNET_SEARCH_ID } from '@/constants';
+import { useParamsStore } from '@/stores';
+import { hasCommonDelimiters } from '@/utils';
+
+/**
+ * @description Modal for configuring options on the web search tool.
+ * @wujessica: This component is not currently used since we do not have the tool options param yet.
+ */
+export const WebSearchModal: React.FC<{
+  onSave: (site: string) => void;
+  onCancel: VoidFunction;
+}> = ({ onSave, onCancel }) => {
+  const {
+    params: { tools },
+  } = useParamsStore();
+  const [site, setSite] = useState('');
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (inputRef.current) {
+      inputRef.current.focus();
+    }
+  }, []);
+
+  return (
+    <form
+      className="flex flex-col gap-y-8"
+      onSubmit={(e) => {
+        e.stopPropagation();
+        e.preventDefault();
+        onSave(site);
+      }}
+    >
+      <Input
+        ref={inputRef}
+        label="Site"
+        placeholder="Ground on 1 domain e.g. wikipedia.org"
+        description={
+          site.length > 0 && hasCommonDelimiters(site)
+            ? 'Multiple domains are not supported.'
+            : undefined
+        }
+        value={site}
+        onChange={(e) => setSite(e.target.value)}
+      />
+      <div className="flex w-full items-center justify-between">
+        <Button label="Cancel" kind="secondary" onClick={onCancel} />
+        <Button type="submit" label="Save" splitIcon="arrow-right" theme="volcanic" />
+      </div>
+    </form>
+  );
+};

--- a/src/interfaces/coral_web/src/components/Conversation/Composer/index.tsx
+++ b/src/interfaces/coral_web/src/components/Conversation/Composer/index.tsx
@@ -9,6 +9,7 @@ import { FirstTurnSuggestions } from '@/components/FirstTurnSuggestions';
 import { Icon, STYLE_LEVEL_TO_CLASSES } from '@/components/Shared';
 import { CHAT_COMPOSER_TEXTAREA_ID } from '@/constants';
 import { useBreakpoint, useIsDesktop } from '@/hooks/breakpoint';
+import { useDataSourceTags } from '@/hooks/tags';
 import { useUnauthedTools } from '@/hooks/tools';
 import { useSettingsStore } from '@/stores';
 import { ConfigurableParams } from '@/stores/slices/paramsSlice';
@@ -18,13 +19,13 @@ import { cn } from '@/utils';
 type Props = {
   isFirstTurn: boolean;
   isStreaming: boolean;
-  canDisableDataSources: boolean;
   value: string;
   streamingMessage: ChatMessage | null;
   onStop: VoidFunction;
   onSend: (message?: string, overrides?: Partial<ConfigurableParams>) => void;
   onChange: (message: string) => void;
   onUploadFile: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  requiredTools?: string[];
   chatWindowRef?: React.RefObject<HTMLDivElement>;
 };
 
@@ -32,7 +33,7 @@ export const Composer: React.FC<Props> = ({
   isFirstTurn,
   value,
   isStreaming,
-  canDisableDataSources,
+  requiredTools,
   onSend,
   onChange,
   onStop,
@@ -47,10 +48,14 @@ export const Composer: React.FC<Props> = ({
   const isSmallBreakpoint = breakpoint === 'sm';
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const { isToolAuthRequired } = useUnauthedTools();
+  const { suggestedTags, totalTags, setTagQuery, tagQuery, getTagQuery } = useDataSourceTags({
+    requiredTools,
+  });
 
   const [isComposing, setIsComposing] = useState(false);
   const [chatWindowHeight, setChatWindowHeight] = useState(0);
   const [isDragDropInputActive, setIsDragDropInputActive] = useState(false);
+  const [showDataSourceMenu, setShowDataSourceMenu] = useState(false);
 
   const isReadyToReceiveMessage = !isStreaming;
   const canSend = isReadyToReceiveMessage && value.trim().length > 0 && !isToolAuthRequired;
@@ -71,15 +76,40 @@ export const Composer: React.FC<Props> = ({
       e.preventDefault();
       if (canSend) {
         onSend(value);
+        setTagQuery('');
+        setShowDataSourceMenu(false);
+        onChange('');
       }
     }
   };
 
-  const handleComposerChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+  const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
     if (isToolAuthRequired) {
       return;
     }
+
     onChange(e.target.value);
+    if (textareaRef.current) {
+      const newTagQuery = getTagQuery(e.target.value, textareaRef.current.selectionStart);
+      setTagQuery(newTagQuery);
+
+      if (newTagQuery.length === 1 && !showDataSourceMenu) {
+        setShowDataSourceMenu(true);
+      } else if (newTagQuery.length === 0 && showDataSourceMenu) {
+        setShowDataSourceMenu(false);
+      }
+    }
+  };
+
+  const handleTagSelect = () => {
+    if (!textareaRef.current) return;
+    onChange(value.slice(0, value.length - tagQuery.length));
+    setTagQuery('');
+    setShowDataSourceMenu(false);
+  };
+
+  const handleDataSourceMenuClick = () => {
+    setShowDataSourceMenu((prevShow) => !prevShow);
   };
 
   useEffect(() => {
@@ -178,7 +208,7 @@ export const Composer: React.FC<Props> = ({
             }}
             rows={1}
             onKeyDown={handleKeyDown}
-            onChange={handleComposerChange}
+            onChange={handleChange}
             disabled={isToolAuthRequired}
           />
           <button
@@ -198,8 +228,19 @@ export const Composer: React.FC<Props> = ({
         </div>
         <ComposerFiles />
         <ComposerToolbar
-          canDisableDataSources={canDisableDataSources}
+          isStreaming={isStreaming}
           onUploadFile={onUploadFile}
+          onDataSourceMenuToggle={handleDataSourceMenuClick}
+          menuProps={{
+            show: showDataSourceMenu,
+            tagQuery: tagQuery,
+            tags: suggestedTags,
+            totalTags: totalTags,
+            onChange: handleTagSelect,
+            onHide: () => setShowDataSourceMenu(false),
+            onToggle: handleDataSourceMenuClick,
+            onSeeAll: () => textareaRef.current?.focus(),
+          }}
         />
       </div>
       <ComposerError className="pt-2" />

--- a/src/interfaces/coral_web/src/components/Conversation/index.tsx
+++ b/src/interfaces/coral_web/src/components/Conversation/index.tsx
@@ -66,6 +66,8 @@ const Conversation: React.FC<Props> = ({
   const { addRecentAgentId } = useRecentAgents();
   const { defaultFileLoaderTool, enableDefaultFileLoaderTool } = useDefaultFileLoaderTool();
 
+  const { data: agent } = useAgent({ agentId });
+
   const {
     userMessage,
     isStreaming,
@@ -170,11 +172,11 @@ const Conversation: React.FC<Props> = ({
                 <WelcomeGuideTooltip step={3} className="absolute bottom-full mb-4" />
                 <Composer
                   isStreaming={isStreaming}
-                  canDisableDataSources={!agentId}
                   value={userMessage}
                   isFirstTurn={messages.length === 0}
                   streamingMessage={streamingMessage}
                   chatWindowRef={chatWindowRef}
+                  requiredTools={agent?.tools}
                   onChange={(message) => setUserMessage(message)}
                   onSend={handleSend}
                   onStop={handleStop}

--- a/src/interfaces/coral_web/src/components/IconButton.tsx
+++ b/src/interfaces/coral_web/src/components/IconButton.tsx
@@ -20,7 +20,6 @@ type Props = {
   iconClassName?: string;
   disabled?: boolean;
   className?: string;
-  dataTestId?: string;
   onClick?: (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;
 };
 
@@ -39,7 +38,6 @@ export const IconButton: React.FC<Props> = ({
   href,
   target,
   shallow,
-  dataTestId,
   onClick,
 }) => {
   const iconButton = (
@@ -70,7 +68,6 @@ export const IconButton: React.FC<Props> = ({
       href={href}
       target={target}
       shallow={shallow}
-      dataTestId={dataTestId}
       onClick={onClick}
     />
   );

--- a/src/interfaces/coral_web/src/hooks/files.ts
+++ b/src/interfaces/coral_web/src/hooks/files.ts
@@ -2,7 +2,7 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { uniqBy } from 'lodash';
 import { useMemo } from 'react';
 
-import { File as CohereFile, FILE_TOOL_CATEGORY, ListFile, useCohereClient } from '@/cohere-client';
+import { File as CohereFile, ListFile, useCohereClient } from '@/cohere-client';
 import { ACCEPTED_FILE_TYPES } from '@/constants';
 import { useNotify } from '@/hooks/toast';
 import { useListTools } from '@/hooks/tools';

--- a/src/interfaces/coral_web/src/hooks/tags.tsx
+++ b/src/interfaces/coral_web/src/hooks/tags.tsx
@@ -21,12 +21,13 @@ export const useDataSourceTags = ({ requiredTools }: { requiredTools?: string[] 
   const { data: tools = [] } = useListTools();
   const { data: files } = useListFiles(id);
   const onlyRequiredTools = useMemo(() => {
+    const availableTools = tools.filter((t) => t.is_visible && t.is_available);
     if (!requiredTools) {
-      return tools;
+      return availableTools;
     }
 
     return requiredTools
-      .map((rt) => tools.find((t) => t.name === rt))
+      .map((rt) => availableTools.find((t) => t.name === rt))
       .filter((t) => !!t) as ManagedTool[];
   }, [tools, requiredTools]);
 

--- a/src/interfaces/coral_web/src/hooks/tags.tsx
+++ b/src/interfaces/coral_web/src/hooks/tags.tsx
@@ -1,0 +1,100 @@
+import { useMemo, useState } from 'react';
+
+import { ManagedTool } from '@/cohere-client';
+import { Tag } from '@/components/Conversation/Composer/DataSourceMenu';
+import { TOOL_FALLBACK_ICON, TOOL_ID_TO_DISPLAY_INFO } from '@/constants';
+import { useListFiles } from '@/hooks/files';
+import { useListTools } from '@/hooks/tools';
+import { useConversationStore } from '@/stores';
+import { formatFileSize } from '@/utils';
+
+/**
+ * @description Hook that contains all the logic for filtering and displaying tags
+ * for data sources.
+ */
+export const useDataSourceTags = ({ requiredTools }: { requiredTools?: string[] }) => {
+  const [tagQuery, setTagQuery] = useState<string>('');
+  const {
+    conversation: { id },
+  } = useConversationStore();
+  const query = tagQuery.replace('@', '');
+  const { data: tools = [] } = useListTools();
+  const { data: files } = useListFiles(id);
+  const onlyRequiredTools = useMemo(() => {
+    if (!requiredTools) {
+      return tools;
+    }
+
+    return requiredTools
+      .map((rt) => tools.find((t) => t.name === rt))
+      .filter((t) => !!t) as ManagedTool[];
+  }, [tools, requiredTools]);
+
+  const filteredFileIdTags: Tag[] = useMemo(
+    () =>
+      (files ?? [])
+        .filter((file) => {
+          return file.file_name.toLowerCase().includes(query.toLowerCase());
+        })
+        .map(({ id, file_name, file_size = 0 }) => ({
+          id,
+          name: file_name,
+          metadata: formatFileSize(file_size),
+          getValue: () => id,
+        })),
+    [files, query]
+  );
+
+  const allToolTags: Tag[] = useMemo(() => {
+    const allTools = [];
+    for (const t of onlyRequiredTools) {
+      allTools.push({
+        id: t.name,
+        name: t.display_name ?? t.name,
+        description: t.description ?? '',
+        icon: TOOL_ID_TO_DISPLAY_INFO[t.name]?.icon ?? TOOL_FALLBACK_ICON,
+        getValue: () => t,
+      });
+    }
+    return allTools;
+  }, [onlyRequiredTools]);
+  const filteredToolTags: Tag[] = useMemo(
+    () =>
+      allToolTags.filter(
+        (tag) =>
+          tag.id.toLowerCase().includes(query.toLowerCase()) ||
+          tag.name.toLowerCase().includes(query.toLowerCase())
+      ),
+    [allToolTags, query]
+  );
+
+  // if user types @ at the current input cursor position, return the @ and the string that follows
+  const getTagQuery = (value: string, cursorPosition: number): string => {
+    // Find the nearest space to the left of the cursor position
+    const spaceIndex = value.lastIndexOf(' ', cursorPosition);
+
+    // Determine the starting index based on the nearest space
+    const startIndex = spaceIndex !== -1 ? spaceIndex + 1 : 0;
+
+    // Match the first word of the string if it starts with "@"
+    const regexPattern = /^@(\S*)/;
+    const match = value.substring(startIndex).match(regexPattern);
+    if (match) {
+      return match[0];
+    }
+    return '';
+  };
+
+  return {
+    suggestedTags: {
+      fileIds: filteredFileIdTags,
+      tools: filteredToolTags,
+    },
+    totalTags: {
+      fileIds: files?.length ?? 0,
+    },
+    tagQuery,
+    setTagQuery,
+    getTagQuery,
+  };
+};


### PR DESCRIPTION
**Description:**
Adds composer actions for data source options (tools and files) triggered by the `@` symbol. 

https://github.com/cohere-ai/cohere-toolkit/assets/5898755/86951e22-263a-49c2-a26e-cf1c315d0eb6

**AI Description**

<!-- begin-generated-description -->

This PR introduces a new component, `DataSourceMenu`, and makes changes to the `ComposerToolbar` and `EnabledDataSources` components.

## New Component: `DataSourceMenu`
A new component, `DataSourceMenu`, has been added to display a list of available tools and data sources that the user can select from. It uses the TagType enum to differentiate between tools and files.

## Changes to `ComposerToolbar`
- The `DataSourceMenu` component has been added to `ComposerToolbar`.
- The `ToolbarActionButton` component has been replaced with the `IconButton` component.
- The `canDisableDataSources` prop has been removed and replaced with `isStreaming`.
- The `handleDataSourceMenuClick` function has been added to handle the toggling of the data source menu.
- The `menuProps` prop has been added to pass the data source menu's state and functions to the `DataSourceMenu` component.

## Changes to `EnabledDataSources`
- The `canDisable` prop has been removed.
- The `canDisable` prop has been removed from the `DataSourceChip` component, and the corresponding `canDisable` logic has been updated.

## Other Changes
- A new hook, `useDataSourceTags`, has been added to handle the logic for filtering and displaying tags for data sources.
- The `requiredTools` prop has been added to the `Composer` component and is passed to the `useDataSourceTags` hook.
- The `WebSearchModal` component has been added, which is currently not in use.

<!-- end-generated-description -->
