### PR TITLE
coral-web: fix partial word breaks in agent cards

### DIFF
--- a/src/interfaces/coral_web/src/components/Agents/DiscoverAgentCard.tsx
+++ b/src/interfaces/coral_web/src/components/Agents/DiscoverAgentCard.tsx
@@ -39,7 +39,7 @@ export const DiscoverAgentCard: React.FC<Props> = ({ id, name, description, isBa
             {name}
           </Text>
         </div>
-        <Text className="line-clamp-2 flex-grow break-all text-left">{description}</Text>
+        <Text className="line-clamp-2 flex-grow">{description}</Text>
         <Button
           className="ml-auto"
           href={isBaseAgent ? '/agents' : `/agents/${id}`}


### PR DESCRIPTION
**Description:**
Word breaks were happening within words, causing the descriptions to look funky.

|1|2|
|-|-|
|<img width="657" alt="Screenshot 2024-06-27 at 2 31 26 PM" src="https://github.com/cohere-ai/cohere-toolkit/assets/5898755/f29a7a2b-bc1f-46f6-8f8a-375de04e418a">|<img width="509" alt="Screenshot 2024-06-27 at 2 31 33 PM" src="https://github.com/cohere-ai/cohere-toolkit/assets/5898755/c94de5c2-ac6b-4143-a80e-27fd91f0db4c">|

**AI Description**

<!-- begin-generated-description -->

This pull request makes changes to the `DiscoverAgentCard` component in the `src/interfaces/coral_web/src/components/Agents/` directory.

**Summary**
The PR removes the `break-all` CSS property from the `Text` element displaying the `description` prop of the `DiscoverAgentCard` component.

**Changes**
- Remove the `break-all` CSS property from the `Text` element displaying the `description` prop.

<!-- end-generated-description -->
