### PR TITLE
metrics: allow suppressing curl logs

### DIFF
--- a/src/backend/services/metrics.py
+++ b/src/backend/services/metrics.py
@@ -27,6 +27,7 @@ from backend.services.auth.utils import get_header_user_id
 
 REPORT_ENDPOINT = os.getenv("REPORT_ENDPOINT", None)
 REPORT_SECRET = os.getenv("REPORT_SECRET", None)
+METRICS_LOGS_CURLS = os.getenv("METRICS_LOGS_CURLS", None)
 NUM_RETRIES = 0
 HEALTH_ENDPOINT = "health"
 HEALTH_ENDPOINT_USER_ID = "health"
@@ -179,7 +180,9 @@ async def report_metrics(data: MetricsData) -> None:
 
     data = attach_secret(data)
     signal = MetricsSignal(signal=data)
-    log_signal_curl(signal)
+    if METRICS_LOGS_CURLS == "true":
+        log_signal_curl(signal)
+    
     if not REPORT_SECRET:
         logger.error("No report secret set")
         return

--- a/src/backend/services/metrics.py
+++ b/src/backend/services/metrics.py
@@ -182,7 +182,7 @@ async def report_metrics(data: MetricsData) -> None:
     signal = MetricsSignal(signal=data)
     if METRICS_LOGS_CURLS == "true":
         log_signal_curl(signal)
-    
+
     if not REPORT_SECRET:
         logger.error("No report secret set")
         return


### PR DESCRIPTION
Thank you for contributing to the Cohere Toolkit!

- [ ] **PR title**: "area: description"
  - Where "area" is whichever of interface, frontend, model, tools, backend, etc. is being modified. Use "docs: ..." for purely docs changes, "infra: ..." for CI changes.
  - Example: "deployment: add Azure model option"


- [ ] **PR message**: ***Delete this entire checklist*** and replace with
    - **Description:** a description of the change
    - **Issue:** the issue # it fixes, if applicable
    - **Dependencies:** any dependencies required for this change


- [ ] **Add tests and docs**: Please include testing and documentation for your changes
- [ ] **Lint and test**: Run `make lint` and `make run-tests`

**AI Description**

<!-- begin-generated-description -->

The pull request introduces changes to the `src/backend/services/metrics.py` file, specifically to the `report_metrics` function. 

The updates involve adding a check for the `METRICS_LOGS_CURLS` environment variable before logging the signal curl. 

Here's a summary of the changes: 
- The `METRICS_LOGS_CURLS` environment variable is introduced and set to `None` by default. 
- In the `report_metrics` function, the `log_signal_curl` call is now conditional. It is executed only if `METRICS_LOGS_CURLS` is set to `"true"`. 

These changes allow for more flexibility and control over the logging behavior, ensuring that the signal curl is logged only when specifically required.

<!-- end-generated-description -->
