### PR TITLE
[backend](do not merge) update agent can update tools_metadata 

### DIFF
--- a/src/backend/routers/agent.py
+++ b/src/backend/routers/agent.py
@@ -174,11 +174,13 @@ async def update_agent(
             status_code=400,
             detail=f"Agent with ID {agent_id} not found.",
         )
-    
+
     if new_agent.tools_metadata:
         for tool_metadata in new_agent.tools_metadata:
-            agent_tool_metadata = agent_tool_metadata_crud.get_agent_tool_metadata_by_id(
-                session, tool_metadata.id
+            agent_tool_metadata = (
+                agent_tool_metadata_crud.get_agent_tool_metadata_by_id(
+                    session, tool_metadata.id
+                )
             )
             if not agent_tool_metadata:
                 raise HTTPException(

--- a/src/backend/routers/agent.py
+++ b/src/backend/routers/agent.py
@@ -174,6 +174,26 @@ async def update_agent(
             status_code=400,
             detail=f"Agent with ID {agent_id} not found.",
         )
+    
+    if new_agent.tools_metadata:
+        for tool_metadata in new_agent.tools_metadata:
+            agent_tool_metadata = agent_tool_metadata_crud.get_agent_tool_metadata_by_id(
+                session, tool_metadata.id
+            )
+            if not agent_tool_metadata:
+                raise HTTPException(
+                    status_code=400,
+                    detail=f"Update failed: Agent tool metadata with ID {tool_metadata.id} not found.",
+                )
+
+        for tool_metadata in new_agent.tools_metadata:
+            update_agent_tool_metadata = UpdateAgentToolMetadata(
+                tool_name=tool_metadata.tool_name,
+                artifacts=tool_metadata.artifacts,
+            )
+            agent_tool_metadata_crud.update_agent_tool_metadata(
+                session, agent_tool_metadata, update_agent_tool_metadata
+            )
 
     try:
         agent = agent_crud.update_agent(session, agent, new_agent)

--- a/src/backend/schemas/agent.py
+++ b/src/backend/schemas/agent.py
@@ -21,6 +21,7 @@ class CreateAgentToolMetadata(BaseModel):
 
 
 class UpdateAgentToolMetadata(BaseModel):
+    tool_name: Optional[str] = None
     artifacts: Optional[list[dict]] = None
 
 
@@ -74,6 +75,7 @@ class UpdateAgent(BaseModel):
     model: Optional[str] = None
     deployment: Optional[str] = None
     tools: Optional[list[str]] = None
+    tools_metadata: Optional[list[AgentToolMetadata]] = None
 
     class Config:
         from_attributes = True

--- a/src/backend/tests/factories/agent.py
+++ b/src/backend/tests/factories/agent.py
@@ -34,5 +34,6 @@ class AgentFactory(BaseFactory):
             )
         ]
     )
+    tools_metadata = factory.List([])
     model = "command-r-plus"
     deployment = ModelDeploymentName.CoherePlatform

--- a/src/backend/tests/factories/agent.py
+++ b/src/backend/tests/factories/agent.py
@@ -34,6 +34,5 @@ class AgentFactory(BaseFactory):
             )
         ]
     )
-    tools_metadata = factory.List([])
     model = "command-r-plus"
     deployment = ModelDeploymentName.CoherePlatform

--- a/src/interfaces/coral_web/src/cohere-client/generated/models/CohereChatRequest.ts
+++ b/src/interfaces/coral_web/src/cohere-client/generated/models/CohereChatRequest.ts
@@ -34,4 +34,5 @@ export type CohereChatRequest = {
   prompt_truncation?: CohereChatPromptTruncation;
   tool_results?: null;
   force_single_step?: boolean | null;
+  agent_id?: string | null;
 };

--- a/src/interfaces/coral_web/src/cohere-client/generated/models/ManagedTool.ts
+++ b/src/interfaces/coral_web/src/cohere-client/generated/models/ManagedTool.ts
@@ -19,4 +19,5 @@ export type ManagedTool = {
   category?: Category;
   is_auth_required?: boolean;
   auth_url?: string | null;
+  token?: string | null;
 };

--- a/src/interfaces/coral_web/src/cohere-client/generated/models/UpdateAgent.ts
+++ b/src/interfaces/coral_web/src/cohere-client/generated/models/UpdateAgent.ts
@@ -1,7 +1,12 @@
 /* generated using openapi-typescript-codegen -- do no edit */
+
 /* istanbul ignore file */
+
 /* tslint:disable */
+
 /* eslint-disable */
+import type { AgentToolMetadata } from './AgentToolMetadata';
+
 export type UpdateAgent = {
   name?: string | null;
   version?: number | null;
@@ -11,4 +16,5 @@ export type UpdateAgent = {
   model?: string | null;
   deployment?: string | null;
   tools?: Array<string> | null;
+  tools_metadata?: Array<AgentToolMetadata> | null;
 };

--- a/src/interfaces/coral_web/src/cohere-client/generated/models/UpdateAgentToolMetadata.ts
+++ b/src/interfaces/coral_web/src/cohere-client/generated/models/UpdateAgentToolMetadata.ts
@@ -3,5 +3,6 @@
 /* tslint:disable */
 /* eslint-disable */
 export type UpdateAgentToolMetadata = {
+  tool_name?: string | null;
   artifacts?: null;
 };

--- a/src/interfaces/coral_web/src/cohere-client/generated/services/DefaultService.ts
+++ b/src/interfaces/coral_web/src/cohere-client/generated/services/DefaultService.ts
@@ -173,7 +173,6 @@ export class DefaultService {
    * session (DBSessionDep): Database session.
    * chat_request (CohereChatRequest): Chat request data.
    * request (Request): Request object.
-   * agent_id (str | None): Agent ID.
    *
    * Returns:
    * EventSourceResponse: Server-sent event response with chatbot responses.
@@ -182,17 +181,12 @@ export class DefaultService {
    */
   public static chatStreamV1ChatStreamPost({
     requestBody,
-    agentId,
   }: {
     requestBody: CohereChatRequest;
-    agentId?: string | null;
   }): CancelablePromise<Array<ChatResponseEvent>> {
     return __request(OpenAPI, {
       method: 'POST',
       url: '/v1/chat-stream',
-      query: {
-        agent_id: agentId,
-      },
       body: requestBody,
       mediaType: 'application/json',
       errors: {
@@ -208,7 +202,6 @@ export class DefaultService {
    * chat_request (CohereChatRequest): Chat request data.
    * session (DBSessionDep): Database session.
    * request (Request): Request object.
-   * agent_id (str | None): Agent ID.
    *
    * Returns:
    * NonStreamedChatResponse: Chatbot response.
@@ -217,17 +210,12 @@ export class DefaultService {
    */
   public static chatV1ChatPost({
     requestBody,
-    agentId,
   }: {
     requestBody: CohereChatRequest;
-    agentId?: string | null;
   }): CancelablePromise<NonStreamedChatResponse> {
     return __request(OpenAPI, {
       method: 'POST',
       url: '/v1/chat',
-      query: {
-        agent_id: agentId,
-      },
       body: requestBody,
       mediaType: 'application/json',
       errors: {


### PR DESCRIPTION
Thank you for contributing to the Cohere Toolkit!

- [ ] **PR title**: "area: description"
  - Where "area" is whichever of interface, frontend, model, tools, backend, etc. is being modified. Use "docs: ..." for purely docs changes, "infra: ..." for CI changes.
  - Example: "deployment: add Azure model option"


- [ ] **PR message**: ***Delete this entire checklist*** and replace with
    - **Description:** a description of the change
    - **Issue:** the issue # it fixes, if applicable
    - **Dependencies:** any dependencies required for this change


- [ ] **Add tests and docs**: Please include testing and documentation for your changes
- [ ] **Lint and test**: Run `make lint` and `make run-tests`

**AI Description**

<!-- begin-generated-description -->

This PR introduces changes to the agent management functionality, specifically focusing on updating agent tool metadata.

**Changed Files:**
- `src/backend/routers/agent.py`
- `src/backend/schemas/agent.py`
- `src/backend/tests/routers/test_agent.py`
- `src/interfaces/coral_web/src/cohere-client/generated/models/CohereChatRequest.ts`
- `src/interfaces/coral_web/src/cohere-client/generated/models/ManagedTool.ts`
- `src/interfaces/coral_web/src/cohere-client/generated/models/UpdateAgent.ts`
- `src/interfaces/coral_web/src/cohere-client/generated/models/UpdateAgentToolMetadata.ts`
- `src/interfaces/coral_web/src/cohere-client/generated/services/DefaultService.ts`

**Code Changes:**
- Added a new field, `tool_name`, to the `UpdateAgentToolMetadata` class in `agent.py` and `schemas/agent.py`.
- Introduced a new function, `test_update_agent_tool_metadata`, in `test_agent.py` to test the update agent tool metadata functionality.
- Updated the `CohereChatRequest` type in `CohereChatRequest.ts` to include an optional `agent_id` field.
- Modified the `ManagedTool` type in `ManagedTool.ts` to include a new field, `token`.
- Added a new import statement for `AgentToolMetadata` and included `tools_metadata` in the `UpdateAgent` type in `UpdateAgent.ts`.
- Added a new field, `tool_name`, to the `UpdateAgentToolMetadata` type in `UpdateAgentToolMetadata.ts`.
- Removed the `agent_id` parameter from the `DefaultService` class methods in `DefaultService.ts`.

**Summary:**
The primary focus of this PR is to enhance the agent management system by allowing updates to agent tool metadata. This includes adding a new field, `tool_name`, to the `UpdateAgentToolMetadata` class and updating the corresponding types and test cases. Additionally, the `CohereChatRequest` and `ManagedTool` types have been extended with new fields, and the `agent_id` parameter has been removed from the `DefaultService` class methods.

<!-- end-generated-description -->
