### PR TITLE
fix(toolkit): refactor agent components to improve data flow and type-safety

### DIFF
--- a/src/interfaces/coral_web/src/cohere-client/generated/index.ts
+++ b/src/interfaces/coral_web/src/cohere-client/generated/index.ts
@@ -30,6 +30,7 @@ export type { DeleteUser } from './models/DeleteUser';
 export type { Deployment } from './models/Deployment';
 export type { Document } from './models/Document';
 export type { File } from './models/File';
+export type { GenerateTitle } from './models/GenerateTitle';
 export type { HTTPValidationError } from './models/HTTPValidationError';
 export type { JWTResponse } from './models/JWTResponse';
 export type { LangchainChatRequest } from './models/LangchainChatRequest';

--- a/src/interfaces/coral_web/src/cohere-client/generated/models/GenerateTitle.ts
+++ b/src/interfaces/coral_web/src/cohere-client/generated/models/GenerateTitle.ts
@@ -1,0 +1,7 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type GenerateTitle = {
+  title: string;
+};

--- a/src/interfaces/coral_web/src/cohere-client/generated/models/UpdateAgent.ts
+++ b/src/interfaces/coral_web/src/cohere-client/generated/models/UpdateAgent.ts
@@ -1,7 +1,12 @@
 /* generated using openapi-typescript-codegen -- do no edit */
+
 /* istanbul ignore file */
+
 /* tslint:disable */
+
 /* eslint-disable */
+import type { AgentToolMetadata } from './AgentToolMetadata';
+
 export type UpdateAgent = {
   name?: string | null;
   version?: number | null;
@@ -11,4 +16,5 @@ export type UpdateAgent = {
   model?: string | null;
   deployment?: string | null;
   tools?: Array<string> | null;
+  tools_metadata?: Array<AgentToolMetadata> | null;
 };

--- a/src/interfaces/coral_web/src/cohere-client/generated/services/DefaultService.ts
+++ b/src/interfaces/coral_web/src/cohere-client/generated/services/DefaultService.ts
@@ -174,7 +174,6 @@ export class DefaultService {
    * session (DBSessionDep): Database session.
    * chat_request (CohereChatRequest): Chat request data.
    * request (Request): Request object.
-   * agent_id (str | None): Agent ID.
    *
    * Returns:
    * EventSourceResponse: Server-sent event response with chatbot responses.
@@ -183,17 +182,12 @@ export class DefaultService {
    */
   public static chatStreamV1ChatStreamPost({
     requestBody,
-    agentId,
   }: {
     requestBody: CohereChatRequest;
-    agentId?: string | null;
   }): CancelablePromise<Array<ChatResponseEvent>> {
     return __request(OpenAPI, {
       method: 'POST',
       url: '/v1/chat-stream',
-      query: {
-        agent_id: agentId,
-      },
       body: requestBody,
       mediaType: 'application/json',
       errors: {
@@ -209,7 +203,6 @@ export class DefaultService {
    * chat_request (CohereChatRequest): Chat request data.
    * session (DBSessionDep): Database session.
    * request (Request): Request object.
-   * agent_id (str | None): Agent ID.
    *
    * Returns:
    * NonStreamedChatResponse: Chatbot response.
@@ -218,17 +211,12 @@ export class DefaultService {
    */
   public static chatV1ChatPost({
     requestBody,
-    agentId,
   }: {
     requestBody: CohereChatRequest;
-    agentId?: string | null;
   }): CancelablePromise<NonStreamedChatResponse> {
     return __request(OpenAPI, {
       method: 'POST',
       url: '/v1/chat',
-      query: {
-        agent_id: agentId,
-      },
       body: requestBody,
       mediaType: 'application/json',
       errors: {

--- a/src/interfaces/coral_web/src/cohere-client/generated/services/DefaultService.ts
+++ b/src/interfaces/coral_web/src/cohere-client/generated/services/DefaultService.ts
@@ -25,6 +25,7 @@ import type { DeleteFile } from '../models/DeleteFile';
 import type { DeleteUser } from '../models/DeleteUser';
 import type { Deployment } from '../models/Deployment';
 import type { File } from '../models/File';
+import type { GenerateTitle } from '../models/GenerateTitle';
 import type { JWTResponse } from '../models/JWTResponse';
 import type { LangchainChatRequest } from '../models/LangchainChatRequest';
 import type { ListAuthStrategy } from '../models/ListAuthStrategy';
@@ -694,6 +695,38 @@ export class DefaultService {
       path: {
         conversation_id: conversationId,
         file_id: fileId,
+      },
+      errors: {
+        422: `Validation Error`,
+      },
+    });
+  }
+  /**
+   * Generate Title
+   * Generate a title for a conversation and update the conversation with the generated title.
+   *
+   * Args:
+   * conversation_id (str): Conversation ID.
+   * session (DBSessionDep): Database session.
+   *
+   * Returns:
+   * str: Generated title for the conversation.
+   *
+   * Raises:
+   * HTTPException: If the conversation with the given ID is not found.
+   * @returns GenerateTitle Successful Response
+   * @throws ApiError
+   */
+  public static generateTitleV1ConversationsConversationIdGenerateTitlePost({
+    conversationId,
+  }: {
+    conversationId: string;
+  }): CancelablePromise<GenerateTitle> {
+    return __request(OpenAPI, {
+      method: 'POST',
+      url: '/v1/conversations/{conversation_id}/generate-title',
+      path: {
+        conversation_id: conversationId,
       },
       errors: {
         422: `Validation Error`,

--- a/src/interfaces/coral_web/src/components/Agents/AgentForm.tsx
+++ b/src/interfaces/coral_web/src/components/Agents/AgentForm.tsx
@@ -1,6 +1,6 @@
 import React, { useMemo } from 'react';
 
-import { CreateAgent } from '@/cohere-client';
+import { CreateAgent, UpdateAgent } from '@/cohere-client';
 import { AgentToolFielPicker } from '@/components/Agents/AgentToolFielPicker';
 import { Checkbox, Input, InputLabel, STYLE_LEVEL_TO_CLASSES, Text } from '@/components/Shared';
 import { DEFAULT_AGENT_TOOLS, TOOL_GOOGLE_DRIVE_ID } from '@/constants';
@@ -8,15 +8,13 @@ import { useListTools } from '@/hooks/tools';
 import { GoogleDriveToolArtifact } from '@/types/tools';
 import { cn } from '@/utils';
 
-export type AgentFormFields = Omit<CreateAgent, 'version' | 'temperature'>;
-export type AgentFormFieldKeys = keyof AgentFormFields;
+export type CreateAgentFormFields = Omit<CreateAgent, 'version' | 'temperature'>;
+export type UpdateAgentFormFields = Omit<UpdateAgent, 'version' | 'temperature'>;
+export type AgentFormFieldKeys = keyof CreateAgentFormFields | keyof UpdateAgentFormFields;
 
-type Props = {
-  fields: AgentFormFields;
-  onChange: <AgentFormFieldKeys extends keyof AgentFormFields>(
-    key: AgentFormFieldKeys,
-    value: AgentFormFields[AgentFormFieldKeys]
-  ) => void;
+type Props<K extends UpdateAgentFormFields | CreateAgentFormFields> = {
+  fields: K;
+  setFields: React.Dispatch<React.SetStateAction<K>>;
   onToolToggle: (toolName: string, checked: boolean, authUrl?: string) => void;
   handleOpenFilePicker: VoidFunction;
   errors?: Partial<Record<AgentFormFieldKeys, string>>;
@@ -26,15 +24,15 @@ type Props = {
 /**
  * @description Base form for creating/updating an agent.
  */
-export const AgentForm: React.FC<Props> = ({
+export function AgentForm<K extends CreateAgentFormFields | UpdateAgentFormFields>({
   fields,
-  onChange,
+  setFields,
   onToolToggle,
   handleOpenFilePicker,
   errors,
   disabled,
   className,
-}) => {
+}: Props<K>) {
   const { data: toolsData } = useListTools();
   const tools =
     toolsData?.filter((t) => t.is_available && !DEFAULT_AGENT_TOOLS.includes(t.name)) ?? [];
@@ -44,20 +42,17 @@ export const AgentForm: React.FC<Props> = ({
       []) as GoogleDriveToolArtifact[];
   }, [fields]);
 
-  const setGoogleDriveFiles = (files: GoogleDriveToolArtifact[]) => {
-    if (files.length === 0) {
-      onChange('tools_metadata', [
-        ...(fields.tools_metadata ?? []).filter((t) => t.tool_name !== TOOL_GOOGLE_DRIVE_ID),
-      ]);
-      return;
-    }
-    onChange('tools_metadata', [
-      ...(fields.tools_metadata ?? []).filter((t) => t.tool_name !== TOOL_GOOGLE_DRIVE_ID),
-      {
-        tool_name: TOOL_GOOGLE_DRIVE_ID,
-        artifacts: files,
-      },
-    ]);
+  const handleRemoveGoogleDriveFiles = (id: string) => {
+    setFields((prev) => ({
+      ...prev,
+      tools_metadata: [
+        ...(prev.tools_metadata?.filter((tool) => tool.tool_name !== TOOL_GOOGLE_DRIVE_ID) ?? []),
+        {
+          ...prev.tools_metadata?.find((tool) => tool.tool_name === TOOL_GOOGLE_DRIVE_ID),
+          artifacts: googleDrivefiles.filter((file) => file.id !== id),
+        },
+      ],
+    }));
   };
 
   return (
@@ -67,7 +62,7 @@ export const AgentForm: React.FC<Props> = ({
           kind="default"
           value={fields.name ?? ''}
           placeholder="Give your assistant a name"
-          onChange={(e) => onChange('name', e.target.value)}
+          onChange={(e) => setFields((prev) => ({ ...prev, name: e.target.value }))}
           hasError={!!errors?.name}
           errorText={errors?.name}
           disabled={disabled}
@@ -78,7 +73,7 @@ export const AgentForm: React.FC<Props> = ({
           kind="default"
           value={fields.description ?? ''}
           placeholder="What does your assistant do?"
-          onChange={(e) => onChange('description', e.target.value)}
+          onChange={(e) => setFields((prev) => ({ ...prev, description: e.target.value }))}
           disabled={disabled}
         />
       </InputLabel>
@@ -100,7 +95,7 @@ export const AgentForm: React.FC<Props> = ({
             STYLE_LEVEL_TO_CLASSES.p
           )}
           rows={5}
-          onChange={(e) => onChange('preamble', e.target.value)}
+          onChange={(e) => setFields((prev) => ({ ...prev, preamble: e.target.value }))}
           data-testid="input-preamble"
           disabled={disabled}
         />
@@ -130,7 +125,7 @@ export const AgentForm: React.FC<Props> = ({
                   <div className="pl-10">
                     <AgentToolFielPicker
                       googleDriveFiles={googleDrivefiles}
-                      setGoogleDriveFiles={setGoogleDriveFiles}
+                      handleRemoveGoogleDriveFiles={handleRemoveGoogleDriveFiles}
                       handleOpenFilePicker={handleOpenFilePicker}
                     />
                   </div>
@@ -142,7 +137,7 @@ export const AgentForm: React.FC<Props> = ({
       </div>
     </div>
   );
-};
+}
 
 const RequiredInputLabel: React.FC<{
   label: string;

--- a/src/interfaces/coral_web/src/components/Agents/AgentForm.tsx
+++ b/src/interfaces/coral_web/src/components/Agents/AgentForm.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo } from 'react';
 
 import { CreateAgent, UpdateAgent } from '@/cohere-client';
-import { AgentToolFielPicker } from '@/components/Agents/AgentToolFielPicker';
+import { AgentToolFilePicker } from '@/components/Agents/AgentToolFilePicker';
 import { Checkbox, Input, InputLabel, STYLE_LEVEL_TO_CLASSES, Text } from '@/components/Shared';
 import { DEFAULT_AGENT_TOOLS, TOOL_GOOGLE_DRIVE_ID } from '@/constants';
 import { useListTools } from '@/hooks/tools';
@@ -123,7 +123,7 @@ export function AgentForm<K extends CreateAgentFormFields | UpdateAgentFormField
                 />
                 {isGoogleDrive && checked && (
                   <div className="pl-10">
-                    <AgentToolFielPicker
+                    <AgentToolFilePicker
                       googleDriveFiles={googleDrivefiles}
                       handleRemoveGoogleDriveFiles={handleRemoveGoogleDriveFiles}
                       handleOpenFilePicker={handleOpenFilePicker}

--- a/src/interfaces/coral_web/src/components/Agents/AgentToolFielPicker.tsx
+++ b/src/interfaces/coral_web/src/components/Agents/AgentToolFielPicker.tsx
@@ -4,18 +4,14 @@ import { GoogleDriveToolArtifact } from '@/types/tools';
 
 type Props = {
   googleDriveFiles?: GoogleDriveToolArtifact[];
-  setGoogleDriveFiles: (files: GoogleDriveToolArtifact[]) => void;
+  handleRemoveGoogleDriveFiles: (id: string) => void;
   handleOpenFilePicker: VoidFunction;
 };
 export const AgentToolFielPicker: React.FC<Props> = ({
   googleDriveFiles,
-  setGoogleDriveFiles,
+  handleRemoveGoogleDriveFiles,
   handleOpenFilePicker,
 }) => {
-  const handleRemoveFile = (id: string) => {
-    setGoogleDriveFiles(googleDriveFiles?.filter((file) => file.id !== id) ?? []);
-  };
-
   return (
     <div className="flex max-w-[300px] flex-col gap-y-2">
       <Button
@@ -38,7 +34,7 @@ export const AgentToolFielPicker: React.FC<Props> = ({
                 {name}
               </Text>
               <IconButton
-                onClick={() => handleRemoveFile(id)}
+                onClick={() => handleRemoveGoogleDriveFiles(id)}
                 iconName="close"
                 size="sm"
                 className="ml-auto"

--- a/src/interfaces/coral_web/src/components/Agents/AgentToolFilePicker.tsx
+++ b/src/interfaces/coral_web/src/components/Agents/AgentToolFilePicker.tsx
@@ -7,7 +7,7 @@ type Props = {
   handleRemoveGoogleDriveFiles: (id: string) => void;
   handleOpenFilePicker: VoidFunction;
 };
-export const AgentToolFielPicker: React.FC<Props> = ({
+export const AgentToolFilePicker: React.FC<Props> = ({
   googleDriveFiles,
   handleRemoveGoogleDriveFiles,
   handleOpenFilePicker,

--- a/src/interfaces/coral_web/src/components/Agents/CreateAgent.tsx
+++ b/src/interfaces/coral_web/src/components/Agents/CreateAgent.tsx
@@ -117,12 +117,15 @@ export const CreateAgent: React.FC = () => {
   };
 
   useEffect(() => {
-    if (pendingAssistant) {
-      console.log(pendingAssistant);
-      setFields(pendingAssistant);
-      removePendingAssistant();
+    if (router.query.p) {
+      if (pendingAssistant) {
+        setFields(pendingAssistant);
+        removePendingAssistant();
+      }
+
+      window.history.replaceState(null, '', router.basePath + router.pathname);
     }
-  }, [pendingAssistant]);
+  }, [router.query.p]);
 
   const handleOpenSubmitModal = () => {
     open({

--- a/src/interfaces/coral_web/src/components/Agents/CreateAgent.tsx
+++ b/src/interfaces/coral_web/src/components/Agents/CreateAgent.tsx
@@ -1,8 +1,8 @@
-import { useSessionStorageValue } from '@react-hookz/web';
+import { useLocalStorageValue } from '@react-hookz/web';
 import { useRouter } from 'next/router';
 import React, { useContext, useEffect, useState } from 'react';
 
-import { AgentForm, AgentFormFields } from '@/components/Agents/AgentForm';
+import { AgentForm, CreateAgentFormFields } from '@/components/Agents/AgentForm';
 import { Button, Text } from '@/components/Shared';
 import {
   DEFAULT_AGENT_MODEL,
@@ -35,8 +35,7 @@ export const CreateAgent: React.FC = () => {
     value: pendingAssistant,
     set: setPendingAssistant,
     remove: removePendingAssistant,
-  } = useSessionStorageValue<AgentFormFields>('pending_assistant', {
-    defaultValue: DEFAULT_FIELD_VALUES,
+  } = useLocalStorageValue<CreateAgentFormFields>('pending_assistant', {
     initializeWithValue: false,
   });
 
@@ -46,7 +45,7 @@ export const CreateAgent: React.FC = () => {
   const { addRecentAgentId } = useRecentAgents();
   const isAgentNameUnique = useIsAgentNameUnique();
   const [isSubmitting, setIsSubmitting] = useState(false);
-  const [fields, setFields] = useState<AgentFormFields>(DEFAULT_FIELD_VALUES);
+  const [fields, setFields] = useState<CreateAgentFormFields>(DEFAULT_FIELD_VALUES);
 
   const openFilePicker = useOpenGoogleDrivePicker((data) => {
     if (data.docs) {
@@ -83,16 +82,6 @@ export const CreateAgent: React.FC = () => {
     return Object.values(requredFields).every(Boolean) && !Object.keys(fieldErrors).length;
   })();
 
-  const handleChange = <AgentFormFieldKeys extends keyof AgentFormFields>(
-    key: AgentFormFieldKeys,
-    value: AgentFormFields[AgentFormFieldKeys]
-  ) => {
-    setFields((prev) => ({
-      ...prev,
-      [key]: value,
-    }));
-  };
-
   const handleToolToggle = (toolName: string, checked: boolean, authUrl?: string) => {
     const enabledTools = [...(fields.tools ? fields.tools : [])];
 
@@ -128,15 +117,12 @@ export const CreateAgent: React.FC = () => {
   };
 
   useEffect(() => {
-    if (router.query.p) {
-      if (pendingAssistant) {
-        setFields(pendingAssistant);
-        removePendingAssistant();
-      }
-
-      window.history.replaceState(null, '', router.basePath + router.pathname);
+    if (pendingAssistant) {
+      console.log(pendingAssistant);
+      setFields(pendingAssistant);
+      removePendingAssistant();
     }
-  }, [router.query.p]);
+  }, [pendingAssistant]);
 
   const handleOpenSubmitModal = () => {
     open({
@@ -179,9 +165,9 @@ export const CreateAgent: React.FC = () => {
           <Text className="text-volcanic-700">
             Create an unique assistant and share with your org
           </Text>
-          <AgentForm
+          <AgentForm<CreateAgentFormFields>
             fields={fields}
-            onChange={handleChange}
+            setFields={setFields}
             onToolToggle={handleToolToggle}
             handleOpenFilePicker={openFilePicker}
             errors={fieldErrors}

--- a/src/interfaces/coral_web/src/components/Agents/UpdateAgent.tsx
+++ b/src/interfaces/coral_web/src/components/Agents/UpdateAgent.tsx
@@ -57,8 +57,7 @@ export const UpdateAgent: React.FC<Props> = ({ agentId }) => {
           return {
             ...prev,
             tools_metadata: [
-              ...(prev.tools_metadata?.filter((tool) => tool.tool_name !== TOOL_GOOGLE_DRIVE_ID) ??
-                []),
+              ...(prev.tools_metadata ?? []),
               {
                 tool_name: TOOL_GOOGLE_DRIVE_ID,
                 user_id: userId,
@@ -180,7 +179,6 @@ export const UpdateAgent: React.FC<Props> = ({ agentId }) => {
       setIsSubmitting(true);
       const newAgent = await updateAgent({
         ...fields,
-        // tools_metadata: [{ tool_name: TOOL_GOOGLE_DRIVE_ID, artifacts: googleDriveFiles ?? [] }],
         agentId,
       });
       setIsSubmitting(false);

--- a/src/interfaces/coral_web/src/components/Agents/UpdateAgent.tsx
+++ b/src/interfaces/coral_web/src/components/Agents/UpdateAgent.tsx
@@ -231,7 +231,7 @@ export const UpdateAgent: React.FC<Props> = ({ agentId }) => {
         />
       </div>
       {isAgentCreator && (
-        <div className="flex flex-col gap-y-12 px-8 py-4 md:px-14 md:pb-8 md:pt-0">
+        <div className="flex flex-col gap-y-6 px-8 py-4 md:px-14 md:pb-8 md:pt-0">
           <InfoBanner agentName={agent.name} className="hidden md:flex" />
           <Button
             className="self-end"

--- a/src/interfaces/coral_web/src/components/Agents/UpdateAgent.tsx
+++ b/src/interfaces/coral_web/src/components/Agents/UpdateAgent.tsx
@@ -56,23 +56,27 @@ export const UpdateAgent: React.FC<Props> = ({ agentId }) => {
         if (!currentGoogleDriveTool) {
           return {
             ...prev,
-            tools_metadata: [
-              ...(prev.tools_metadata ?? []),
-              {
-                tool_name: TOOL_GOOGLE_DRIVE_ID,
-                user_id: userId,
-                artifacts: data.docs.map(
-                  (doc) =>
-                    ({
-                      id: doc.id,
-                      name: doc.name,
-                      type: doc.type,
-                      url: doc.url,
-                    } as GoogleDriveToolArtifact)
-                ),
-              },
-            ],
           };
+          // FIX(@knajjars): uncomment this once the backend is ready
+          // return {
+          //   ...prev,
+          //   tools_metadata: [
+          //     ...(prev.tools_metadata ?? []),
+          //     {
+          //       tool_name: TOOL_GOOGLE_DRIVE_ID,
+          //       user_id: userId,
+          //       artifacts: data.docs.map(
+          //         (doc) =>
+          //           ({
+          //             id: doc.id,
+          //             name: doc.name,
+          //             type: doc.type,
+          //             url: doc.url,
+          //           } as GoogleDriveToolArtifact)
+          //       ),
+          //     },
+          //   ],
+          // };
         }
         // If the tool is already enabled, update the artifacts
         const updateGoogleDriveTool: AgentToolMetadata = {


### PR DESCRIPTION
This PR refactors the way `<CreateAgent />` and `<UpdateAgent />` use `<AgentForm />` by improving type-safety using generics for `fields` and `setFields` instead of using a `onChange` handler.

Additionally prepares for updating the agents tools artifacts https://github.com/cohere-ai/cohere-toolkit/pull/340


**AI Description**


This PR introduces the `GenerateTitle` type and the corresponding `generateTitleV1ConversationsConversationIdGenerateTitlePost` method in the `DefaultService` class. It also updates the `UpdateAgent` type and related components.

- Adds the `GenerateTitle` type, which consists of a `title` field of type `string`.
- Implements the `generateTitleV1ConversationsConversationIdGenerateTitlePost` method in the `DefaultService` class. This method generates a title for a conversation and updates the conversation with the generated title. It takes the conversation ID and a database session as arguments and returns the generated title.
- Updates the `UpdateAgent` type to include a new field, `tools_metadata`, which is an optional array of `AgentToolMetadata`.
- Modifies the `AgentForm` component to support both creating and updating an agent. It now accepts `CreateAgentFormFields` or `UpdateAgentFormFields` as props.
- Renames `AgentFormFields` to `CreateAgentFormFields` in `CreateAgent.tsx`.
- Updates the `UpdateAgent` component to use `UpdateAgentFormFields` instead of `AgentFormFields`.
- Changes the `handleChange` function in `UpdateAgent.tsx` to `handleToolToggle`.
- Refactors the logic for setting Google Drive files in the `AgentToolFielPicker` component. The `setGoogleDriveFiles` prop is replaced with `handleRemoveGoogleDriveFiles`, and the `handleRemoveFile` function is removed.

