### PR TITLE
coral-web: import useAgent

### DIFF
--- a/src/interfaces/coral_web/src/components/Conversation/index.tsx
+++ b/src/interfaces/coral_web/src/components/Conversation/index.tsx
@@ -10,7 +10,7 @@ import { HotKeysProvider } from '@/components/Shared/HotKeys';
 import { WelcomeGuideTooltip } from '@/components/WelcomeGuideTooltip';
 import { ReservedClasses } from '@/constants';
 import { useChatHotKeys } from '@/hooks/actions';
-import { useRecentAgents } from '@/hooks/agents';
+import { useAgent, useRecentAgents } from '@/hooks/agents';
 import { useChat } from '@/hooks/chat';
 import { useDefaultFileLoaderTool, useFileActions } from '@/hooks/files';
 import { WelcomeGuideStep, useWelcomeGuideState } from '@/hooks/ftux';


### PR DESCRIPTION
**Description:** 

Adds a missing import causing the frontend to be upset.

**AI Description**

<!-- begin-generated-description -->

This pull request updates the import statements in `index.tsx` within the `Conversation` component of the `coral_web` interface.

## Summary
The `useAgent` hook is now imported from `'@/hooks/agents'. This hook is likely used to manage the state and behavior of an agent or user within a conversation.

## Changes
- Added `import { useAgent, ... } from '@/hooks/agents';` in `src/interfaces/coral_web/src/components/Conversation/index.tsx`.

<!-- end-generated-description -->
