### PR TITLE
fix(toolkit): Requests will go into pending on window visibility hidden

### DIFF
--- a/src/interfaces/coral_web/src/cohere-client/client.ts
+++ b/src/interfaces/coral_web/src/cohere-client/client.ts
@@ -100,6 +100,7 @@ export class CohereClient {
       headers: { ...this.getHeaders(), ...headers },
       body: requestBody,
       signal,
+      openWhenHidden: true, // When false, the requests will be paused when the tab is hidden and resume/retry when the tab is visible again
       onopen: onOpen,
       onmessage: onMessage,
       onclose: onClose,

--- a/src/interfaces/coral_web/src/components/Conversation/Composer/index.tsx
+++ b/src/interfaces/coral_web/src/components/Conversation/Composer/index.tsx
@@ -9,6 +9,7 @@ import { FirstTurnSuggestions } from '@/components/FirstTurnSuggestions';
 import { Icon, STYLE_LEVEL_TO_CLASSES } from '@/components/Shared';
 import { CHAT_COMPOSER_TEXTAREA_ID } from '@/constants';
 import { useBreakpoint, useIsDesktop } from '@/hooks/breakpoint';
+import { useSlugRoutes } from '@/hooks/slugRoutes';
 import { useDataSourceTags } from '@/hooks/tags';
 import { useUnauthedTools } from '@/hooks/tools';
 import { useSettingsStore } from '@/stores';
@@ -48,6 +49,7 @@ export const Composer: React.FC<Props> = ({
   const isSmallBreakpoint = breakpoint === 'sm';
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const { isToolAuthRequired } = useUnauthedTools();
+  const { agentId } = useSlugRoutes();
   const { suggestedTags, totalTags, setTagQuery, tagQuery, getTagQuery } = useDataSourceTags({
     requiredTools,
   });
@@ -159,7 +161,7 @@ export const Composer: React.FC<Props> = ({
 
   return (
     <div className="flex w-full flex-col">
-      <FirstTurnSuggestions isFirstTurn={isFirstTurn} onSuggestionClick={onSend} />
+      {!agentId && <FirstTurnSuggestions isFirstTurn={isFirstTurn} onSuggestionClick={onSend} />}
       <div
         className={cn(
           'relative flex w-full flex-col',


### PR DESCRIPTION

**AI Description**

<!-- begin-generated-description -->

This pull request introduces changes to two files: `client.ts` and `index.tsx`. Here's a summary:

## Summary
- The `openWhenHidden` option in the `CohereClient` class constructor in `client.ts` is now set to `true`. This ensures that requests continue even when the tab is hidden and resume/retry when it becomes visible again.
- In `index.tsx`, the `useSlugRoutes` hook is imported, and the `agentId` variable is now used to conditionally render the `FirstTurnSuggestions` component.

## Details
- **client.ts**: The `openWhenHidden` option is added to the `CohereClient` class constructor options, ensuring that requests are not paused when the tab is hidden.
- **index.tsx**:
  - The `useSlugRoutes` hook is imported, and the `agentId` variable is now used.
  - The `FirstTurnSuggestions` component is now conditionally rendered based on the `agentId` variable.

<!-- end-generated-description -->
