### PR TITLE
coral-web: display historical tool events

### DIFF
--- a/src/backend/services/chat.py
+++ b/src/backend/services/chat.py
@@ -750,8 +750,7 @@ def handle_stream_tool_calls_generation(
     stream_event = StreamToolCallsGeneration(**event | {"tool_calls": tool_calls})
     stream_end_data["tool_calls"].extend(tool_calls)
 
-    # TODO: remove False condition to enable saving tool calls
-    if should_store and False:
+    if should_store:
         save_tool_calls_message(
             session,
             tool_calls,

--- a/src/interfaces/coral_web/src/cohere-client/generated/models/ChatMessage.ts
+++ b/src/interfaces/coral_web/src/cohere-client/generated/models/ChatMessage.ts
@@ -12,7 +12,8 @@ import type { ChatRole } from './ChatRole';
  */
 export type ChatMessage = {
   role: ChatRole;
-  message: string | null;
+  message?: string | null;
+  tool_plan?: string | null;
   tool_results?: null;
   tool_calls?: null;
 };

--- a/src/interfaces/coral_web/src/cohere-client/generated/models/Message.ts
+++ b/src/interfaces/coral_web/src/cohere-client/generated/models/Message.ts
@@ -9,6 +9,7 @@ import type { Citation } from './Citation';
 import type { Document } from './Document';
 import type { File } from './File';
 import type { MessageAgent } from './MessageAgent';
+import type { ToolCall } from './ToolCall';
 
 export type Message = {
   text: string;
@@ -21,5 +22,7 @@ export type Message = {
   documents: Array<Document>;
   citations: Array<Citation>;
   files: Array<File>;
+  tool_calls: Array<ToolCall>;
+  tool_plan: string | null;
   agent: MessageAgent;
 };

--- a/src/interfaces/coral_web/src/cohere-client/generated/models/StreamEnd.ts
+++ b/src/interfaces/coral_web/src/cohere-client/generated/models/StreamEnd.ts
@@ -5,6 +5,7 @@
 /* tslint:disable */
 
 /* eslint-disable */
+import type { ChatMessage } from './ChatMessage';
 import type { Citation } from './Citation';
 import type { Document } from './Document';
 import type { SearchQuery } from './SearchQuery';
@@ -21,4 +22,6 @@ export type StreamEnd = {
   search_queries?: Array<SearchQuery>;
   tool_calls?: Array<ToolCall>;
   finish_reason?: string | null;
+  chat_history?: Array<ChatMessage> | null;
+  error?: string | null;
 };

--- a/src/interfaces/coral_web/src/cohere-client/generated/services/DefaultService.ts
+++ b/src/interfaces/coral_web/src/cohere-client/generated/services/DefaultService.ts
@@ -151,6 +151,17 @@ export class DefaultService {
     });
   }
   /**
+   * Login
+   * @returns any Successful Response
+   * @throws ApiError
+   */
+  public static loginV1ToolAuthGet(): CancelablePromise<any> {
+    return __request(OpenAPI, {
+      method: 'GET',
+      url: '/v1/tool/auth',
+    });
+  }
+  /**
    * Chat Stream
    * Stream chat endpoint to handle user messages and return chatbot responses.
    *
@@ -260,7 +271,7 @@ export class DefaultService {
   }): CancelablePromise<User> {
     return __request(OpenAPI, {
       method: 'POST',
-      url: '/v1/users/',
+      url: '/v1/users',
       body: requestBody,
       mediaType: 'application/json',
       errors: {
@@ -291,7 +302,7 @@ export class DefaultService {
   }): CancelablePromise<Array<User>> {
     return __request(OpenAPI, {
       method: 'GET',
-      url: '/v1/users/',
+      url: '/v1/users',
       query: {
         offset: offset,
         limit: limit,

--- a/src/interfaces/coral_web/src/components/Citations/CitationDocument.tsx
+++ b/src/interfaces/coral_web/src/components/Citations/CitationDocument.tsx
@@ -33,7 +33,7 @@ export const CitationDocument: React.FC<Props> = (props) => {
       <CitationDocumentHeader
         toolId={document.tool_name ?? undefined}
         url={document.url ?? ''}
-        title={document.title ?? undefined}
+        title={document.title && document.title.length > 0 ? document.title : undefined}
         isExpandable={isExpandable}
         isExpanded={isExpanded}
         isSelected={isExpandable}

--- a/src/interfaces/coral_web/src/components/Citations/CitationDocumentHeader.tsx
+++ b/src/interfaces/coral_web/src/components/Citations/CitationDocumentHeader.tsx
@@ -44,7 +44,7 @@ export const CitationDocumentHeader: React.FC<Props> = ({
   const hasUrl = url !== '';
   const safeUrl = hasUrl ? getSafeUrl(url) : undefined;
 
-  const isFile = !toolId && !hasUrl && title;
+  const isFile = !toolId && !hasUrl && title && title.length > 0;
   const isTool = !!toolId && !hasUrl && !!TOOL_ID_TO_DISPLAY_INFO[toolId];
   const toolDisplayInfo = toolId ? TOOL_ID_TO_DISPLAY_INFO[toolId] : undefined;
   // The title field is provided for web search documents and files, but not for tools.

--- a/src/interfaces/coral_web/src/components/Citations/CitationDocumentSnippet.tsx
+++ b/src/interfaces/coral_web/src/components/Citations/CitationDocumentSnippet.tsx
@@ -78,7 +78,7 @@ export const CitationDocumentSnippet: React.FC<
           <CitationDocumentHeader
             toolId={toolId}
             url={document.url ?? ''}
-            title={document.title ?? undefined}
+            title={document.title && document.title.length > 0 ? document.title : undefined}
             isExpandable={false}
             isExpanded={true}
             isSelected={true}

--- a/src/interfaces/coral_web/src/components/ToolEvents.tsx
+++ b/src/interfaces/coral_web/src/components/ToolEvents.tsx
@@ -87,7 +87,7 @@ const ToolEvent: React.FC<ToolEventProps> = ({ plan, event }) => {
     case TOOL_CALCULATOR_ID: {
       return (
         <ToolEventWrapper icon={icon}>
-          Calculating <b className="font-medium">{event?.parameters?.expression}</b>
+          Calculating <b className="font-medium">{event?.parameters?.code}</b>
         </ToolEventWrapper>
       );
     }
@@ -120,7 +120,7 @@ const ToolEventWrapper: React.FC<PropsWithChildren<{ icon?: IconName }>> = ({
   return (
     <div className="flex w-full gap-x-2 rounded bg-secondary-50 px-3 py-2 transition-colors ease-in-out group-hover:bg-secondary-100">
       <Icon name={icon} kind="outline" className="flex h-[21px] items-center text-secondary-600" />
-      <Text className="text-secondary-800" styleAs="p-sm">
+      <Text className="pt-px text-secondary-800" styleAs="p-sm" as="span">
         {children}
       </Text>
     </div>

--- a/src/interfaces/coral_web/src/utils/conversation.ts
+++ b/src/interfaces/coral_web/src/utils/conversation.ts
@@ -1,29 +1,59 @@
 import { Message, MessageAgent } from '@/cohere-client';
-import { BotMessage, BotState, MessageType, UserMessage } from '@/types/message';
+import { BotState, FulfilledMessage, MessageType, UserMessage } from '@/types/message';
 import { replaceTextWithCitations } from '@/utils/citations';
 import { replaceCodeBlockWithIframe } from '@/utils/preview';
 
-export const mapHistoryToMessages = (history?: Message[]) => {
-  return history
-    ? history.map<UserMessage | BotMessage>((message) => {
-        const isBotMessage = message.agent === MessageAgent.CHATBOT;
-        let text = message.text;
-        if (isBotMessage) {
-          text = replaceCodeBlockWithIframe(message.text);
-        }
-        return {
-          ...(isBotMessage
-            ? { type: MessageType.BOT, state: BotState.FULFILLED, originalText: message.text ?? '' }
-            : { type: MessageType.USER }),
+type UserOrBotMessage = UserMessage | FulfilledMessage;
+
+/**
+ * @description Maps chat history given by the API to a list of messages that can be displayed in the chat.
+ */
+export const mapHistoryToMessages = (history?: Message[]): UserOrBotMessage[] => {
+  if (!history) return [];
+
+  let messages: UserOrBotMessage[] = [];
+  let tempToolEvents: FulfilledMessage['toolEvents'];
+
+  for (const message of history) {
+    if (message.agent === MessageAgent.CHATBOT) {
+      if (!message.tool_plan) {
+        messages.push({
+          type: MessageType.BOT,
+          state: BotState.FULFILLED,
+          originalText: message.text ?? '',
           text: replaceTextWithCitations(
-            text ?? '',
+            replaceCodeBlockWithIframe(message.text) ?? '',
             message.citations ?? [],
             message.generation_id ?? ''
           ),
           generationId: message.generation_id ?? '',
           citations: message.citations,
-          files: message.files,
-        };
-      })
-    : [];
+          toolEvents: tempToolEvents,
+        });
+        tempToolEvents = undefined;
+      } else {
+        // Historical tool events come in as chatbot messages before the actual final response message.
+        if (tempToolEvents) {
+          tempToolEvents.push({
+            text: message.tool_plan,
+            tool_calls: message.tool_calls,
+          });
+        } else {
+          tempToolEvents = [{ text: message.tool_plan, tool_calls: message.tool_calls }];
+        }
+      }
+    } else {
+      messages.push({
+        type: MessageType.USER,
+        text: replaceTextWithCitations(
+          message.text ?? '',
+          message.citations ?? [],
+          message.generation_id ?? ''
+        ),
+        files: message.files,
+      });
+    }
+  }
+
+  return messages;
 };


### PR DESCRIPTION
**Description:** 

This PR reads and displays tool events that are saved in the chat history. It also fixes some display bugs to do with citations i.e. handles the case where a blank `title` is returned, we should fallback properly on the tool name. Note: there is a bug where web page titles aren't being sent in the `title` field.

https://github.com/cohere-ai/cohere-toolkit/assets/5898755/3ab59de4-a5c9-4642-8db1-b34f147c22a0

**AI Description**

<!-- begin-generated-description -->

<!--
  New: command-r-plus will maintain a pr description for you!
  Simply delete this section to opt out.
  Content inside this section will be overwritten by command as the PR is updated.
-->

<!-- end-generated-description -->
