### PR TITLE
coral-web: support multihop tool streaming events

### DIFF
--- a/src/interfaces/coral_web/src/components/Citations/CitationDocumentHeader.tsx
+++ b/src/interfaces/coral_web/src/components/Citations/CitationDocumentHeader.tsx
@@ -1,12 +1,12 @@
 import { IconButton } from '@/components/IconButton';
 import { DocumentIcon, Icon, IconName, Text } from '@/components/Shared';
-import { TOOL_FALLBACK_ICON, TOOL_ID_TO_DISPLAY_INFO, TOOL_INTERNET_SEARCH_ID } from '@/constants';
+import { TOOL_FALLBACK_ICON, TOOL_ID_TO_DISPLAY_INFO, TOOL_WEB_SEARCH_ID } from '@/constants';
 import { cn, getSafeUrl, getWebDomain } from '@/utils';
 
 const getWebSourceName = (toolId?: string) => {
   if (!toolId) {
     return '';
-  } else if (toolId === TOOL_INTERNET_SEARCH_ID) {
+  } else if (toolId === TOOL_WEB_SEARCH_ID) {
     return 'from the web';
   }
   return `from ${toolId}`;

--- a/src/interfaces/coral_web/src/components/FirstTurnSuggestions.tsx
+++ b/src/interfaces/coral_web/src/components/FirstTurnSuggestions.tsx
@@ -2,11 +2,7 @@ import { Transition } from '@headlessui/react';
 import React, { useMemo } from 'react';
 
 import ButtonGroup from '@/components/ButtonGroup';
-import {
-  TOOL_CALCULATOR_ID,
-  TOOL_INTERNET_SEARCH_ID,
-  TOOL_PYTHON_INTERPRETER_ID,
-} from '@/constants';
+import { TOOL_CALCULATOR_ID, TOOL_PYTHON_INTERPRETER_ID, TOOL_WEB_SEARCH_ID } from '@/constants';
 import { useListTools } from '@/hooks/tools';
 import { useParamsStore } from '@/stores';
 import { ConfigurableParams } from '@/stores/slices/paramsSlice';
@@ -26,7 +22,7 @@ const SUGGESTED_PROMPTS: Prompt[] = [
       tools: [
         { name: TOOL_PYTHON_INTERPRETER_ID },
         { name: TOOL_CALCULATOR_ID },
-        { name: TOOL_INTERNET_SEARCH_ID },
+        { name: TOOL_WEB_SEARCH_ID },
       ],
     },
     message:

--- a/src/interfaces/coral_web/src/components/MessageRow.tsx
+++ b/src/interfaces/coral_web/src/components/MessageRow.tsx
@@ -49,7 +49,7 @@ const MessageRow = forwardRef<HTMLDivElement, Props>(function MessageRowInternal
 
   const [isShowing, setIsShowing] = useState(false);
   const [isLongPressMenuOpen, setIsLongPressMenuOpen] = useState(false);
-  const [isStepsExpanded, setIsStepsExpanded] = useState<boolean>(isLast);
+  const [isStepsExpanded, setIsStepsExpanded] = useState<boolean>(true);
   const {
     citations: { selectedCitation, hoveredGenerationId },
     hoverCitation,
@@ -81,12 +81,6 @@ const MessageRow = forwardRef<HTMLDivElement, Props>(function MessageRowInternal
       setTimeout(() => setIsShowing(true), 300);
     }
   }, []);
-
-  useEffect(() => {
-    if (isLast) {
-      setIsStepsExpanded(true);
-    }
-  }, [isLast]);
 
   const [highlightMessage, setHighlightMessage] = useState(false);
   const prevSelectedCitationGenId = usePreviousDistinct(selectedCitation?.generationId);

--- a/src/interfaces/coral_web/src/constants.ts
+++ b/src/interfaces/coral_web/src/constants.ts
@@ -50,15 +50,15 @@ export const LOCAL_STORAGE_KEYS = {
 /**
  * Tools
  */
-export const TOOL_INTERNET_SEARCH_ID = 'internet_search';
-export const TOOL_PYTHON_INTERPRETER_ID = 'python_interpreter';
-export const TOOL_CALCULATOR_ID = 'calculator';
+export const TOOL_WEB_SEARCH_ID = 'web_search';
+export const TOOL_PYTHON_INTERPRETER_ID = 'toolkit_python_interpreter';
+export const TOOL_CALCULATOR_ID = 'toolkit_calculator';
 export const TOOL_WIKIPEDIA_ID = 'wikipedia';
 export const TOOL_SEARCH_FILE_ID = 'search_file';
 
 export const TOOL_FALLBACK_ICON = 'circles-four';
 export const TOOL_ID_TO_DISPLAY_INFO: { [id: string]: { icon: IconName } } = {
-  [TOOL_INTERNET_SEARCH_ID]: { icon: 'search' },
+  [TOOL_WEB_SEARCH_ID]: { icon: 'search' },
   [TOOL_PYTHON_INTERPRETER_ID]: { icon: 'code' },
   [TOOL_CALCULATOR_ID]: { icon: 'calculator' },
   [TOOL_WIKIPEDIA_ID]: { icon: 'web' },

--- a/src/interfaces/coral_web/src/types/message.ts
+++ b/src/interfaces/coral_web/src/types/message.ts
@@ -1,4 +1,4 @@
-import { Citation, File, StreamToolInput } from '@/cohere-client';
+import { Citation, File, StreamToolCallsGeneration, StreamToolInput } from '@/cohere-client';
 
 export enum BotState {
   LOADING = 'loading',
@@ -36,7 +36,7 @@ export type FulfilledMessage = BaseMessage & {
   citations?: Citation[];
   isRAGOn?: boolean;
   originalText: string;
-  toolEvents?: StreamToolInput[];
+  toolEvents?: StreamToolCallsGeneration[];
 };
 
 /**
@@ -45,7 +45,7 @@ export type FulfilledMessage = BaseMessage & {
 export type AbortedMessage = BaseMessage & {
   type: MessageType.BOT;
   state: BotState.ABORTED;
-  toolEvents?: StreamToolInput[];
+  toolEvents?: StreamToolCallsGeneration[];
 };
 
 /**
@@ -67,7 +67,7 @@ export type TypingMessage = BaseMessage & {
   originalText: string;
   citations?: Citation[];
   isRAGOn?: boolean;
-  toolEvents?: StreamToolInput[];
+  toolEvents?: StreamToolCallsGeneration[];
 };
 
 /**


### PR DESCRIPTION
**Description:** 
This PR shows the tool events streaming in when using multihop. It also updates some tool names to match what the backend gives us.

Note: the stream response doesn't complete, likely due to my local setup being a bit broken but this demonstrates parsing the tool events streaming in:

https://github.com/cohere-ai/cohere-toolkit/assets/5898755/e659cb09-588d-470c-a840-75272aee25c4

**AI Description**

<!-- begin-generated-description -->

This PR updates the code to replace references to `TOOL_INTERNET_SEARCH_ID` with `TOOL_WEB_SEARCH_ID`. This includes changes in the following files:

- `src/interfaces/coral_web/src/components/Citations/CitationDocumentHeader.tsx`
- `src/interfaces/coral_web/src/components/FirstTurnSuggestions.tsx`
- `src/interfaces/coral_web/src/components/ToolEvents.tsx`
- `src/interfaces/coral_web/src/constants.ts`
- `src/interfaces/coral_web/src/hooks/chat.ts`
- `src/interfaces/coral_web/src/types/message.ts`

Additionally, there are some other minor changes, such as updating the default value of `isStepsExpanded` in `src/interfaces/coral_web/src/components/MessageRow.tsx` and removing some unused imports.

<!-- end-generated-description -->
