### PR TITLE
chore(toolkit): cleanup and improve code for google drive file picker

### DIFF
--- a/src/interfaces/coral_web/src/components/Agents/AgentForm.tsx
+++ b/src/interfaces/coral_web/src/components/Agents/AgentForm.tsx
@@ -1,10 +1,11 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 
 import { CreateAgent } from '@/cohere-client';
 import { AgentToolFielPicker } from '@/components/Agents/AgentToolFielPicker';
 import { Checkbox, Input, InputLabel, STYLE_LEVEL_TO_CLASSES, Text } from '@/components/Shared';
 import { DEFAULT_AGENT_TOOLS, TOOL_GOOGLE_DRIVE_ID } from '@/constants';
 import { useListTools } from '@/hooks/tools';
+import { GoogleDriveToolArtifact } from '@/types/tools';
 import { cn } from '@/utils';
 
 export type AgentFormFields = Omit<CreateAgent, 'version' | 'temperature'>;
@@ -12,11 +13,12 @@ export type AgentFormFieldKeys = keyof AgentFormFields;
 
 type Props = {
   fields: AgentFormFields;
-  onChange: (key: Omit<AgentFormFieldKeys, 'tools'>, value: string) => void;
+  onChange: <AgentFormFieldKeys extends keyof AgentFormFields>(
+    key: AgentFormFieldKeys,
+    value: AgentFormFields[AgentFormFieldKeys]
+  ) => void;
   onToolToggle: (toolName: string, checked: boolean, authUrl?: string) => void;
   handleOpenFilePicker: VoidFunction;
-  setGoogleDriveFiles: (files: Record<string, any>[]) => void;
-  googleDriveFiles?: Record<string, any>[];
   errors?: Partial<Record<AgentFormFieldKeys, string>>;
   disabled?: boolean;
   className?: string;
@@ -29,8 +31,6 @@ export const AgentForm: React.FC<Props> = ({
   onChange,
   onToolToggle,
   handleOpenFilePicker,
-  setGoogleDriveFiles,
-  googleDriveFiles,
   errors,
   disabled,
   className,
@@ -38,6 +38,27 @@ export const AgentForm: React.FC<Props> = ({
   const { data: toolsData } = useListTools();
   const tools =
     toolsData?.filter((t) => t.is_available && !DEFAULT_AGENT_TOOLS.includes(t.name)) ?? [];
+
+  const googleDrivefiles: GoogleDriveToolArtifact[] = useMemo(() => {
+    return (fields.tools_metadata?.find((t) => t.tool_name === TOOL_GOOGLE_DRIVE_ID)?.artifacts ??
+      []) as GoogleDriveToolArtifact[];
+  }, [fields]);
+
+  const setGoogleDriveFiles = (files: GoogleDriveToolArtifact[]) => {
+    if (files.length === 0) {
+      onChange('tools_metadata', [
+        ...(fields.tools_metadata ?? []).filter((t) => t.tool_name !== TOOL_GOOGLE_DRIVE_ID),
+      ]);
+      return;
+    }
+    onChange('tools_metadata', [
+      ...(fields.tools_metadata ?? []).filter((t) => t.tool_name !== TOOL_GOOGLE_DRIVE_ID),
+      {
+        tool_name: TOOL_GOOGLE_DRIVE_ID,
+        artifacts: files,
+      },
+    ]);
+  };
 
   return (
     <div className={cn('flex flex-col gap-y-4', className)}>
@@ -108,7 +129,7 @@ export const AgentForm: React.FC<Props> = ({
                 {isGoogleDrive && checked && (
                   <div className="pl-10">
                     <AgentToolFielPicker
-                      googleDriveFiles={googleDriveFiles}
+                      googleDriveFiles={googleDrivefiles}
                       setGoogleDriveFiles={setGoogleDriveFiles}
                       handleOpenFilePicker={handleOpenFilePicker}
                     />

--- a/src/interfaces/coral_web/src/components/Agents/AgentToolFielPicker.tsx
+++ b/src/interfaces/coral_web/src/components/Agents/AgentToolFielPicker.tsx
@@ -1,9 +1,10 @@
 import { IconButton } from '@/components/IconButton';
 import { Button, Icon, Text } from '@/components/Shared';
+import { GoogleDriveToolArtifact } from '@/types/tools';
 
 type Props = {
-  googleDriveFiles?: Record<string, any>[];
-  setGoogleDriveFiles: (files: Record<string, any>[]) => void;
+  googleDriveFiles?: GoogleDriveToolArtifact[];
+  setGoogleDriveFiles: (files: GoogleDriveToolArtifact[]) => void;
   handleOpenFilePicker: VoidFunction;
 };
 export const AgentToolFielPicker: React.FC<Props> = ({
@@ -14,6 +15,7 @@ export const AgentToolFielPicker: React.FC<Props> = ({
   const handleRemoveFile = (id: string) => {
     setGoogleDriveFiles(googleDriveFiles?.filter((file) => file.id !== id) ?? []);
   };
+
   return (
     <div className="flex max-w-[300px] flex-col gap-y-2">
       <Button
@@ -29,8 +31,8 @@ export const AgentToolFielPicker: React.FC<Props> = ({
             <div key={id} className="flex flex-shrink-0 items-center gap-x-2 truncate">
               <Icon
                 name={type === 'folder' ? 'folder' : 'file'}
-                kind="outline"
                 className="text-secondary-600"
+                size="sm"
               />
               <Text styleAs="caption" className="truncate">
                 {name}

--- a/src/interfaces/coral_web/src/components/Agents/CreateAgent.tsx
+++ b/src/interfaces/coral_web/src/components/Agents/CreateAgent.tsx
@@ -2,8 +2,7 @@ import { useSessionStorageValue } from '@react-hookz/web';
 import { useRouter } from 'next/router';
 import React, { useContext, useEffect, useState } from 'react';
 
-import { CreateAgent } from '@/cohere-client';
-import { AgentForm, AgentFormFieldKeys, AgentFormFields } from '@/components/Agents/AgentForm';
+import { AgentForm, AgentFormFields } from '@/components/Agents/AgentForm';
 import { Button, Text } from '@/components/Shared';
 import {
   DEFAULT_AGENT_MODEL,
@@ -15,6 +14,7 @@ import { ModalContext } from '@/context/ModalContext';
 import { useCreateAgent, useIsAgentNameUnique, useRecentAgents } from '@/hooks/agents';
 import { useNotify } from '@/hooks/toast';
 import { useListTools, useOpenGoogleDrivePicker } from '@/hooks/tools';
+import { GoogleDriveToolArtifact } from '@/types/tools';
 
 const DEFAULT_FIELD_VALUES = {
   name: '',
@@ -27,7 +27,7 @@ const DEFAULT_FIELD_VALUES = {
 /**
  * @description Form to create a new agent.
  */
-export const CreateAgentForm: React.FC = () => {
+export const CreateAgent: React.FC = () => {
   const router = useRouter();
   const { open, close } = useContext(ModalContext);
 
@@ -47,13 +47,29 @@ export const CreateAgentForm: React.FC = () => {
   const isAgentNameUnique = useIsAgentNameUnique();
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [fields, setFields] = useState<AgentFormFields>(DEFAULT_FIELD_VALUES);
-  const [googleDriveFiles, setGoogleDriveFiles] = useState<Record<string, any>[]>();
 
   const openFilePicker = useOpenGoogleDrivePicker((data) => {
     if (data.docs) {
-      setGoogleDriveFiles(
-        data.docs.map((doc) => ({ id: doc.id, name: doc.name, type: doc.type, url: doc.url }))
-      );
+      setFields((prev) => ({
+        ...prev,
+        tools_metadata: [
+          ...(prev.tools_metadata?.filter((tool) => tool.tool_name !== TOOL_GOOGLE_DRIVE_ID) ?? []),
+          ...[
+            {
+              tool_name: TOOL_GOOGLE_DRIVE_ID,
+              artifacts: data.docs.map(
+                (doc) =>
+                  ({
+                    id: doc.id,
+                    name: doc.name,
+                    type: doc.type,
+                    url: doc.url,
+                  } as GoogleDriveToolArtifact)
+              ),
+            },
+          ],
+        ],
+      }));
     }
   });
 
@@ -67,11 +83,14 @@ export const CreateAgentForm: React.FC = () => {
     return Object.values(requredFields).every(Boolean) && !Object.keys(fieldErrors).length;
   })();
 
-  const handleChange = (key: Omit<AgentFormFieldKeys, 'tools'>, value: string) => {
-    setFields({
-      ...fields,
-      [key as string]: value,
-    });
+  const handleChange = <AgentFormFieldKeys extends keyof AgentFormFields>(
+    key: AgentFormFieldKeys,
+    value: AgentFormFields[AgentFormFieldKeys]
+  ) => {
+    setFields((prev) => ({
+      ...prev,
+      [key]: value,
+    }));
   };
 
   const handleToolToggle = (toolName: string, checked: boolean, authUrl?: string) => {
@@ -81,10 +100,10 @@ export const CreateAgentForm: React.FC = () => {
       handleGoogleDriveToggle(checked, authUrl);
     }
 
-    setFields({
-      ...fields,
+    setFields((prev) => ({
+      ...prev,
       tools: checked ? [...enabledTools, toolName] : enabledTools.filter((t) => t !== toolName),
-    });
+    }));
   };
 
   const handleGoogleDriveToggle = (checked: boolean, authUrl?: string) => {
@@ -100,7 +119,11 @@ export const CreateAgentForm: React.FC = () => {
         openFilePicker();
       }
     } else {
-      setGoogleDriveFiles(undefined);
+      setFields((prev) => ({
+        ...prev,
+        tools: (fields.tools ?? []).filter((t) => t !== TOOL_GOOGLE_DRIVE_ID),
+        tools_metadata: fields.tools_metadata?.filter((t) => t.tool_name !== TOOL_GOOGLE_DRIVE_ID),
+      }));
     }
   };
 
@@ -134,12 +157,7 @@ export const CreateAgentForm: React.FC = () => {
     try {
       setIsSubmitting(true);
 
-      const payload: CreateAgent = {
-        ...fields,
-        tools_metadata: [{ tool_name: TOOL_GOOGLE_DRIVE_ID, artifacts: googleDriveFiles ?? [] }],
-      };
-
-      const agent = await createAgent(payload);
+      const agent = await createAgent(fields);
       addRecentAgentId(agent.id);
       setFields(DEFAULT_FIELD_VALUES);
       close();
@@ -166,8 +184,6 @@ export const CreateAgentForm: React.FC = () => {
             onChange={handleChange}
             onToolToggle={handleToolToggle}
             handleOpenFilePicker={openFilePicker}
-            googleDriveFiles={googleDriveFiles}
-            setGoogleDriveFiles={setGoogleDriveFiles}
             errors={fieldErrors}
             className="mt-6"
           />

--- a/src/interfaces/coral_web/src/components/Conversation/index.tsx
+++ b/src/interfaces/coral_web/src/components/Conversation/index.tsx
@@ -1,7 +1,7 @@
 import { Transition } from '@headlessui/react';
 import React, { useCallback, useEffect, useRef } from 'react';
 
-import { UpdateAgentPanel } from '@/components/Agents/UpdateAgentPanel';
+import { UpdateAgent } from '@/components/Agents/UpdateAgent';
 import { Composer } from '@/components/Conversation/Composer';
 import { Header } from '@/components/Conversation/Header';
 import MessagingContainer from '@/components/Conversation/MessagingContainer';
@@ -199,7 +199,7 @@ const Conversation: React.FC<Props> = ({
         leaveFrom="2xl:agent-panel-2xl md:w-agent-panel lg:w-agent-panel-lg w-full"
         leaveTo="w-0"
       >
-        <UpdateAgentPanel agentId={agentId} />
+        <UpdateAgent agentId={agentId} />
       </Transition>
     </div>
   );

--- a/src/interfaces/coral_web/src/pages/new.tsx
+++ b/src/interfaces/coral_web/src/pages/new.tsx
@@ -3,7 +3,7 @@ import { GetServerSideProps, NextPage } from 'next';
 
 import { CohereClient } from '@/cohere-client';
 import { AgentsList } from '@/components/Agents/AgentsList';
-import { CreateAgentForm } from '@/components/Agents/CreateAgentForm';
+import { CreateAgent } from '@/components/Agents/CreateAgent';
 import { Layout, LeftSection, MainSection } from '@/components/Layout';
 import { appSSR } from '@/pages/_app';
 
@@ -16,7 +16,7 @@ const AgentsNewPage: NextPage<Props> = () => {
         <AgentsList />
       </LeftSection>
       <MainSection>
-        <CreateAgentForm />
+        <CreateAgent />
       </MainSection>
     </Layout>
   );

--- a/src/interfaces/coral_web/src/types/tools.ts
+++ b/src/interfaces/coral_web/src/types/tools.ts
@@ -1,0 +1,6 @@
+export type GoogleDriveToolArtifact = {
+  type: string;
+  id: string;
+  name: string;
+  url: string;
+};


### PR DESCRIPTION
Thank you for contributing to the Cohere Toolkit!

- [ ] **PR title**: "area: description"
  - Where "area" is whichever of interface, frontend, model, tools, backend, etc. is being modified. Use "docs: ..." for purely docs changes, "infra: ..." for CI changes.
  - Example: "deployment: add Azure model option"


- [ ] **PR message**: ***Delete this entire checklist*** and replace with
    - **Description:** a description of the change
    - **Issue:** the issue # it fixes, if applicable
    - **Dependencies:** any dependencies required for this change


- [ ] **Add tests and docs**: Please include testing and documentation for your changes
- [ ] **Lint and test**: Run `make lint` and `make run-tests`

**AI Description**

<!-- begin-generated-description -->

This PR updates the code for creating and updating agents. It introduces a new type, `GoogleDriveToolArtifact`, and makes changes to the `AgentForm`, `AgentToolFielPicker`, `CreateAgent`, and `UpdateAgent` components.

- Renames `CreateAgentForm` to `CreateAgent` and updates the import statement for `AgentForm` and `AgentFormFields`.
- Removes the `CreateAgent` import statement as it is now imported from '`@/components/Agents/AgentForm'.
- Updates the `UpdateAgentPanel` component to `UpdateAgent`.
- Updates the `UpdateAgent` component to use the `GoogleDriveToolArtifact` type.
- Updates the `AgentForm` component to use the `GoogleDriveToolArtifact` type and introduces a new function, `setGoogleDriveFiles`, to handle setting the Google Drive files.
- Updates the `AgentToolFielPicker` component to use the `GoogleDriveToolArtifact` type and changes the `setGoogleDriveFiles` function to accept `GoogleDriveToolArtifact[]` instead of `Record<string, any>[]`.
- Updates the `CreateAgent` component to use the `GoogleDriveToolArtifact` type and changes how the `setGoogleDriveFiles` function is called.
- Updates the `UpdateAgent` component to use the `GoogleDriveToolArtifact` type and changes how the `setGoogleDriveFiles` function is called.
- Updates the `UpdateAgent` component to use the `GoogleDriveToolArtifact` type and changes the `handleChange` function to match the new type.
- Updates the `UpdateAgent` component to use the `GoogleDriveToolArtifact` type and removes the `setGoogleDriveFiles` function call.
- Updates the `UpdateAgent` component to use the `GoogleDriveToolArtifact` type and changes the `handleChange` function to match the new type.
- Updates the `UpdateAgent` component to use the `GoogleDriveToolArtifact` type and removes the `setGoogleDriveFiles` function call.

<!-- end-generated-description -->
