### PR TITLE
Metrics: fix error when data is None and improve logger

### DIFF
--- a/src/backend/services/metrics.py
+++ b/src/backend/services/metrics.py
@@ -175,8 +175,7 @@ class MetricsMiddleware(BaseHTTPMiddleware):
 
 async def report_metrics(data: MetricsData) -> None:
     if not data:
-        logger.error("No metrics data to report")
-        return
+        raise ValueError("No metrics data to report")
 
     data = attach_secret(data)
     signal = MetricsSignal(signal=data)
@@ -184,6 +183,7 @@ async def report_metrics(data: MetricsData) -> None:
     if not REPORT_SECRET:
         logger.error("No report secret set")
         return
+    
     if not REPORT_ENDPOINT:
         logger.error("No report endpoint set")
         return

--- a/src/backend/services/metrics.py
+++ b/src/backend/services/metrics.py
@@ -32,6 +32,7 @@ HEALTH_ENDPOINT = "health"
 HEALTH_ENDPOINT_USER_ID = "health"
 
 logger = logging.getLogger(__name__)
+logger.setLevel(logging.ERROR)
 
 
 class MetricsMiddleware(BaseHTTPMiddleware):

--- a/src/backend/services/metrics.py
+++ b/src/backend/services/metrics.py
@@ -32,7 +32,6 @@ HEALTH_ENDPOINT = "health"
 HEALTH_ENDPOINT_USER_ID = "health"
 
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.ERROR)
 
 
 class MetricsMiddleware(BaseHTTPMiddleware):

--- a/src/backend/services/metrics.py
+++ b/src/backend/services/metrics.py
@@ -183,7 +183,7 @@ async def report_metrics(data: MetricsData) -> None:
     if not REPORT_SECRET:
         logger.error("No report secret set")
         return
-    
+
     if not REPORT_ENDPOINT:
         logger.error("No report endpoint set")
         return


### PR DESCRIPTION
Thank you for contributing to the Cohere Toolkit!

- [ ] **PR title**: "area: description"
  - Where "area" is whichever of interface, frontend, model, tools, backend, etc. is being modified. Use "docs: ..." for purely docs changes, "infra: ..." for CI changes.
  - Example: "deployment: add Azure model option"


- [ ] **PR message**: ***Delete this entire checklist*** and replace with
    - **Description:** a description of the change
    - **Issue:** the issue # it fixes, if applicable
    - **Dependencies:** any dependencies required for this change


- [ ] **Add tests and docs**: Please include testing and documentation for your changes
- [ ] **Lint and test**: Run `make lint` and `make run-tests`

**AI Description**

<!-- begin-generated-description -->

The pull request makes changes to the `metrics.py` file in the backend services of a Python application. The modifications aim to improve error handling, logging, and asynchronous operations related to metrics collection and reporting.

Here's a summary of the changes:
- Added imports for `get_header_user_id` and `logging` modules.
- Introduced a logger instance with the error-level severity.
- Modified the `dispatch` method to use `await` with `run_loop` to ensure asynchronous execution.
- Updated the `get_event_data` method to use a `try-except` block for obtaining the `user_id` using `get_header_user_id`. It also logs a warning if getting the user ID fails.
- Refactored multiple methods (`get_method`, `get_endpoint_name`, `get_status_code`, `get_success`, `get_user_id`, `get_user`, `get_object_ids`, and `get_agent') to log warnings using the logger instance instead of `logging`.
- Added a check in the `report_metrics` method to ensure that metrics data is not empty before proceeding with reporting.
- Modified the `report_metrics` method to use the logger instance for error logging instead of `logging`.
- Updated the `run_loop` method to be an asynchronous function, including error handling using `task_exception_handler` to catch and log exceptions.
- Modified the `collect_metrics_chat_stream` and `collect_metrics_rerank` decorators to use the `await` keyword with `run_loop` to ensure asynchronous execution.

<!-- end-generated-description -->
