### PR TITLE
frontend: Use localhost:4000 as a default FRONTEND_HOSTNAME value

### DIFF
--- a/src/interfaces/coral_web/src/env.mjs
+++ b/src/interfaces/coral_web/src/env.mjs
@@ -7,7 +7,7 @@ export const env = createEnv({
   },
   client: {
     NEXT_PUBLIC_API_HOSTNAME: z.string(),
-    NEXT_PUBLIC_FRONTEND_HOSTNAME: z.string(),
+    NEXT_PUBLIC_FRONTEND_HOSTNAME: z.string().optional().default('http://localhost:4000'),
     NEXT_PUBLIC_HAS_CUSTOM_LOGO: z.string().optional().default('false'),
   },
   runtimeEnv: {


### PR DESCRIPTION
Though we are setting environment variable values for `FRONTEND_HOSTNAME` during the setup flow, for ease of use it's nice to have a default value for this in the frontend so that it doesn't fail to launch entirely if the value is missing.

**AI Description**

<!-- begin-generated-description -->

This pull request updates the `env.mjs` file in the `src/interfaces/coral_web/src` directory. Specifically, it modifies the `client` object within the `createEnv` function:

- The `NEXT_PUBLIC_FRONTEND_HOSTNAME` field now has an optional default value of `'http://localhost:4000''.

<!-- end-generated-description -->
