### PR TITLE
Backend: misc fixes

### DIFF
--- a/src/backend/chat/collate.py
+++ b/src/backend/chat/collate.py
@@ -3,7 +3,7 @@ from typing import Any, Dict, List
 
 from backend.model_deployments.base import BaseDeployment
 
-RELEVANCE_THRESHOLD = 0.3
+RELEVANCE_THRESHOLD = 0.1
 
 
 def rerank_and_chunk(

--- a/src/backend/tests/crud/test_agent_tool_metadata.py
+++ b/src/backend/tests/crud/test_agent_tool_metadata.py
@@ -19,8 +19,7 @@ def test_create_agent_tool_metadata(session, user):
         user_id=user.id,
         agent_id=agent.id,
         tool_name=ToolName.Google_Drive,
-        artifacts=["file_id"],
-        type="file",
+        artifacts=[{"file": "file_id"}],
     )
     agent_tool_metadata = agent_tool_metadata_crud.create_agent_tool_metadata(
         session, agent_tool_metadata_data
@@ -28,8 +27,7 @@ def test_create_agent_tool_metadata(session, user):
     assert agent_tool_metadata.user_id == user.id
     assert agent_tool_metadata.agent_id == agent.id
     assert agent_tool_metadata.tool_name == ToolName.Google_Drive
-    assert agent_tool_metadata.artifacts == ["file_id"]
-    assert agent_tool_metadata.type == "file"
+    assert agent_tool_metadata.artifacts == [{"file": "file_id"}]
 
     agent_tool_metadata = agent_tool_metadata_crud.get_agent_tool_metadata_by_id(
         session, agent_tool_metadata.id
@@ -37,16 +35,14 @@ def test_create_agent_tool_metadata(session, user):
     assert agent_tool_metadata.user_id == user.id
     assert agent_tool_metadata.agent_id == agent.id
     assert agent_tool_metadata.tool_name == ToolName.Google_Drive
-    assert agent_tool_metadata.artifacts == ["file_id"]
-    assert agent_tool_metadata.type == "file"
+    assert agent_tool_metadata.artifacts == [{"file": "file_id"}]
 
 
 def test_create_agent_missing_agent_id(session, user):
     agent_tool_metadata_data = AgentToolMetadata(
         user_id=user.id,
         tool_name=ToolName.Google_Drive,
-        artifacts=["file_id"],
-        type="file",
+        artifacts=[{"file": "file_id"}],
     )
     with pytest.raises(IntegrityError):
         _ = agent_tool_metadata_crud.create_agent_tool_metadata(
@@ -62,8 +58,7 @@ def test_create_agent_missing_tool_name(session, user):
     agent_tool_metadata_data = AgentToolMetadata(
         user_id=user.id,
         agent_id=agent.id,
-        artifacts=["file_id"],
-        type="file",
+        artifacts=[{"file": "file_id"}],
     )
     with pytest.raises(IntegrityError):
         _ = agent_tool_metadata_crud.create_agent_tool_metadata(
@@ -79,8 +74,7 @@ def test_create_agent_missing_user_id(session, user):
     agent_tool_metadata_data = AgentToolMetadata(
         agent_id=agent.id,
         tool_name=ToolName.Google_Drive,
-        artifacts=["file_id"],
-        type="file",
+        artifacts=[{"file": "file_id"}],
     )
     with pytest.raises(IntegrityError):
         _ = agent_tool_metadata_crud.create_agent_tool_metadata(
@@ -94,13 +88,11 @@ def test_update_agent_tool_metadata(session, user):
         user_id=user.id,
         agent_id=agent.id,
         tool_name=ToolName.Google_Drive,
-        artifacts=["file_id"],
-        type="file",
+        artifacts=[{"file": "file_id"}],
     )
 
     new_agent_tool_metadata_data = UpdateAgentToolMetadata(
-        artifacts=["new_file_id"],
-        type="file",
+        artifacts=[{"file": "new_file_id"}],
     )
 
     agent_tool_metadata = agent_tool_metadata_crud.update_agent_tool_metadata(
@@ -110,7 +102,6 @@ def test_update_agent_tool_metadata(session, user):
     assert agent_tool_metadata.agent_id == original_agent_tool_metadata.agent_id
     assert agent_tool_metadata.tool_name == original_agent_tool_metadata.tool_name
     assert agent_tool_metadata.artifacts == new_agent_tool_metadata_data.artifacts
-    assert agent_tool_metadata.type == new_agent_tool_metadata_data.type
 
 
 def test_get_agent_tool_metadata_by_id(session, user):
@@ -119,8 +110,7 @@ def test_get_agent_tool_metadata_by_id(session, user):
         user_id=user.id,
         agent_id=agent.id,
         tool_name=ToolName.Google_Drive,
-        artifacts=["file1", "file2"],
-        type="file_ids",
+        artifacts=[{"file_ids": ["file2", "file2"]}],
     )
     agent_tool_metadata = agent_tool_metadata_crud.get_agent_tool_metadata_by_id(
         session, agent_tool_metadata.id
@@ -128,8 +118,7 @@ def test_get_agent_tool_metadata_by_id(session, user):
     assert agent_tool_metadata.user_id == user.id
     assert agent_tool_metadata.agent_id == agent.id
     assert agent_tool_metadata.tool_name == ToolName.Google_Drive
-    assert agent_tool_metadata.artifacts == ["file1", "file2"]
-    assert agent_tool_metadata.type == "file_ids"
+    assert agent_tool_metadata.artifacts == [{"file_ids": ["file2", "file2"]}]
 
 
 def test_get_all_agent_tool_metadata_by_agent_id(session, user):
@@ -141,25 +130,29 @@ def test_get_all_agent_tool_metadata_by_agent_id(session, user):
         user_id=user.id,
         agent_id=agent1.id,
         tool_name=ToolName.Google_Drive,
-        type="file_ids",
-        artifacts=["file1", "file2"],
+        artifacts=[{"file_ids": ["file2", "file2"]}],
     )
-    for i in range(10):
-        _ = get_factory("AgentToolMetadata", session).create(
-            id=f"{i}",
-            tool_name=ToolName.Google_Drive,
-            type=f"type{i}",
-            artifacts=["file_id"],
-            user_id=user.id,
-            agent_id=agent2.id,
-        )
+
+    _ = get_factory("AgentToolMetadata", session).create(
+        user_id=user.id,
+        agent_id=agent1.id,
+        tool_name=ToolName.Wiki_Retriever_LangChain,
+        artifacts=[],
+    )
+
+    _ = get_factory("AgentToolMetadata", session).create(
+        user_id=user.id,
+        agent_id=agent2.id,
+        tool_name=ToolName.Google_Drive,
+        artifacts=[{"file_ids": ["file2", "file2"]}],
+    )
 
     all_agent_tool_metadata = (
         agent_tool_metadata_crud.get_all_agent_tool_metadata_by_agent_id(
-            session, agent_id=agent2.id
+            session, agent_id=agent1.id
         )
     )
-    assert len(all_agent_tool_metadata) == 10
+    assert len(all_agent_tool_metadata) == 2
 
 
 def test_delete_agent_tool_metadata_by_id(session, user):
@@ -168,8 +161,7 @@ def test_delete_agent_tool_metadata_by_id(session, user):
         user_id=user.id,
         agent_id=agent.id,
         tool_name=ToolName.Google_Drive,
-        artifacts=["file1", "file2"],
-        type="file_ids",
+        artifacts=[{"file_ids": ["file2", "file2"]}],
     )
 
     agent_tool_metadata_crud.delete_agent_tool_metadata_by_id(

--- a/src/backend/tests/tools/test_collate.py
+++ b/src/backend/tests/tools/test_collate.py
@@ -56,7 +56,7 @@ def test_rerank() -> None:
                 "parameters": {"query": "what is the highest mountain in the world?"},
                 "name": "retriever",
             },
-            "outputs": [outputs[0]],
+            "outputs": [outputs[0], outputs[1], outputs[2]],
         },
         {
             "call": {


### PR DESCRIPTION
- Decrease rerank threshold
- Fix agent metadata tests

**AI Description**

<!-- begin-generated-description -->

This PR makes changes to the `src/backend` directory, affecting the `chat`, `tests/crud`, and `tests/tools` modules. 

## Summary
- Updates the `RELEVANCE_THRESHOLD` constant in `collate.py` from `0.3` to `0.1`.
- Refactors the `artifacts` and `type` attributes in `test_agent_tool_metadata.py` to use a dictionary format instead of a list.
- Adds an additional output to the `test_rerank` function in `test_collate.py`.

## Details

### `src/backend/chat/collate.py`
- Updates the `RELEVANCE_THRESHOLD` constant from `0.3` to `0.1`.

### `src/backend/tests/crud/test_agent_tool_metadata.py`
- Refactors the `artifacts` attribute in the `AgentToolMetadata` class to use a dictionary format, e.g., `artifacts=["file_id"]` becomes `artifacts=[{"file": "file_id"}]`.
- Removes the `type` attribute from the `AgentToolMetadata` class.

### `src/backend/tests/tools/test_collate.py`
- Adds two additional outputs to the `test_rerank` function.

<!-- end-generated-description -->
