### PR TITLE
Add PKCE docs

### DIFF
--- a/docs/auth_guide.md
+++ b/docs/auth_guide.md
@@ -12,7 +12,7 @@ This is the current list of implemented Auth strategies:
 
 To enable one or more of these strategies, add them to the `ENABLED_AUTH_STRATEGIES` list in the `backend/config/auth.py` file, then add any required environment variables in your `.env` file, and generate a secret key to be used as the `AUTH_SECRET_KEY` environment variable. This is used to encode and decode your access tokens.
 
-For the `AUTH_SECRET_KEY`, if you want to test auth functionality you can use any string value.
+Regarding the `AUTH_SECRET_KEY` variable, if you want to test auth any string will suffice.
 For production use-cases, it is recommended to run the following python commands in a local CLI to generate a random key:
 
 ```
@@ -25,6 +25,13 @@ print(secrets.token_hex(32))
 When configuring your OAuth apps, make sure to whitelist the Redirect URI to the frontend endpoint, it should look like 
 `<FRONTEND_HOST>/auth/<STRATEGY_NAME>`. For example, your Redirect URI will be `http://localhost:4000/auth/google` if you're running the GoogleOAuth class locally.
 
+## Enabling Proof of Key Code Exchange (PKCE)
+
+Many OIDC-compliant auth providers also implement PKCE for added protection. This involves generating `code_verifier` and `code_challenge` values in the frontend and using these values to validate that the same entity that initially logged in with the auth provider is the one requesting an access token from an authorization code. 
+
+For more [details click here.](https://oauth.net/2/pkce/)
+
+To enable the additional PKCE auth flow, you will need to first ensure your auth provider is PKCE-compliant, then set the `PKCE_ENABLED` class attribute in your OIDCConnect auth strategy to `True`. 
 ## Implementing new Auth strategies
 
 To implement a new strategy, refer to the `backend/services/auth/strategies` folder. Auth strategies will need to inherit from one of two base classes, `BaseAuthenticationStrategy` or `BaseOAuthStrategy`.

--- a/docs/auth_guide.md
+++ b/docs/auth_guide.md
@@ -32,6 +32,7 @@ Many OIDC-compliant auth providers also implement PKCE for added protection. Thi
 For more [details click here.](https://oauth.net/2/pkce/)
 
 To enable the additional PKCE auth flow, you will need to first ensure your auth provider is PKCE-compliant, then set the `PKCE_ENABLED` class attribute in your OIDCConnect auth strategy to `True`. 
+
 ## Implementing new Auth strategies
 
 To implement a new strategy, refer to the `backend/services/auth/strategies` folder. Auth strategies will need to inherit from one of two base classes, `BaseAuthenticationStrategy` or `BaseOAuthStrategy`.


### PR DESCRIPTION
Thank you for contributing to the Cohere Toolkit!

- [ ] **PR title**: "area: description"
  - Where "area" is whichever of interface, frontend, model, tools, backend, etc. is being modified. Use "docs: ..." for purely docs changes, "infra: ..." for CI changes.
  - Example: "deployment: add Azure model option"


- [ ] **PR message**: ***Delete this entire checklist*** and replace with
    - **Description:** a description of the change
    - **Issue:** the issue # it fixes, if applicable
    - **Dependencies:** any dependencies required for this change


- [ ] **Add tests and docs**: Please include testing and documentation for your changes
- [ ] **Lint and test**: Run `make lint` and `make run-tests`

**AI Description**

<!-- begin-generated-description -->

The pull request describes updates to the authentication (auth) strategies implementation guide. It includes changes to the existing content and introduces new sections.

## Summary
- The `AUTH_SECRET_KEY` variable-related instructions have been rephrased for clarity.
- A new section on **Enabling Proof of Key Code Exchange (PKCE)** has been added, detailing:
  - The purpose and benefits of PKCE.
  - The process of generating `code_verifier` and `code_challenge` values for enhanced security.
  - A link to additional resources for PKCE details.
  - Instructions to enable the PKCE auth flow, including a prerequisite check and the necessary configuration change.

## Detailed Changes
- **Rephrased Instructions for `AUTH_SECRET_KEY`**:
  - The text has been reworded for clarity, emphasizing that any string value can be used for testing auth functionality.

- **New Section: Enabling Proof of Key Code Exchange (PKCE)**:
  - **Introduction**: Explains that many OIDC-compliant auth providers use PKCE for added protection.
  - **Code Values Generation**: Describes the process of generating `code_verifier` and `code_challenge` values in the frontend to validate the entity requesting an access token.
  - **Additional Resources**: Provides a link to oauth.net for further PKCE details.
  - **Enabling PKCE Auth Flow**: Instructs users to ensure their auth provider is PKCE-compliant before setting the `PKCE_ENABLED` attribute to `True`.

<!-- end-generated-description -->
