### PR TITLE
Agent: fix update metadata

### DIFF
--- a/src/backend/schemas/agent.py
+++ b/src/backend/schemas/agent.py
@@ -21,6 +21,8 @@ class CreateAgentToolMetadata(BaseModel):
 
 
 class UpdateAgentToolMetadata(BaseModel):
+    id: Optional[str] = None
+    tool_name: Optional[str] = None
     artifacts: Optional[list[dict]] = None
 
 
@@ -74,7 +76,7 @@ class UpdateAgent(BaseModel):
     model: Optional[str] = None
     deployment: Optional[str] = None
     tools: Optional[list[str]] = None
-    tools_metadata: Optional[list[AgentToolMetadata]] = None
+    tools_metadata: Optional[list[UpdateAgentToolMetadata]] = None
 
     class Config:
         from_attributes = True

--- a/src/backend/tests/routers/test_agent.py
+++ b/src/backend/tests/routers/test_agent.py
@@ -86,7 +86,6 @@ def test_create_agent_with_tool_metadata(
     response = session_client.post(
         "/v1/agents", json=request_json, headers={"User-Id": "123"}
     )
-    print(response.json())
     assert response.status_code == 200
     response_agent = response.json()
 
@@ -463,6 +462,130 @@ def test_update_agent_with_tool_metadata(
     assert tool_metadata[0].artifacts == [
         {"url": "test", "name": "test", "type": "folder"}
     ]
+
+
+def test_update_agent_with_tool_metadata_and_new_tool_metadata(
+    session_client: TestClient, session: Session
+) -> None:
+    agent = get_factory("Agent", session).create(
+        name="test agent",
+        version=1,
+        description="test description",
+        preamble="test preamble",
+        temperature=0.5,
+        model="command-r-plus",
+        deployment=ModelDeploymentName.CoherePlatform,
+        user_id="123",
+    )
+    agent_tool_metadata = get_factory("AgentToolMetadata", session).create(
+        agent_id=agent.id,
+        tool_name=ToolName.Google_Drive,
+        artifacts=[
+            {
+                "url": "test",
+                "name": "test",
+                "type": "folder",
+            },
+        ],
+    )
+
+    request_json = {
+        "tools_metadata": [
+            {
+                "user_id": "123",
+                "organization_id": None,
+                "id": agent_tool_metadata.id,
+                "tool_name": "google_drive",
+                "artifacts": [
+                    {
+                        "url": "test",
+                        "name": "test",
+                        "type": "folder",
+                    }
+                ],
+            },
+            {
+                "tool_name": "search_file",
+                "artifacts": [
+                    {
+                        "url": "test",
+                        "name": "test",
+                        "type": "file",
+                    }
+                ],
+            },
+        ],
+    }
+
+    response = session_client.put(
+        f"/v1/agents/{agent.id}",
+        json=request_json,
+        headers={"User-Id": "123"},
+    )
+
+    assert response.status_code == 200
+    updated_agent = response.json()
+
+    tool_metadata = (
+        session.query(AgentToolMetadata)
+        .filter(AgentToolMetadata.agent_id == agent.id)
+        .all()
+    )
+    assert len(tool_metadata) == 2
+    assert tool_metadata[0].tool_name == "google_drive"
+    assert tool_metadata[0].artifacts == [
+        {"url": "test", "name": "test", "type": "folder"}
+    ]
+    assert tool_metadata[1].tool_name == "search_file"
+    assert tool_metadata[1].artifacts == [
+        {"url": "test", "name": "test", "type": "file"}
+    ]
+
+
+def test_update_agent_remove_existing_tool_metadata(
+    session_client: TestClient, session: Session
+) -> None:
+    agent = get_factory("Agent", session).create(
+        name="test agent",
+        version=1,
+        description="test description",
+        preamble="test preamble",
+        temperature=0.5,
+        model="command-r-plus",
+        deployment=ModelDeploymentName.CoherePlatform,
+        user_id="123",
+    )
+    agent_tool_metadata = get_factory("AgentToolMetadata", session).create(
+        agent_id=agent.id,
+        tool_name=ToolName.Google_Drive,
+        artifacts=[
+            {
+                "url": "test",
+                "name": "test",
+                "type": "folder",
+            },
+        ],
+    )
+
+    request_json = {
+        "tools_metadata": [],
+    }
+
+    response = session_client.put(
+        f"/v1/agents/{agent.id}",
+        json=request_json,
+        headers={"User-Id": "123"},
+    )
+
+    assert response.status_code == 200
+    updated_agent = response.json()
+
+    tool_metadata = (
+        session.query(AgentToolMetadata)
+        .filter(AgentToolMetadata.agent_id == agent.id)
+        .all()
+    )
+    assert len(tool_metadata) == 0
 
 
 def test_update_nonexistent_agent(session_client: TestClient, session: Session) -> None:


### PR DESCRIPTION
Fix reported bugs:
- Error when sending empty metadata -> now all elements are deleted
- Other fields not updated when there was metadata -> now everything is updated correctly
- Error when there was no ID -> now a new instance is added when there's no ID

**AI Description**

<!-- begin-generated-description -->

The PR introduces changes to the agent management functionality, specifically enhancing the creation and updating of agents and their associated tool metadata.

## Summary
- The `update_agent` function in `src/backend/routers/agent.py` has been modified to handle tool metadata updates more efficiently.
- New test cases have been added in `src/backend/tests/routers/test_agent.py` to validate the updated agent creation and updating behavior, including scenarios with new and existing tool metadata.
- The `UpdateAgentToolMetadata` class in `src/backend/schemas/agent.py` has been updated to include optional `id` and `tool_name` fields.

## Detailed Changes
- **src/backend/routers/agent.py**:
   - The `psycopg2` module is imported.
   - The `update_agent` function now checks if `new_agent.tools_metadata` is not None before proceeding with tool metadata updates.
   - Tool metadata that are not included in the request are deleted using `agent_tool_metadata_crud.delete_agent_tool_metadata_by_id`.
   - The code creates or updates tool metadata from the request using a try-except block and the `update_or_create_tool_metadata` function.
   - If a `UniqueViolation` error occurs during tool metadata updates, an `HTTPException` is raised with a status code of 400 and an appropriate error message.
   - The `tools_metadata` attribute is removed from `new_agent` before updating the agent to avoid unintentional updates.
   - The `update_agent` function now calls `agent_crud.update_agent` to update the agent and sets `request.state.agent` to the updated agent.
- **src/backend/schemas/agent.py**:
   - The `UpdateAgentToolMetadata` class now includes optional `id` and `tool_name` fields, both of type `Optional [str]`.
- **src/backend/tests/routers/test_agent.py**:
   - A new test case, `test_update_agent_with_tool_metadata_and_new_tool_metadata`, has been added to test agent updates with new tool metadata.
   - Another new test case, `test_update_agent_remove_existing_tool_metadata`, verifies the removal of existing tool metadata during agent updates.

<!-- end-generated-description -->
