### PR TITLE
bug(backend): toolkit tool clashes with cohere platform tools

### DIFF
--- a/src/backend/config/tools.py
+++ b/src/backend/config/tools.py
@@ -35,7 +35,7 @@ class ToolName(StrEnum):
     Search_File = "search_file"
     Read_File = "read_document"
     Python_Interpreter = "toolkit_python_interpreter"
-    Calculator = "calculator"
+    Calculator = "toolkit_calculator"
     Tavily_Internet_Search = "web_search"
     Google_Drive = GOOGLE_DRIVE_TOOL_ID
 


### PR DESCRIPTION
using calculator with any other tool will return this error
```
data: {"event": "stream-end", "data": {"response_id": "d061fce3-a656-43de-b03b-544d23763417", "generation_id": null, "conversation_id": "3902dd85-f92a-42a3-8cdc-0a3d853b3635", "text": "", "citations": [], "documents": [], "search_results": [], "search_queries": [], "tool_calls": [], "finish_reason": "ERROR", "chat_history": [], "error": "status_code: 400, body: {'message': \"invalid request: the 'calculator' tool can't be used with a custom definition: choose a different name or remove the provided definition\"}"}}

```
**AI Description**

<!-- begin-generated-description -->

This pull request updates the `ToolName` class in the `src/backend/config/tools.py` file by renaming one of the attributes.

## Summary
The `Calculator` attribute of the `ToolName` class has been renamed from `"calculator"` to `"toolkit_calculator"`.

## Changes
- `src/backend/config/tools.py`: Renames the `Calculator` attribute of the `ToolName` class to `"toolkit_calculator"`.

<!-- end-generated-description -->
