### PR TITLE
frontend: fix iframe preview with rehype-raw plugin

### DIFF
--- a/src/interfaces/coral_web/src/components/DataTable.tsx
+++ b/src/interfaces/coral_web/src/components/DataTable.tsx
@@ -1,4 +1,5 @@
-import { PropsWithChildren, useCallback } from 'react';
+import type { Component, ExtraProps } from 'hast-util-to-jsx-runtime/lib/components';
+import { ComponentPropsWithoutRef, useCallback } from 'react';
 
 import { Icon, Text } from '@/components/Shared';
 import { StructuredTable } from '@/components/Shared/Markdown/directives/table-tools';
@@ -9,9 +10,11 @@ import { downloadFile, structuredTableToXSV } from '@/utils/download';
 
 const FALLBACK_FILE_NAME = 'cohere-table';
 
-type Props = PropsWithChildren<{
-  structuredTable: StructuredTable | null;
-}>;
+type ElementProps = {
+  hProperties: {
+    structuredTable: StructuredTable;
+  };
+};
 
 /**
  * A React component that wraps a table generated from Markdown and adds functionality related to the data in the table
@@ -22,15 +25,20 @@ type Props = PropsWithChildren<{
  * How to test: Every Markdown table gets converted to a DataTable. In the chat app, try the following query:
  * "Create a table with 2 columns: (1) Cuisine; (2) One popular dish from that cuisine"
  */
-export const DataTable: React.FC<Props> = (props) => {
-  const { children, structuredTable } = props;
+export const DataTable: Component<ComponentPropsWithoutRef<'table'> & ExtraProps> = ({
+  children,
+  node,
+}) => {
+  const data = node?.data as ElementProps | undefined;
+  const structuredTable = data?.hProperties?.structuredTable;
+
   const {
     conversation: { name: conversationName },
   } = useConversationStore();
   const { error } = useNotify();
 
   const downloadAsCSV = useCallback(() => {
-    const csv = structuredTableToXSV(structuredTable, ',');
+    const csv = structuredTableToXSV(structuredTable!, ',');
     if (csv === null) {
       error('Unable to download table as CSV.');
       return;

--- a/src/interfaces/coral_web/src/components/Shared/Markdown/Markdown.tsx
+++ b/src/interfaces/coral_web/src/components/Shared/Markdown/Markdown.tsx
@@ -2,12 +2,13 @@ import { ComponentPropsWithoutRef, useMemo } from 'react';
 import ReactMarkdown, { Components, UrlTransform } from 'react-markdown';
 import rehypeHighlight from 'rehype-highlight';
 import rehypeKatex from 'rehype-katex';
-// import rehypeRaw from 'rehype-raw';
+import rehypeRaw from 'rehype-raw';
 import remarkDirective from 'remark-directive';
 import remarkGfm from 'remark-gfm';
 import remarkMath from 'remark-math';
 import { PluggableList } from 'unified';
 
+import { removeExtraBlankSpaces } from '@/components/Shared/Markdown/directives/utils';
 import { Iframe } from '@/components/Shared/Markdown/tags/Iframe';
 import { Text } from '@/components/Shared/Text';
 import { cn } from '@/utils';
@@ -48,13 +49,15 @@ export const getActiveMarkdownPlugins = (
     // renderRemarkUnknowns is a plugin that converts unrecognized directives to regular text nodes
     renderRemarkUnknowns,
     remarkReferences,
-    // renderTableTools is a plugin that detects tables and saves them in a readable structure
-    renderTableTools,
   ];
 
   const rehypePlugins: PluggableList = [
     // remarkRaw is a plugin that allows raw HTML in markdown
-    // rehypeRaw, // FIX(@tomtobac): Disabled because it is causing issues with the rendering of the markdown
+    rehypeRaw,
+    // removeExtraBlankSpaces is a plugin that removes extra blank spaces from the text elements
+    removeExtraBlankSpaces,
+    // renderTableTools is a plugin that detects tables and saves them in a readable structure
+    renderTableTools,
     // rehypeHighlight is a plugin that adds syntax highlighting to code blocks
     // Version 7.0.0 seems to have a memory leak bug that's why we are using 6.0.0
     // https://github.com/remarkjs/react-markdown/issues/791#issuecomment-2096106784
@@ -132,6 +135,7 @@ export const Markdown = ({
         allowedElements={allowedElements}
         components={components}
         urlTransform={urlTransform}
+        skipHtml={false}
       >
         {text}
       </ReactMarkdown>

--- a/src/interfaces/coral_web/src/components/Shared/Markdown/directives/utils.ts
+++ b/src/interfaces/coral_web/src/components/Shared/Markdown/directives/utils.ts
@@ -1,14 +1,19 @@
 import { Root } from 'hast';
 import type { Plugin } from 'unified';
-import { visit } from 'unist-util-visit';
 
 /**
- * A remark plugin that removes extra blank spaces from the text.
+ * A rehype plugin that removes extra blank spaces between tables.
  */
 export const removeExtraBlankSpaces: Plugin<void[], Root> = () => {
   return (tree) => {
-    visit(tree, 'text', (node) => {
-      node.value = node.value.replace(/\n{2,}/g, '\n');
-    });
+    for (let i = 0; i < tree.children.length; i++) {
+      const node = tree.children[i];
+      if (node.type == 'element' && node.tagName == 'table' && i > 0) {
+        const prevNode = tree.children[i - 1];
+        if (prevNode.type == 'text') {
+          prevNode.value = prevNode.value.replace(/\n{2,}/g, '\n');
+        }
+      }
+    }
   };
 };

--- a/src/interfaces/coral_web/src/components/Shared/Markdown/directives/utils.ts
+++ b/src/interfaces/coral_web/src/components/Shared/Markdown/directives/utils.ts
@@ -1,0 +1,14 @@
+import { Root } from 'hast';
+import type { Plugin } from 'unified';
+import { visit } from 'unist-util-visit';
+
+/**
+ * A remark plugin that removes extra blank spaces from the text.
+ */
+export const removeExtraBlankSpaces: Plugin<void[], Root> = () => {
+  return (tree) => {
+    visit(tree, 'text', (node) => {
+      node.value = node.value.replace(/\n{2,}/g, '\n');
+    });
+  };
+};

--- a/src/interfaces/coral_web/src/utils/preview.ts
+++ b/src/interfaces/coral_web/src/utils/preview.ts
@@ -64,7 +64,6 @@ const getReconstructedHtml = (rawHTML: string) => {
 };
 
 export const replaceCodeBlockWithIframe = (content: string) => {
-  return content; // FIX(@tomtobac): Disabled because it is causing issues with the rendering of the markdown
   const matchingRegex = /```html([\s\S]+)/;
   const replacingRegex = /```html([\s\S]+?)(```|$)/;
 


### PR DESCRIPTION
## Description

Enables iframe rendering with `rehype-raw`
- Fix: download CSV from the table (now the plugin points to HTML elements and not markdown anymore)
- Fix: extra blank spaces in front of the table

Closes OS-2196

## Screenshots

<img width="761" alt="image" src="https://github.com/cohere-ai/cohere-toolkit/assets/10562610/7502e08a-ca45-4704-a237-349ff1189e22">

