### PR TITLE
coral-web: show loading text when tool events are still streaming in

### DIFF
--- a/src/interfaces/coral_web/src/components/Conversation/MessagingContainer.tsx
+++ b/src/interfaces/coral_web/src/components/Conversation/MessagingContainer.tsx
@@ -16,6 +16,7 @@ import { cn } from '@/utils';
 
 type Props = {
   isStreaming: boolean;
+  isStreamingToolEvents: boolean;
   startOptionsEnabled: boolean;
   messages: ChatMessage[];
   streamingMessage: StreamingMessage | null;
@@ -166,7 +167,7 @@ type MessagesProps = Props;
  * This component is in charge of rendering the messages.
  */
 const Messages = forwardRef<HTMLDivElement, MessagesProps>(function MessagesInternal(
-  { onRetry, messages, streamingMessage, agentId },
+  { onRetry, messages, streamingMessage, agentId, isStreamingToolEvents },
   ref
 ) {
   const isChatEmpty = messages.length === 0;
@@ -189,6 +190,7 @@ const Messages = forwardRef<HTMLDivElement, MessagesProps>(function MessagesInte
               key={i}
               message={m}
               isLast={isLastInList && !streamingMessage}
+              isStreamingToolEvents={isStreamingToolEvents}
               className={cn({
                 // Hide the last message if it is the same as the separate streamed message
                 // to avoid a flash of duplicate messages.
@@ -205,7 +207,14 @@ const Messages = forwardRef<HTMLDivElement, MessagesProps>(function MessagesInte
         })}
       </div>
 
-      {streamingMessage && <MessageRow isLast message={streamingMessage} onRetry={onRetry} />}
+      {streamingMessage && (
+        <MessageRow
+          isLast
+          isStreamingToolEvents={isStreamingToolEvents}
+          message={streamingMessage}
+          onRetry={onRetry}
+        />
+      )}
     </div>
   );
 });

--- a/src/interfaces/coral_web/src/components/Conversation/index.tsx
+++ b/src/interfaces/coral_web/src/components/Conversation/index.tsx
@@ -72,6 +72,7 @@ const Conversation: React.FC<Props> = ({
   const {
     userMessage,
     isStreaming,
+    isStreamingToolEvents,
     streamingMessage,
     setUserMessage,
     handleSend: send,
@@ -164,6 +165,7 @@ const Conversation: React.FC<Props> = ({
             conversationId={conversationId}
             startOptionsEnabled={startOptionsEnabled}
             isStreaming={isStreaming}
+            isStreamingToolEvents={isStreamingToolEvents}
             onRetry={handleRetry}
             messages={messages}
             streamingMessage={streamingMessage}

--- a/src/interfaces/coral_web/src/components/MessageRow.tsx
+++ b/src/interfaces/coral_web/src/components/MessageRow.tsx
@@ -16,6 +16,7 @@ import {
 import { ToolEvents } from '@/components/ToolEvents';
 import { ReservedClasses } from '@/constants';
 import { Breakpoint, useBreakpoint } from '@/hooks/breakpoint';
+import { useChat } from '@/hooks/chat';
 import { getMessageRowId } from '@/hooks/citations';
 import { useCitationsStore } from '@/stores';
 import {
@@ -32,6 +33,7 @@ import { cn } from '@/utils';
 type Props = {
   isLast: boolean;
   message: ChatMessage;
+  isStreamingToolEvents: boolean;
   delay?: boolean;
   className?: string;
   onCopy?: VoidFunction;
@@ -42,7 +44,7 @@ type Props = {
  * Renders a single message row from the user or from our models.
  */
 const MessageRow = forwardRef<HTMLDivElement, Props>(function MessageRowInternal(
-  { message, delay = false, isLast, className = '', onCopy, onRetry },
+  { message, delay = false, isLast, isStreamingToolEvents, className = '', onCopy, onRetry },
   ref
 ) {
   const breakpoint = useBreakpoint();
@@ -174,7 +176,13 @@ const MessageRow = forwardRef<HTMLDivElement, Props>(function MessageRowInternal
           <Avatar message={message} />
           <div className="flex w-full min-w-0 max-w-message flex-1 flex-col items-center gap-x-3 md:flex-row">
             <div className="w-full">
-              {hasSteps && <ToolEvents show={isStepsExpanded} events={message.toolEvents} />}
+              {hasSteps && (
+                <ToolEvents
+                  show={isStepsExpanded}
+                  events={message.toolEvents}
+                  isStreaming={isStreamingToolEvents}
+                />
+              )}
 
               <MessageContent isLast={isLast} message={message} onRetry={onRetry} />
             </div>

--- a/src/interfaces/coral_web/src/components/ToolEvents.tsx
+++ b/src/interfaces/coral_web/src/components/ToolEvents.tsx
@@ -15,12 +15,13 @@ import { cn } from '@/utils';
 type Props = {
   show: boolean;
   events: StreamToolCallsGeneration[] | undefined;
+  isStreaming: boolean;
 };
 
 /**
  * @description Renders a list of events depending on the model's plan and tool inputs.
  */
-export const ToolEvents: React.FC<Props> = ({ show, events }) => {
+export const ToolEvents: React.FC<Props> = ({ show, events, isStreaming }) => {
   return (
     <Transition
       show={show}
@@ -40,6 +41,18 @@ export const ToolEvents: React.FC<Props> = ({ show, events }) => {
           ))}
         </Fragment>
       ))}
+      <div>
+        {isStreaming && (
+          <Text className={cn('flex min-w-0 text-volcanic-700')} as="span">
+            Working on it
+            <span className="w-max">
+              <div className="animate-typing-ellipsis overflow-hidden whitespace-nowrap pr-1">
+                ...
+              </div>
+            </span>
+          </Text>
+        )}
+      </div>
     </Transition>
   );
 };

--- a/src/interfaces/coral_web/src/components/ToolEvents.tsx
+++ b/src/interfaces/coral_web/src/components/ToolEvents.tsx
@@ -14,14 +14,14 @@ import { cn } from '@/utils';
 
 type Props = {
   show: boolean;
-  events: StreamToolCallsGeneration[] | undefined;
   isStreaming: boolean;
+  events: StreamToolCallsGeneration[] | undefined;
 };
 
 /**
  * @description Renders a list of events depending on the model's plan and tool inputs.
  */
-export const ToolEvents: React.FC<Props> = ({ show, events, isStreaming }) => {
+export const ToolEvents: React.FC<Props> = ({ show, isStreaming, events }) => {
   return (
     <Transition
       show={show}
@@ -41,18 +41,16 @@ export const ToolEvents: React.FC<Props> = ({ show, events, isStreaming }) => {
           ))}
         </Fragment>
       ))}
-      <div>
-        {isStreaming && (
-          <Text className={cn('flex min-w-0 text-volcanic-700')} as="span">
-            Working on it
-            <span className="w-max">
-              <div className="animate-typing-ellipsis overflow-hidden whitespace-nowrap pr-1">
-                ...
-              </div>
-            </span>
-          </Text>
-        )}
-      </div>
+      {isStreaming && (
+        <Text className={cn('flex min-w-0 text-volcanic-700')} as="span">
+          Working on it
+          <span className="w-max">
+            <div className="animate-typing-ellipsis overflow-hidden whitespace-nowrap pr-1">
+              ...
+            </div>
+          </span>
+        </Text>
+      )}
     </Transition>
   );
 };

--- a/src/interfaces/coral_web/src/hooks/chat.ts
+++ b/src/interfaces/coral_web/src/hooks/chat.ts
@@ -100,6 +100,7 @@ export const useChat = (config?: { onSend?: (msg: string) => void }) => {
 
   const [userMessage, setUserMessage] = useState('');
   const [isStreaming, setIsStreaming] = useState(false);
+  const [isStreamingToolEvents, setIsStreamingToolEvents] = useState(false);
   const [streamingMessage, setStreamingMessage] = useState<StreamingMessage | null>(null);
   const { agentId } = useSlugRoutes();
 
@@ -252,6 +253,7 @@ export const useChat = (config?: { onSend?: (msg: string) => void }) => {
             }
 
             case StreamEvent.TEXT_GENERATION: {
+              setIsStreamingToolEvents(false);
               const data = eventData.data as StreamTextGeneration;
               botResponse += data?.text ?? '';
               setStreamingMessage({
@@ -279,6 +281,7 @@ export const useChat = (config?: { onSend?: (msg: string) => void }) => {
             }
 
             case StreamEvent.TOOL_CALLS_CHUNK: {
+              setIsStreamingToolEvents(true);
               const data = eventData.data as StreamToolCallsChunk;
 
               // Initiate an empty tool event if one doesn't already exist at the current index
@@ -631,6 +634,7 @@ export const useChat = (config?: { onSend?: (msg: string) => void }) => {
   return {
     userMessage,
     isStreaming,
+    isStreamingToolEvents,
     handleSend: handleChat,
     handleStop,
     handleRetry,


### PR DESCRIPTION
Thank you for contributing to the Cohere Toolkit!


https://github.com/cohere-ai/cohere-toolkit/assets/140425731/b48210b3-c52a-4fc5-9c08-36d52ce5a09d



- [ ] **PR title**: "area: description"
  - Where "area" is whichever of interface, frontend, model, tools, backend, etc. is being modified. Use "docs: ..." for purely docs changes, "infra: ..." for CI changes.
  - Example: "deployment: add Azure model option"


- [ ] **PR message**: ***Delete this entire checklist*** and replace with
    - **Description:** a description of the change
    - **Issue:** the issue # it fixes, if applicable
    - **Dependencies:** any dependencies required for this change


- [ ] **Add tests and docs**: Please include testing and documentation for your changes
- [ ] **Lint and test**: Run `make lint` and `make run-tests`

**AI Description**

<!-- begin-generated-description -->

This pull request introduces the `isStreamingToolEvents` state and prop to various components and hooks in the `coral_web` interface. This new feature allows the rendering of a "Working on it" message with an ellipsis animation while tool events are being streamed. 

- The `Props` interface in `MessagingContainer.tsx` is updated with the `isStreamingToolEvents` property.
- The `Messages` component in `MessagingContainer.tsx` now includes `isStreamingToolEvents` in its prop types and rendering logic.
- The `MessageRow` component in `MessageRow.tsx` has been modified to include `isStreamingToolEvents` in its prop types and rendering logic.
- The `ToolEvents` component in `ToolEvents.tsx` now includes `isStreaming` in its prop types and renders the "Working on it" message with an ellipsis animation when `isStreaming` is true.
- The `useChat` hook in `chat.ts` has been updated to include the `isStreamingToolEvents` state and logic to update it based on different stream events.
- The `Conversation` component in `index.tsx` now includes `isStreamingToolEvents` in its prop types.

<!-- end-generated-description -->
