### PR TITLE
coral-web: preselect + hide read_document and search_file tools in agent form

### DIFF
--- a/src/interfaces/coral_web/src/components/Agents/AgentForm.tsx
+++ b/src/interfaces/coral_web/src/components/Agents/AgentForm.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import { CreateAgent } from '@/cohere-client';
 import { Checkbox, Input, InputLabel, STYLE_LEVEL_TO_CLASSES, Text } from '@/components/Shared';
+import { DEFAULT_AGENT_TOOLS } from '@/constants';
 import { useListTools } from '@/hooks/tools';
 import { cn } from '@/utils';
 
@@ -28,7 +29,8 @@ export const AgentForm: React.FC<Props> = ({
   className,
 }) => {
   const { data: toolsData } = useListTools();
-  const tools = toolsData?.filter((t) => t.is_available) ?? [];
+  const tools =
+    toolsData?.filter((t) => t.is_available && !DEFAULT_AGENT_TOOLS.includes(t.name)) ?? [];
 
   return (
     <div className={cn('flex flex-col gap-y-4', className)}>

--- a/src/interfaces/coral_web/src/components/Agents/CreateAgentForm.tsx
+++ b/src/interfaces/coral_web/src/components/Agents/CreateAgentForm.tsx
@@ -3,11 +3,24 @@ import React, { useContext, useState } from 'react';
 
 import { AgentForm, AgentFormFieldKeys, AgentFormFields } from '@/components/Agents/AgentForm';
 import { Button, Text } from '@/components/Shared';
-import { DEFAULT_AGENT_MODEL, DEPLOYMENT_COHERE_PLATFORM } from '@/constants';
+import {
+  DEFAULT_AGENT_MODEL,
+  DEPLOYMENT_COHERE_PLATFORM,
+  TOOL_READ_DOCUMENT_ID,
+  TOOL_SEARCH_FILE_ID,
+} from '@/constants';
 import { ModalContext } from '@/context/ModalContext';
 import { useCreateAgent, useIsAgentNameUnique, useRecentAgents } from '@/hooks/agents';
 import { useNotify } from '@/hooks/toast';
 
+const DEFAULT_FIELD_VALUES = {
+  name: '',
+  description: '',
+  preamble: '',
+  deployment: DEPLOYMENT_COHERE_PLATFORM,
+  model: DEFAULT_AGENT_MODEL,
+  tools: [TOOL_SEARCH_FILE_ID, TOOL_READ_DOCUMENT_ID],
+};
 /**
  * @description Form to create a new agent.
  */
@@ -19,14 +32,7 @@ export const CreateAgentForm: React.FC = () => {
   const { addRecentAgentId } = useRecentAgents();
   const isAgentNameUnique = useIsAgentNameUnique();
   const [isSubmitting, setIsSubmitting] = useState(false);
-  const [fields, setFields] = useState<AgentFormFields>({
-    name: '',
-    description: '',
-    preamble: '',
-    deployment: DEPLOYMENT_COHERE_PLATFORM,
-    model: DEFAULT_AGENT_MODEL,
-    tools: [],
-  });
+  const [fields, setFields] = useState<AgentFormFields>(DEFAULT_FIELD_VALUES);
 
   const fieldErrors = {
     ...(isAgentNameUnique(fields.name) ? {} : { name: 'Assistant name must be unique' }),
@@ -73,14 +79,7 @@ export const CreateAgentForm: React.FC = () => {
       setIsSubmitting(true);
       const agent = await createAgent(fields);
       addRecentAgentId(agent.id);
-      setFields({
-        name: '',
-        description: '',
-        preamble: '',
-        deployment: DEPLOYMENT_COHERE_PLATFORM,
-        model: DEFAULT_AGENT_MODEL,
-        tools: [],
-      });
+      setFields(DEFAULT_FIELD_VALUES);
       close();
       setIsSubmitting(false);
       router.push(`/agents/${agent.id}`, undefined, { shallow: true });

--- a/src/interfaces/coral_web/src/components/Agents/CreateAgentForm.tsx
+++ b/src/interfaces/coral_web/src/components/Agents/CreateAgentForm.tsx
@@ -3,12 +3,7 @@ import React, { useContext, useState } from 'react';
 
 import { AgentForm, AgentFormFieldKeys, AgentFormFields } from '@/components/Agents/AgentForm';
 import { Button, Text } from '@/components/Shared';
-import {
-  DEFAULT_AGENT_MODEL,
-  DEPLOYMENT_COHERE_PLATFORM,
-  TOOL_READ_DOCUMENT_ID,
-  TOOL_SEARCH_FILE_ID,
-} from '@/constants';
+import { DEFAULT_AGENT_MODEL, DEFAULT_AGENT_TOOLS, DEPLOYMENT_COHERE_PLATFORM } from '@/constants';
 import { ModalContext } from '@/context/ModalContext';
 import { useCreateAgent, useIsAgentNameUnique, useRecentAgents } from '@/hooks/agents';
 import { useNotify } from '@/hooks/toast';
@@ -19,7 +14,7 @@ const DEFAULT_FIELD_VALUES = {
   preamble: '',
   deployment: DEPLOYMENT_COHERE_PLATFORM,
   model: DEFAULT_AGENT_MODEL,
-  tools: [TOOL_SEARCH_FILE_ID, TOOL_READ_DOCUMENT_ID],
+  tools: DEFAULT_AGENT_TOOLS,
 };
 /**
  * @description Form to create a new agent.

--- a/src/interfaces/coral_web/src/constants.ts
+++ b/src/interfaces/coral_web/src/constants.ts
@@ -67,3 +67,5 @@ export const TOOL_ID_TO_DISPLAY_INFO: { [id: string]: { icon: IconName } } = {
   [TOOL_WIKIPEDIA_ID]: { icon: 'web' },
   [TOOL_SEARCH_FILE_ID]: { icon: 'search' },
 };
+
+export const DEFAULT_AGENT_TOOLS = [TOOL_SEARCH_FILE_ID, TOOL_READ_DOCUMENT_ID];

--- a/src/interfaces/coral_web/src/constants.ts
+++ b/src/interfaces/coral_web/src/constants.ts
@@ -56,6 +56,7 @@ export const TOOL_PYTHON_INTERPRETER_ID = 'toolkit_python_interpreter';
 export const TOOL_CALCULATOR_ID = 'toolkit_calculator';
 export const TOOL_WIKIPEDIA_ID = 'wikipedia';
 export const TOOL_SEARCH_FILE_ID = 'search_file';
+export const TOOL_READ_DOCUMENT_ID = 'read_document';
 export const TOOL_GOOGLE_DRIVE_ID = 'google_drive';
 
 export const TOOL_FALLBACK_ICON = 'circles-four';


### PR DESCRIPTION
Thank you for contributing to the Cohere Toolkit!


https://github.com/cohere-ai/cohere-toolkit/assets/140425731/bf60b873-46c8-4688-bf5a-da66c75f30c6


- [ ] **PR title**: "area: description"
  - Where "area" is whichever of interface, frontend, model, tools, backend, etc. is being modified. Use "docs: ..." for purely docs changes, "infra: ..." for CI changes.
  - Example: "deployment: add Azure model option"


- [ ] **PR message**: ***Delete this entire checklist*** and replace with
    - **Description:** a description of the change
    - **Issue:** the issue # it fixes, if applicable
    - **Dependencies:** any dependencies required for this change


- [ ] **Add tests and docs**: Please include testing and documentation for your changes
- [ ] **Lint and test**: Run `make lint` and `make run-tests`

**AI Description**

<!-- begin-generated-description -->

This pull request updates the `CreateAgentForm` and `AgentForm` components to include new constants for tool IDs and default field values.

## Summary
The `CreateAgentForm` and `AgentForm` components have been updated to include the `TOOL_READ_DOCUMENT_ID` and `TOOL_SEARCH_FILE_ID` constants from the `@/constants` module. These constants are used to specify default tools for new agents and filter out omitted tools when displaying available tools.

## Changes
- Add `TOOL_READ_DOCUMENT_ID` and `TOOL_SEARCH_FILE_ID` imports to `CreateAgentForm.tsx` and `AgentForm.tsx`.
- Set default values for the `name`, `description`, `preamble`, `deployment`, `model`, and `tools` fields in `CreateAgentForm.tsx`.
- Update the `tools` data filtering logic in `AgentForm.tsx` to exclude omitted tools.

<!-- end-generated-description -->
