### PR TITLE
Agents: remove user_id and org_id + refactor

### DIFF
--- a/src/backend/crud/agent_tool_metadata.py
+++ b/src/backend/crud/agent_tool_metadata.py
@@ -1,7 +1,7 @@
 from sqlalchemy.orm import Session
 
 from backend.database_models.agent_tool_metadata import AgentToolMetadata
-from backend.schemas.agent import UpdateAgentToolMetadata
+from backend.schemas.agent import UpdateAgentToolMetadataRequest
 
 
 def create_agent_tool_metadata(
@@ -17,9 +17,14 @@ def create_agent_tool_metadata(
     Returns:
         AgentToolMetadata: Created agent tool metadata.
     """
-    db.add(agent_tool_metadata)
-    db.commit()
-    db.refresh(agent_tool_metadata)
+    try:
+        db.add(agent_tool_metadata)
+        db.commit()
+        db.refresh(agent_tool_metadata)
+    except Exception as e:
+        db.rollback()
+        raise e
+
     return agent_tool_metadata
 
 
@@ -28,12 +33,27 @@ def get_agent_tool_metadata_by_id(
 ) -> AgentToolMetadata:
     """
     Get a agent tool metadata by its ID.
+
+    Args:
+        db (Session): Database session.
+        agent_tool_metadata_id (str): Agent tool metadata ID.
+
+    Returns:
+        AgentToolMetadata: Agent tool metadata with the given ID.
     """
-    return (
-        db.query(AgentToolMetadata)
-        .filter(AgentToolMetadata.id == agent_tool_metadata_id)
-        .first()
-    )
+    agent = None
+
+    try:
+        agent = (
+            db.query(AgentToolMetadata)
+            .filter(AgentToolMetadata.id == agent_tool_metadata_id)
+            .first()
+        )
+    except Exception as e:
+        db.rollback()
+        raise e
+
+    return agent
 
 
 def get_all_agent_tool_metadata_by_agent_id(
@@ -41,36 +61,78 @@ def get_all_agent_tool_metadata_by_agent_id(
 ) -> list[AgentToolMetadata]:
     """
     Get a agent tool metadata by its agent ID.
-    """
 
-    return (
-        db.query(AgentToolMetadata).filter(AgentToolMetadata.agent_id == agent_id).all()
-    )
+    Args:
+        db (Session): Database session.
+        agent_id (str): Agent ID.
+
+    Returns:
+        list[AgentToolMetadata]: List of agent tool metadata with the given agent ID.
+    """
+    agents = None
+
+    try:
+        agents = (
+            db.query(AgentToolMetadata)
+            .filter(AgentToolMetadata.agent_id == agent_id)
+            .all()
+        )
+    except Exception as e:
+        db.rollback()
+        raise e
+
+    return agents
 
 
 def update_agent_tool_metadata(
     db: Session,
     agent_tool_metadata: AgentToolMetadata,
-    new_agent_tool_metadata: UpdateAgentToolMetadata,
+    new_agent_tool_metadata: UpdateAgentToolMetadataRequest,
 ) -> AgentToolMetadata:
     """
     Update a agent tool metadata.
+
+    Args:
+        db (Session): Database session.
+        agent_tool_metadata (AgentToolMetadata): Agent tool metadata to be updated.
+        new_agent_tool_metadata (UpdateAgentToolMetadataRequest): New agent tool metadata data.
+
+    Returns:
+        AgentToolMetadata: Updated agent tool metadata.
     """
-    for attr, value in new_agent_tool_metadata.model_dump(exclude_none=True).items():
-        setattr(agent_tool_metadata, attr, value)
-    db.commit()
-    db.refresh(agent_tool_metadata)
+    try:
+        for attr, value in new_agent_tool_metadata.model_dump(
+            exclude_none=True
+        ).items():
+            setattr(agent_tool_metadata, attr, value)
+        db.commit()
+        db.refresh(agent_tool_metadata)
+    except Exception as e:
+        db.rollback()
+        raise e
+
     return agent_tool_metadata
 
 
 def delete_agent_tool_metadata_by_id(db: Session, agent_tool_metadata_id: str) -> None:
     """
     Delete a agent tool metadata by its ID.
+
+    Args:
+        db (Session): Database session.
+        agent_tool_metadata_id (str): Agent tool metadata ID.
+
+    Returns:
+        None
     """
-    agent_tool_metadata = (
-        db.query(AgentToolMetadata)
-        .filter(AgentToolMetadata.id == agent_tool_metadata_id)
-        .first()
-    )
-    db.delete(agent_tool_metadata)
-    db.commit()
+    try:
+        agent_tool_metadata = (
+            db.query(AgentToolMetadata)
+            .filter(AgentToolMetadata.id == agent_tool_metadata_id)
+            .first()
+        )
+        db.delete(agent_tool_metadata)
+        db.commit()
+    except Exception as e:
+        db.rollback()
+        raise e

--- a/src/backend/routers/agent.py
+++ b/src/backend/routers/agent.py
@@ -1,11 +1,8 @@
-import psycopg2
-from fastapi import APIRouter, Depends, Form, HTTPException, Request
+from fastapi import APIRouter, Depends, HTTPException, Request
 
 from backend.config.routers import RouterName
-from backend.config.tools import ALL_TOOLS
 from backend.crud import agent as agent_crud
 from backend.crud import agent_tool_metadata as agent_tool_metadata_crud
-from backend.crud import user as user_crud
 from backend.database_models.agent import Agent as AgentModel
 from backend.database_models.agent_tool_metadata import (
     AgentToolMetadata as AgentToolMetadataModel,
@@ -13,17 +10,25 @@ from backend.database_models.agent_tool_metadata import (
 from backend.database_models.database import DBSessionDep
 from backend.routers.utils import (
     add_agent_to_request_state,
+    add_agent_tool_metadata_to_request_state,
     add_session_user_to_request_state,
 )
 from backend.schemas.agent import (
     Agent,
+    AgentPublic,
     AgentToolMetadata,
-    CreateAgent,
-    CreateAgentToolMetadata,
+    AgentToolMetadataPublic,
+    CreateAgentRequest,
+    CreateAgentToolMetadataRequest,
     DeleteAgent,
     DeleteAgentToolMetadata,
-    UpdateAgent,
-    UpdateAgentToolMetadata,
+    UpdateAgentRequest,
+    UpdateAgentToolMetadataRequest,
+)
+from backend.services.agent import (
+    raise_db_error,
+    validate_agent_exists,
+    validate_agent_tool_metadata_exists,
 )
 from backend.services.auth.utils import get_header_user_id
 from backend.services.request_validators import (
@@ -40,27 +45,30 @@ router.name = RouterName.AGENT
 
 @router.post(
     "",
-    response_model=Agent,
+    response_model=AgentPublic,
     dependencies=[
         Depends(validate_user_header),
         Depends(validate_create_agent_request),
     ],
 )
-def create_agent(session: DBSessionDep, agent: CreateAgent, request: Request) -> Agent:
+async def create_agent(
+    session: DBSessionDep, agent: CreateAgentRequest, request: Request
+) -> AgentPublic:
     """
     Create an agent.
     Args:
         session (DBSessionDep): Database session.
-        agent (CreateAgent): Agent data.
+        agent (CreateAgentRequest): Agent data.
         request (Request): Request object.
     Returns:
-        Agent: Created agent.
+        AgentPublic: Created agent with no user ID or organization ID.
     Raises:
         HTTPException: If the agent creation fails.
     """
     # add user data into request state for metrics
     user_id = get_header_user_id(request)
     add_session_user_to_request_state(request, session)
+
     agent_data = AgentModel(
         name=agent.name,
         description=agent.description,
@@ -72,26 +80,22 @@ def create_agent(session: DBSessionDep, agent: CreateAgent, request: Request) ->
         tools=agent.tools,
     )
 
-    try:
-        created_agent = agent_crud.create_agent(session, agent_data)
-        add_agent_to_request_state(request, created_agent)
-        if agent.tools_metadata:
-            for tool_metadata in agent.tools_metadata:
-                agent_tool_metadata_data = AgentToolMetadataModel(
-                    user_id=user_id,
-                    agent_id=created_agent.id,
-                    tool_name=tool_metadata.tool_name,
-                    artifacts=tool_metadata.artifacts,
-                )
-                agent_tool_metadata_crud.create_agent_tool_metadata(
-                    session, agent_tool_metadata_data
-                )
-        return created_agent
-    except Exception as e:
-        raise HTTPException(status_code=500, detail=str(e))
+    # try:
+    created_agent = agent_crud.create_agent(session, agent_data)
+    add_agent_to_request_state(request, created_agent)
+
+    if agent.tools_metadata:
+        for tool_metadata in agent.tools_metadata:
+            await update_or_create_tool_metadata(
+                created_agent, tool_metadata, session, request
+            )
+    # except Exception as e:
+    # raise HTTPException(status_code=500, detail=str(e))
+
+    return created_agent
 
 
-@router.get("", response_model=list[Agent])
+@router.get("", response_model=list[AgentPublic])
 async def list_agents(
     *, offset: int = 0, limit: int = 100, session: DBSessionDep, request: Request
 ) -> list[Agent]:
@@ -105,7 +109,7 @@ async def list_agents(
         request (Request): Request object.
 
     Returns:
-        list[Agent]: List of agents.
+        list[AgentPublic]: List of agents with no user ID or organization ID.
     """
     try:
         return agent_crud.get_agents(session, offset=offset, limit=limit)
@@ -146,7 +150,7 @@ async def get_agent_by_id(
 
 @router.put(
     "/{agent_id}",
-    response_model=Agent,
+    response_model=AgentPublic,
     dependencies=[
         Depends(validate_user_header),
         Depends(validate_update_agent_request),
@@ -154,61 +158,31 @@ async def get_agent_by_id(
 )
 async def update_agent(
     agent_id: str,
-    new_agent: UpdateAgent,
+    new_agent: UpdateAgentRequest,
     session: DBSessionDep,
     request: Request,
-) -> Agent:
+) -> AgentPublic:
     """
     Update an agent by ID.
 
     Args:
         agent_id (str): Agent ID.
-        new_agent (UpdateAgent): New agent data.
+        new_agent (UpdateAgentRequest): New agent data.
         session (DBSessionDep): Database session.
         request (Request): Request object.
 
     Returns:
-        Agent: Updated agent.
+        AgentPublic: Updated agent with no user ID or organization ID.
 
     Raises:
         HTTPException: If the agent with the given ID is not found.
     """
     add_session_user_to_request_state(request, session)
-    agent = agent_crud.get_agent_by_id(session, agent_id)
-
-    if not agent:
-        raise HTTPException(
-            status_code=404, detail=f"Agent with ID {agent_id} not found."
-        )
+    agent = validate_agent_exists(session, agent_id)
 
     if new_agent.tools_metadata is not None:
-        # Delete tool metadata that are not in the request
-        for tool_metadata in agent.tools_metadata:
-            if tool_metadata.tool_name not in [
-                metadata.tool_name for metadata in new_agent.tools_metadata
-            ]:
-                agent_tool_metadata_crud.delete_agent_tool_metadata_by_id(
-                    session, tool_metadata.id
-                )
-
-        # Create or update tool metadata from the request
-        for tool_metadata in new_agent.tools_metadata:
-            try:
-                await update_or_create_tool_metadata(
-                    agent, tool_metadata, session, request
-                )
-            except Exception as e:
-                if "psycopg2.errors.UniqueViolation" in str(e):
-                    raise HTTPException(
-                        status_code=400,
-                        detail=f"Tool name {tool_metadata.tool_name} already exists for given user and agent.",
-                    )
-
-                raise HTTPException(status_code=500, detail=str(e))
-
-        # Remove tools_metadata from new_agent to avoid updating it in the agent
-        new_agent.tools_metadata = None
-        agent = agent_crud.get_agent_by_id(session, agent_id)
+        print("New agent", new_agent)
+        agent = await handle_tool_metadata_update(agent, new_agent, session, request)
 
     try:
         agent = agent_crud.update_agent(session, agent, new_agent)
@@ -219,19 +193,50 @@ async def update_agent(
     return agent
 
 
-async def update_or_create_tool_metadata(agent, new_tool_metadata, session, request):
-    if new_tool_metadata.id:
+async def handle_tool_metadata_update(
+    agent: Agent, new_agent: Agent, session: DBSessionDep, request: Request
+) -> Agent:
+    # Delete tool metadata that are not in the request
+    new_tools_names = [metadata.tool_name for metadata in new_agent.tools_metadata]
+    for tool_metadata in agent.tools_metadata:
+        if tool_metadata.tool_name not in new_tools_names:
+            agent_tool_metadata_crud.delete_agent_tool_metadata_by_id(
+                session, tool_metadata.id
+            )
+
+    # Create or update tool metadata from the request
+    for tool_metadata in new_agent.tools_metadata:
+        print("Tool metadata", tool_metadata)
+        try:
+            await update_or_create_tool_metadata(agent, tool_metadata, session, request)
+        except Exception as e:
+            raise_db_error(e, "Tool name", tool_metadata.tool_name)
+
+    # Remove tools_metadata from new_agent to avoid updating it in the agent
+    new_agent.tools_metadata = None
+    agent = agent_crud.get_agent_by_id(session, agent.id)
+    return agent
+
+
+async def update_or_create_tool_metadata(
+    agent: Agent,
+    new_tool_metadata: AgentToolMetadata,
+    session: DBSessionDep,
+    request: Request,
+) -> None:
+    existing_tools_names = [metadata.tool_name for metadata in agent.tools_metadata]
+    if new_tool_metadata.tool_name in existing_tools_names or new_tool_metadata.id:
         await update_agent_tool_metadata(
             agent.id, new_tool_metadata.id, session, new_tool_metadata, request
         )
     else:
-        create_metadata_req = CreateAgentToolMetadata(
+        create_metadata_req = CreateAgentToolMetadataRequest(
             **new_tool_metadata.model_dump(exclude_none=True)
         )
         create_agent_tool_metadata(session, agent.id, create_metadata_req, request)
 
 
-@router.delete("/{agent_id}")
+@router.delete("/{agent_id}", response_model=DeleteAgent)
 async def delete_agent(
     agent_id: str, session: DBSessionDep, request: Request
 ) -> DeleteAgent:
@@ -249,13 +254,7 @@ async def delete_agent(
     Raises:
         HTTPException: If the agent with the given ID is not found.
     """
-    agent = agent_crud.get_agent_by_id(session, agent_id)
-
-    if not agent:
-        raise HTTPException(
-            status_code=400,
-            detail=f"Agent with ID {agent_id} not found.",
-        )
+    agent = validate_agent_exists(session, agent_id)
 
     add_agent_to_request_state(request, agent)
     try:
@@ -269,10 +268,10 @@ async def delete_agent(
 # Tool Metadata Endpoints
 
 
-@router.get("/{agent_id}/tool-metadata", response_model=list[AgentToolMetadata])
+@router.get("/{agent_id}/tool-metadata", response_model=list[AgentToolMetadataPublic])
 async def list_agent_tool_metadata(
     agent_id: str, session: DBSessionDep, request: Request
-) -> list[AgentToolMetadata]:
+) -> list[AgentToolMetadataPublic]:
     """
     List all agent tool metadata by agent ID.
 
@@ -282,7 +281,7 @@ async def list_agent_tool_metadata(
         request (Request): Request object.
 
     Returns:
-        list[AgentToolMetadata]: List of agent tool metadata.
+        list[AgentToolMetadataPublic]: List of agent tool metadata with no user ID or organization ID.
 
     Raises:
         HTTPException: If the agent tool metadata retrieval fails.
@@ -297,21 +296,21 @@ async def list_agent_tool_metadata(
 
 @router.post(
     "/{agent_id}/tool-metadata",
-    response_model=AgentToolMetadata,
+    response_model=AgentToolMetadataPublic,
 )
 def create_agent_tool_metadata(
     session: DBSessionDep,
     agent_id: str,
-    agent_tool_metadata: CreateAgentToolMetadata,
+    agent_tool_metadata: CreateAgentToolMetadataRequest,
     request: Request,
-) -> AgentToolMetadata:
+) -> AgentToolMetadataPublic:
     """
     Create an agent tool metadata.
 
     Args:
         session (DBSessionDep): Database session.
         agent_id (str): Agent ID.
-        agent_tool_metadata (CreateAgentToolMetadata): Agent tool metadata data.
+        agent_tool_metadata (CreateAgentToolMetadataRequest): Agent tool metadata data.
         request (Request): Request object.
 
     Returns:
@@ -321,6 +320,8 @@ def create_agent_tool_metadata(
         HTTPException: If the agent tool metadata creation fails.
     """
     user_id = get_header_user_id(request)
+    agent = validate_agent_exists(session, agent_id)
+    add_agent_to_request_state(request, agent)
 
     agent_tool_metadata_data = AgentToolMetadataModel(
         user_id=user_id,
@@ -329,22 +330,15 @@ def create_agent_tool_metadata(
         artifacts=agent_tool_metadata.artifacts,
     )
 
-    request.state.agent_tool_metadata = agent_tool_metadata_data
     try:
         created_agent_tool_metadata = (
             agent_tool_metadata_crud.create_agent_tool_metadata(
                 session, agent_tool_metadata_data
             )
         )
-        request.state.agent_tool_metadata = agent_tool_metadata_data
+        add_agent_tool_metadata_to_request_state(request, created_agent_tool_metadata)
     except Exception as e:
-        if "psycopg2.errors.UniqueViolation" in str(e):
-            raise HTTPException(
-                status_code=400,
-                detail=f"Tool name {agent_tool_metadata.tool_name} already exists for given user and agent.",
-            )
-
-        raise HTTPException(status_code=500, detail=str(e))
+        raise_db_error(e, "Tool name", agent_tool_metadata.tool_name)
 
     return created_agent_tool_metadata
 
@@ -354,7 +348,7 @@ async def update_agent_tool_metadata(
     agent_id: str,
     agent_tool_metadata_id: str,
     session: DBSessionDep,
-    new_agent_tool_metadata: UpdateAgentToolMetadata,
+    new_agent_tool_metadata: UpdateAgentToolMetadataRequest,
     request: Request,
 ) -> AgentToolMetadata:
     """
@@ -364,7 +358,7 @@ async def update_agent_tool_metadata(
         agent_id (str): Agent ID.
         agent_tool_metadata_id (str): Agent tool metadata ID.
         session (DBSessionDep): Database session.
-        new_agent_tool_metadata (UpdateAgentToolMetadata): New agent tool metadata data.
+        new_agent_tool_metadata (UpdateAgentToolMetadataRequest): New agent tool metadata data.
         request (Request): Request object.
 
     Returns:
@@ -374,28 +368,17 @@ async def update_agent_tool_metadata(
         HTTPException: If the agent tool metadata with the given ID is not found.
         HTTPException: If the agent tool metadata update fails.
     """
-    agent_tool_metadata = agent_tool_metadata_crud.get_agent_tool_metadata_by_id(
+    agent_tool_metadata = validate_agent_tool_metadata_exists(
         session, agent_tool_metadata_id
     )
-    if not agent_tool_metadata:
-        raise HTTPException(
-            status_code=400,
-            detail=f"Agent tool metadata with ID {agent_tool_metadata_id} not found.",
-        )
 
     try:
         agent_tool_metadata_crud.update_agent_tool_metadata(
             session, agent_tool_metadata, new_agent_tool_metadata
         )
-        request.state.agent_tool_metadata = agent_tool_metadata
+        add_agent_tool_metadata_to_request_state(request, agent_tool_metadata)
     except Exception as e:
-        if "psycopg2.errors.UniqueViolation" in str(e):
-            raise HTTPException(
-                status_code=400,
-                detail=f"Tool name {agent_tool_metadata.tool_name} already exists for given user and agent.",
-            )
-
-        raise HTTPException(status_code=500, detail=str(e))
+        raise_db_error(e, "Tool name", agent_tool_metadata.tool_name)
 
     return agent_tool_metadata
 
@@ -420,16 +403,11 @@ async def delete_agent_tool_metadata(
         HTTPException: If the agent tool metadata with the given ID is not found.
         HTTPException: If the agent tool metadata deletion fails.
     """
-    agent_tool_metadata = agent_tool_metadata_crud.get_agent_tool_metadata_by_id(
+    agent_tool_metadata = validate_agent_tool_metadata_exists(
         session, agent_tool_metadata_id
     )
-    if not agent_tool_metadata:
-        raise HTTPException(
-            status_code=400,
-            detail=f"Agent tool metadata with ID {agent_tool_metadata_id} not found.",
-        )
 
-    request.state.agent_tool_metadata = agent_tool_metadata
+    add_agent_tool_metadata_to_request_state(request, agent_tool_metadata)
     try:
         agent_tool_metadata_crud.delete_agent_tool_metadata_by_id(
             session, agent_tool_metadata_id

--- a/src/backend/routers/utils.py
+++ b/src/backend/routers/utils.py
@@ -3,7 +3,7 @@ from fastapi import Request
 from backend.crud import user as user_crud
 from backend.database_models.database import DBSessionDep
 from backend.database_models.user import User
-from backend.schemas.agent import Agent
+from backend.schemas.agent import Agent, AgentToolMetadata
 from backend.schemas.metrics import MetricsAgent, MetricsUser
 from backend.services.auth.utils import get_header_user_id
 
@@ -36,3 +36,10 @@ def add_user_to_request_state(request: Request, user: User):
         request.state.user = MetricsUser(
             id=user.id, email=user.email, fullname=user.fullname
         )
+
+
+def add_agent_tool_metadata_to_request_state(
+    request: Request, agent_tool_metadata: AgentToolMetadata
+):
+    if agent_tool_metadata:
+        request.state.agent_tool_metadata = agent_tool_metadata

--- a/src/backend/schemas/agent.py
+++ b/src/backend/schemas/agent.py
@@ -1,7 +1,7 @@
 import datetime
 from typing import Optional
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 
 class AgentBase(BaseModel):
@@ -9,18 +9,27 @@ class AgentBase(BaseModel):
     organization_id: Optional[str] = None
 
 
+# Agent Tool Metadata
 class AgentToolMetadata(AgentBase):
     id: str
     tool_name: str
     artifacts: list[dict]
 
 
-class CreateAgentToolMetadata(BaseModel):
+class AgentToolMetadataPublic(AgentToolMetadata):
+    user_id: Optional[str] = Field(exclude=True)
+
+    class Config:
+        from_attributes = True
+
+
+class CreateAgentToolMetadataRequest(BaseModel):
+    id: Optional[str] = None
     tool_name: str
     artifacts: list[dict]
 
 
-class UpdateAgentToolMetadata(BaseModel):
+class UpdateAgentToolMetadataRequest(BaseModel):
     id: Optional[str] = None
     tool_name: Optional[str] = None
     artifacts: Optional[list[dict]] = None
@@ -30,6 +39,7 @@ class DeleteAgentToolMetadata(BaseModel):
     pass
 
 
+# Agent
 class Agent(AgentBase):
     id: str
     created_at: datetime.datetime
@@ -51,7 +61,13 @@ class Agent(AgentBase):
         use_enum_values = True
 
 
-class CreateAgent(BaseModel):
+class AgentPublic(Agent):
+    user_id: Optional[str] = Field(exclude=True)
+    organization_id: Optional[str] = Field(exclude=True)
+    tools_metadata: Optional[list[AgentToolMetadataPublic]] = None
+
+
+class CreateAgentRequest(BaseModel):
     name: str
     version: Optional[int] = None
     description: Optional[str] = None
@@ -60,14 +76,18 @@ class CreateAgent(BaseModel):
     model: str
     deployment: str
     tools: Optional[list[str]] = None
-    tools_metadata: Optional[list[CreateAgentToolMetadata]] = None
+    tools_metadata: Optional[list[CreateAgentToolMetadataRequest]] = None
 
     class Config:
         from_attributes = True
         use_enum_values = True
 
 
-class UpdateAgent(BaseModel):
+class ListAgentsResponse(BaseModel):
+    agents: list[Agent]
+
+
+class UpdateAgentRequest(BaseModel):
     name: Optional[str] = None
     version: Optional[int] = None
     description: Optional[str] = None
@@ -76,7 +96,7 @@ class UpdateAgent(BaseModel):
     model: Optional[str] = None
     deployment: Optional[str] = None
     tools: Optional[list[str]] = None
-    tools_metadata: Optional[list[UpdateAgentToolMetadata]] = None
+    tools_metadata: Optional[list[CreateAgentToolMetadataRequest]] = None
 
     class Config:
         from_attributes = True

--- a/src/backend/services/agent.py
+++ b/src/backend/services/agent.py
@@ -1,0 +1,44 @@
+from fastapi import HTTPException
+
+from backend.crud import agent as agent_crud
+from backend.crud import agent_tool_metadata as agent_tool_metadata_crud
+from backend.database_models.agent import Agent, AgentToolMetadata
+from backend.database_models.database import DBSessionDep
+
+
+def validate_agent_exists(session: DBSessionDep, agent_id: str) -> Agent:
+    agent = agent_crud.get_agent_by_id(session, agent_id)
+
+    if not agent:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Agent with ID {agent_id} not found.",
+        )
+
+    return agent
+
+
+def validate_agent_tool_metadata_exists(
+    session: DBSessionDep, agent_tool_metadata_id: str
+) -> AgentToolMetadata:
+    agent_tool_metadata = agent_tool_metadata_crud.get_agent_tool_metadata_by_id(
+        session, agent_tool_metadata_id
+    )
+
+    if not agent_tool_metadata:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Agent tool metadata with ID {agent_tool_metadata_id} not found.",
+        )
+
+    return agent_tool_metadata
+
+
+def raise_db_error(e: Exception, type: str, name: str):
+    if "psycopg2.errors.UniqueViolation" in str(e):
+        raise HTTPException(
+            status_code=400,
+            detail=f"{type} {name} already exists for given user and agent.",
+        )
+
+    raise HTTPException(status_code=500, detail=str(e))

--- a/src/backend/tests/routers/test_agent.py
+++ b/src/backend/tests/routers/test_agent.py
@@ -900,7 +900,7 @@ def test_fail_delete_nonexistent_agent(
     assert response.json() == {"detail": "Agent with ID 456 not found."}
 
 
-# # Test create agent tool metadata
+# Test create agent tool metadata
 def test_create_agent_tool_metadata(
     session_client: TestClient, session: Session
 ) -> None:


### PR DESCRIPTION
1/n - Will do the same refactor for all the endpoints/schemas/types so that:

1. We don't return `user_id` and `organization_id` when not strictly needed
2. We rollback transactions if they fail
3. We have more readable code and better functions

**AI Description**

<!-- begin-generated-description -->

<!--
  New: command-r-plus will maintain a pr description for you!
  Simply delete this section to opt out.
  Content inside this section will be overwritten by command as the PR is updated.
-->

<!-- end-generated-description -->
