### PR TITLE
coral-web: remove register buttons on login screen

### DIFF
--- a/src/interfaces/coral_web/src/pages/login.tsx
+++ b/src/interfaces/coral_web/src/pages/login.tsx
@@ -5,7 +5,6 @@ import { useMemo, useState } from 'react';
 import { SubmitHandler, useForm } from 'react-hook-form';
 
 import { CohereClient, CohereUnauthorizedError, ListAuthStrategy } from '@/cohere-client';
-import { AuthLink } from '@/components/AuthLink';
 import { Button, Input, Text } from '@/components/Shared';
 import { OidcSSOButton } from '@/components/Welcome/OidcSSOButton';
 import { WelcomePage } from '@/components/WelcomePage';
@@ -86,7 +85,7 @@ const LoginPage: NextPage<Props> = () => {
   };
 
   return (
-    <WelcomePage title="Login" navigationAction="register">
+    <WelcomePage title="Login">
       <div className="flex flex-col items-center justify-center">
         <Text
           as="h1"
@@ -159,15 +158,6 @@ const LoginPage: NextPage<Props> = () => {
             />
           </form>
         )}
-
-        <Text as="div" className="mt-10 flex w-full items-center justify-between text-volcanic-700">
-          New user?
-          <AuthLink
-            redirect={redirect !== '/' ? redirect : undefined}
-            action="register"
-            className="text-green-700 no-underline"
-          />
-        </Text>
       </div>
     </WelcomePage>
   );


### PR DESCRIPTION
**Description:**

|after|before|
|-|-|
|<img width="931" alt="Screenshot 2024-06-27 at 2 51 02 PM" src="https://github.com/cohere-ai/cohere-toolkit/assets/5898755/8cd08644-bd2b-482f-95fa-54a119f8d94b">|<img width="933" alt="Screenshot 2024-06-27 at 2 51 19 PM" src="https://github.com/cohere-ai/cohere-toolkit/assets/5898755/593da055-2633-4eab-86f7-dd61baeb4924">|

**AI Description**

<!-- begin-generated-description -->

This pull request makes changes to the `LoginPage` component in the `login.tsx` file. 

## Summary
The `LoginPage` component has been updated to remove the "New user?" text and the associated `AuthLink` element. This change simplifies the login page by removing the explicit mention of user registration during the login process. 

## Code Changes
- The `navigationAction` prop in the `WelcomePage` component has been removed, eliminating the "register" action.
- The entire block of code containing the `Text` component, which displayed the "New user?" message, has been deleted.
- Along with the "New user?" message, the `AuthLink` component, which provided a registration link, has also been removed.

<!-- end-generated-description -->
