### PR TITLE
coral-web: enable message generation cancelling

### DIFF
--- a/src/interfaces/coral_web/src/components/Conversation/Composer/index.tsx
+++ b/src/interfaces/coral_web/src/components/Conversation/Composer/index.tsx
@@ -221,7 +221,6 @@ export const Composer: React.FC<Props> = ({
             )}
             type="button"
             onClick={() => (canSend ? onSend(value) : onStop())}
-            disabled={!canSend}
           >
             {isReadyToReceiveMessage ? <Icon name="arrow-right" /> : <Square />}
           </button>


### PR DESCRIPTION
Allows user to hit the stop/square button in the composer mid generation to abort the process

https://github.com/cohere-ai/cohere-toolkit/assets/140425731/070fc3cc-5600-438c-9d22-79f286c7ad8e



- [ ] **PR title**: "area: description"
  - Where "area" is whichever of interface, frontend, model, tools, backend, etc. is being modified. Use "docs: ..." for purely docs changes, "infra: ..." for CI changes.
  - Example: "deployment: add Azure model option"


- [ ] **PR message**: ***Delete this entire checklist*** and replace with
    - **Description:** a description of the change
    - **Issue:** the issue # it fixes, if applicable
    - **Dependencies:** any dependencies required for this change


- [ ] **Add tests and docs**: Please include testing and documentation for your changes
- [ ] **Lint and test**: Run `make lint` and `make run-tests`

**AI Description**

<!-- begin-generated-description -->

This pull request makes changes to the `src/interfaces/coral_web/src` directory, specifically within the `Composer` component and the `useChat` hook. 

## Summary
The changes in this PR focus on updating error handling and message creation within the chat functionality. 

## Changes
- Removed the `isAbortError` import in `chat.ts`, indicating a shift away from using this specific error type.
- Added a `console.debug` statement in the `onError` function to log stream errors, providing more detailed information for debugging.
- Updated the error message when encountering a `CohereNetworkError` to include the specific error message or a general error description.
- Modified the condition for appending the API key configuration error message to the user-facing error message. Now, it only appends the additional message when the error is specifically a 'network error' and the deployment is on the Cohere platform.
- Adjusted the `handleStop` function to update the conversation messages by adding an aborted message and resetting the streaming state.

<!-- end-generated-description -->
