### PR TITLE
tools: Make sure the Coral Dockerfile is using Node 20 as well

### DIFF
--- a/src/interfaces/coral_web/Dockerfile
+++ b/src/interfaces/coral_web/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18-alpine AS base
+FROM node:20-alpine AS base
 
 WORKDIR /app
 


### PR DESCRIPTION
The `.nvmrc` was recently updated to require Node 20.12.2, so we need to upgrade the base image in the Dockerfile as well