### PR TITLE
chore: generate client types

### DIFF
--- a/src/interfaces/coral_web/src/cohere-client/generated/index.ts
+++ b/src/interfaces/coral_web/src/cohere-client/generated/index.ts
@@ -30,6 +30,7 @@ export type { DeleteUser } from './models/DeleteUser';
 export type { Deployment } from './models/Deployment';
 export type { Document } from './models/Document';
 export type { File } from './models/File';
+export type { GenerateTitle } from './models/GenerateTitle';
 export type { HTTPValidationError } from './models/HTTPValidationError';
 export type { JWTResponse } from './models/JWTResponse';
 export type { LangchainChatRequest } from './models/LangchainChatRequest';

--- a/src/interfaces/coral_web/src/cohere-client/generated/models/GenerateTitle.ts
+++ b/src/interfaces/coral_web/src/cohere-client/generated/models/GenerateTitle.ts
@@ -1,0 +1,7 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type GenerateTitle = {
+  title: string;
+};

--- a/src/interfaces/coral_web/src/cohere-client/generated/models/UpdateAgent.ts
+++ b/src/interfaces/coral_web/src/cohere-client/generated/models/UpdateAgent.ts
@@ -1,7 +1,12 @@
 /* generated using openapi-typescript-codegen -- do no edit */
+
 /* istanbul ignore file */
+
 /* tslint:disable */
+
 /* eslint-disable */
+import type { AgentToolMetadata } from './AgentToolMetadata';
+
 export type UpdateAgent = {
   name?: string | null;
   version?: number | null;
@@ -11,4 +16,5 @@ export type UpdateAgent = {
   model?: string | null;
   deployment?: string | null;
   tools?: Array<string> | null;
+  tools_metadata?: Array<AgentToolMetadata> | null;
 };

--- a/src/interfaces/coral_web/src/cohere-client/generated/services/DefaultService.ts
+++ b/src/interfaces/coral_web/src/cohere-client/generated/services/DefaultService.ts
@@ -25,6 +25,7 @@ import type { DeleteFile } from '../models/DeleteFile';
 import type { DeleteUser } from '../models/DeleteUser';
 import type { Deployment } from '../models/Deployment';
 import type { File } from '../models/File';
+import type { GenerateTitle } from '../models/GenerateTitle';
 import type { JWTResponse } from '../models/JWTResponse';
 import type { LangchainChatRequest } from '../models/LangchainChatRequest';
 import type { ListAuthStrategy } from '../models/ListAuthStrategy';
@@ -694,6 +695,38 @@ export class DefaultService {
       path: {
         conversation_id: conversationId,
         file_id: fileId,
+      },
+      errors: {
+        422: `Validation Error`,
+      },
+    });
+  }
+  /**
+   * Generate Title
+   * Generate a title for a conversation and update the conversation with the generated title.
+   *
+   * Args:
+   * conversation_id (str): Conversation ID.
+   * session (DBSessionDep): Database session.
+   *
+   * Returns:
+   * str: Generated title for the conversation.
+   *
+   * Raises:
+   * HTTPException: If the conversation with the given ID is not found.
+   * @returns GenerateTitle Successful Response
+   * @throws ApiError
+   */
+  public static generateTitleV1ConversationsConversationIdGenerateTitlePost({
+    conversationId,
+  }: {
+    conversationId: string;
+  }): CancelablePromise<GenerateTitle> {
+    return __request(OpenAPI, {
+      method: 'POST',
+      url: '/v1/conversations/{conversation_id}/generate-title',
+      path: {
+        conversation_id: conversationId,
       },
       errors: {
         422: `Validation Error`,

--- a/src/interfaces/coral_web/src/components/Agents/AgentForm.tsx
+++ b/src/interfaces/coral_web/src/components/Agents/AgentForm.tsx
@@ -1,15 +1,16 @@
 import React from 'react';
 
-import { CreateAgent } from '@/cohere-client';
+import { CreateAgent, UpdateAgent } from '@/cohere-client';
 import { Checkbox, Input, InputLabel, STYLE_LEVEL_TO_CLASSES, Text } from '@/components/Shared';
 import { useListTools } from '@/hooks/tools';
 import { cn } from '@/utils';
 
-export type AgentFormFields = Omit<CreateAgent, 'version' | 'temperature'>;
-export type AgentFormFieldKeys = keyof AgentFormFields;
+export type CreateAgentFormFields = Omit<CreateAgent, 'version' | 'temperature'>;
+export type UpdateAgentFormFields = UpdateAgent;
+export type AgentFormFieldKeys = keyof CreateAgentFormFields | keyof UpdateAgentFormFields;
 
 type Props = {
-  fields: AgentFormFields;
+  fields: CreateAgentFormFields | UpdateAgentFormFields;
   onChange: (key: Omit<AgentFormFieldKeys, 'tools'>, value: string) => void;
   onToolToggle: (toolName: string, checked: boolean) => void;
   errors?: Partial<Record<AgentFormFieldKeys, string>>;

--- a/src/interfaces/coral_web/src/components/Agents/CreateAgentForm.tsx
+++ b/src/interfaces/coral_web/src/components/Agents/CreateAgentForm.tsx
@@ -1,7 +1,11 @@
 import { useRouter } from 'next/router';
 import React, { useContext, useState } from 'react';
 
-import { AgentForm, AgentFormFieldKeys, AgentFormFields } from '@/components/Agents/AgentForm';
+import {
+  AgentForm,
+  AgentFormFieldKeys,
+  CreateAgentFormFields,
+} from '@/components/Agents/AgentForm';
 import { Button, Text } from '@/components/Shared';
 import { DEFAULT_AGENT_MODEL, DEPLOYMENT_COHERE_PLATFORM } from '@/constants';
 import { ModalContext } from '@/context/ModalContext';
@@ -19,7 +23,7 @@ export const CreateAgentForm: React.FC = () => {
   const { addRecentAgentId } = useRecentAgents();
   const isAgentNameUnique = useIsAgentNameUnique();
   const [isSubmitting, setIsSubmitting] = useState(false);
-  const [fields, setFields] = useState<AgentFormFields>({
+  const [fields, setFields] = useState<CreateAgentFormFields>({
     name: '',
     description: '',
     preamble: '',

--- a/src/interfaces/coral_web/src/components/Agents/UpdateAgentPanel.tsx
+++ b/src/interfaces/coral_web/src/components/Agents/UpdateAgentPanel.tsx
@@ -1,6 +1,10 @@
 import React, { useEffect, useState } from 'react';
 
-import { AgentForm, AgentFormFieldKeys, AgentFormFields } from '@/components/Agents/AgentForm';
+import {
+  AgentForm,
+  AgentFormFieldKeys,
+  UpdateAgentFormFields,
+} from '@/components/Agents/AgentForm';
 import { IconButton } from '@/components/IconButton';
 import { Banner, Button, Spinner, Text } from '@/components/Shared';
 import { useAgent, useIsAgentNameUnique, useUpdateAgent } from '@/hooks/agents';
@@ -21,7 +25,7 @@ export const UpdateAgentPanel: React.FC<Props> = ({ agentId }) => {
   const { mutateAsync: updateAgent } = useUpdateAgent();
   const isAgentNameUnique = useIsAgentNameUnique();
   const [isSubmitting, setIsSubmitting] = useState(false);
-  const [fields, setFields] = useState<AgentFormFields>({
+  const [fields, setFields] = useState<UpdateAgentFormFields>({
     name: '',
     description: '',
     deployment: '',
@@ -40,7 +44,9 @@ export const UpdateAgentPanel: React.FC<Props> = ({ agentId }) => {
   };
 
   const fieldErrors = {
-    ...(isAgentNameUnique(fields.name, agentId) ? {} : { name: 'Assistant name must be unique' }),
+    ...(isAgentNameUnique(fields.name ?? '', agentId)
+      ? {}
+      : { name: 'Assistant name must be unique' }),
   };
 
   const canSubmit = (() => {

--- a/src/interfaces/coral_web/src/hooks/agents.ts
+++ b/src/interfaces/coral_web/src/hooks/agents.ts
@@ -3,7 +3,7 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { isNil } from 'lodash';
 import { useMemo } from 'react';
 
-import { Agent, CreateAgent, useCohereClient } from '@/cohere-client';
+import { Agent, CreateAgent, UpdateAgent, useCohereClient } from '@/cohere-client';
 import { LOCAL_STORAGE_KEYS } from '@/constants';
 
 export const useListAgents = () => {
@@ -68,7 +68,7 @@ export const useUpdateAgent = () => {
   const cohereClient = useCohereClient();
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: async (request: CreateAgent & { agentId: string }) => {
+    mutationFn: async (request: UpdateAgent & { agentId: string }) => {
       try {
         return await cohereClient.updateAgent(request);
       } catch (e) {


### PR DESCRIPTION
Thank you for contributing to the Cohere Toolkit!

- [ ] **PR title**: "area: description"
  - Where "area" is whichever of interface, frontend, model, tools, backend, etc. is being modified. Use "docs: ..." for purely docs changes, "infra: ..." for CI changes.
  - Example: "deployment: add Azure model option"


- [ ] **PR message**: ***Delete this entire checklist*** and replace with
    - **Description:** a description of the change
    - **Issue:** the issue # it fixes, if applicable
    - **Dependencies:** any dependencies required for this change


- [ ] **Add tests and docs**: Please include testing and documentation for your changes
- [ ] **Lint and test**: Run `make lint` and `make run-tests`

**AI Description**

<!-- begin-generated-description -->

This pull request introduces a new feature to generate a title for a conversation and update the conversation with the generated title. 

**Code Changes:**
- Added a new `GenerateTitle` type, which consists of a `title` field of type `string`.
- Modified the `DefaultService` class to include a new method, `generateTitleV1ConversationsConversationIdGenerateTitlePost`, which generates a title for a conversation.
- Updated the import statements in `DefaultService.ts` to include the new `GenerateTitle` model.
- Added `AgentToolMetadata` as an import and a new field in the `UpdateAgent` type.

<!-- end-generated-description -->
