### PR TITLE
coral-web: filter conversations for default assistant

### DIFF
--- a/src/interfaces/coral_web/src/hooks/conversation.tsx
+++ b/src/interfaces/coral_web/src/hooks/conversation.tsx
@@ -22,8 +22,16 @@ export const useConversations = (params: { offset?: number; limit?: number; agen
   const client = useCohereClient();
 
   return useQuery<ConversationWithoutMessages[], ApiError>({
-    queryKey: ['conversations'],
-    queryFn: async () => client.listConversations(params),
+    queryKey: ['conversations', params.agentId],
+    queryFn: async () => {
+      const conversations = await client.listConversations(params);
+
+      if (params.agentId) {
+        return conversations;
+      }
+
+      return conversations.filter((c) => c.agent_id === null);
+    },
     retry: 0,
     refetchOnWindowFocus: false,
     initialData: [],


### PR DESCRIPTION
**Description:**

We aren't properly filtering conversations for the default agent, which has an id of `null`. We should also add the `agentId` to the query key for better caching.

https://github.com/cohere-ai/cohere-toolkit/assets/5898755/eb48fcce-8f3d-4f25-a061-81f2bfba847c

**AI Description**

<!-- begin-generated-description -->

The pull request makes changes to the `useConversations` hook in the `conversation.tsx` file. 

## Summary
The changes in this PR update the `queryKey and `queryFn` options used by the `useQuery` hook in the `useConversations` hook. The `queryKey` now includes the `params.agentId`, and the `queryFn` has been modified to filter conversations based on the provided `agentId`.

## Changes
- The `queryKey` now includes `['conversations', params.agentId]` instead of just `['conversations'].
- The `queryFn` now uses the `params.agentId` to filter the conversations returned by the `client.listConversations(params)` function.
- If `params.agentId` is not provided, the conversations with a `null` `agent_id` are returned.

<!-- end-generated-description -->
