### PR TITLE
feat(toolkit): Dedupe links when URL is cited multiple times in the references

### DIFF
--- a/src/interfaces/coral_web/src/components/Citations/Citation.tsx
+++ b/src/interfaces/coral_web/src/components/Citations/Citation.tsx
@@ -69,7 +69,7 @@ export const Citation = React.forwardRef<HTMLDivElement, Props>(function Citatio
     citationRef: containerRef,
   });
 
-  if (!startEndKeyToDocs || documents.length === 0) {
+  if (!startEndKeyToDocs || documents.length === 0 || (!isSelected && !!selectedCitation)) {
     return null;
   }
 
@@ -80,6 +80,7 @@ export const Citation = React.forwardRef<HTMLDivElement, Props>(function Citatio
     uniqBy(flatten(Object.values(startEndKeyToDocs)), 'document_id'),
     'document_id'
   );
+  const uniqueDocumentsUrls = uniqBy(uniqueDocuments, 'url');
 
   const handleMouseEnter = () => {
     hoverCitation(generationId);
@@ -146,9 +147,9 @@ export const Citation = React.forwardRef<HTMLDivElement, Props>(function Citatio
 
         <div className={cn('mb-4 flex items-center justify-between', { hidden: isSelected })}>
           <Text as="span" styleAs="caption" className="text-volcanic-800">
-            {uniqueDocuments.length} {pluralize('reference', uniqueDocuments.length)}
+            {uniqueDocuments.length} {pluralize('reference', uniqueDocuments.length)} from
           </Text>
-          {uniqueDocuments.length > DEFAULT_NUM_VISIBLE_DOCS && (
+          {uniqueDocumentsUrls.length > DEFAULT_NUM_VISIBLE_DOCS && (
             <IconButton
               className={cn(
                 'h-4 w-4 text-volcanic-800 transition delay-75 duration-200 ease-in-out',
@@ -163,25 +164,39 @@ export const Citation = React.forwardRef<HTMLDivElement, Props>(function Citatio
         </div>
 
         <div className="flex w-full flex-col gap-y-4">
-          {uniqueDocuments.map((doc, index) => {
-            const isVisible =
-              (!isSelected && isAllDocsVisible) ||
-              (!isSelected && index < DEFAULT_NUM_VISIBLE_DOCS) ||
-              (isSelected && highlightedDocumentIds.includes(doc.document_id));
+          {isSelected
+            ? uniqueDocuments.map((doc) => {
+                const isVisible = highlightedDocumentIds.includes(doc.document_id);
 
-            if (!isVisible) {
-              return null;
-            }
+                if (!isVisible) {
+                  return null;
+                }
 
-            return (
-              <CitationDocument
-                key={doc.document_id}
-                isExpandable={isSelected}
-                document={doc}
-                keyword={keyword}
-              />
-            );
-          })}
+                return (
+                  <CitationDocument
+                    key={doc.document_id}
+                    isExpandable={isSelected}
+                    document={doc}
+                    keyword={keyword}
+                  />
+                );
+              })
+            : uniqueDocumentsUrls.map((doc, index) => {
+                const isVisible = isAllDocsVisible || index < DEFAULT_NUM_VISIBLE_DOCS;
+
+                if (!isVisible) {
+                  return null;
+                }
+
+                return (
+                  <CitationDocument
+                    key={doc.url}
+                    isExpandable={isSelected}
+                    document={doc}
+                    keyword={keyword}
+                  />
+                );
+              })}
         </div>
       </div>
     </Transition>

--- a/src/interfaces/coral_web/src/components/Citations/Citation.tsx
+++ b/src/interfaces/coral_web/src/components/Citations/Citation.tsx
@@ -76,6 +76,7 @@ export const Citation = React.forwardRef<HTMLDivElement, Props>(function Citatio
   const highlightedDocumentIds = documents
     .slice(0, DEFAULT_NUM_VISIBLE_DOCS)
     .map((doc) => doc.document_id);
+
   const uniqueDocuments = sortBy(
     uniqBy(flatten(Object.values(startEndKeyToDocs)), 'document_id'),
     'document_id'
@@ -147,7 +148,7 @@ export const Citation = React.forwardRef<HTMLDivElement, Props>(function Citatio
 
         <div className={cn('mb-4 flex items-center justify-between', { hidden: isSelected })}>
           <Text as="span" styleAs="caption" className="text-volcanic-800">
-            {uniqueDocuments.length} {pluralize('reference', uniqueDocuments.length)} from
+            {uniqueDocumentsUrls.length} {pluralize('reference', uniqueDocumentsUrls.length)}
           </Text>
           {uniqueDocumentsUrls.length > DEFAULT_NUM_VISIBLE_DOCS && (
             <IconButton


### PR DESCRIPTION


https://github.com/cohere-ai/cohere-toolkit/assets/19353218/0e4c0e33-ea27-4cee-8cf5-56fcb139bd37



**AI Description**

<!-- begin-generated-description -->

This pull request makes changes to the `Citation.tsx` component in the `src/interfaces/coral_web/src/components/Citations` directory. 

## Summary
The `Citation` component renders a list of citations with associated documents. The changes in this PR modify the logic for displaying citations and documents based on selection state and visibility settings. 

## Changes
- Updated the condition to return `null` when there are no relevant documents or when a citation is not selected.
- Introduced a new variable, `uniqueDocumentsUrls`, to store unique document URLs.
- Modified the condition for rendering the number of references and the associated icon button. Now, it considers the length of `uniqueDocumentsUrls` instead of `uniqueDocuments`.
- Refactored the mapping logic for rendering individual documents:
  - When a citation is selected, it maps over `uniqueDocuments` and renders only the selected documents.
  - When no citation is selected, it maps over `uniqueDocumentsUrls` and renders documents based on visibility settings.

<!-- end-generated-description -->
