### PR TITLE
tanzim/metrics chat tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,8 @@ down:
 	@docker compose down
 run-tests:
 	docker compose run --build backend poetry run pytest src/backend/tests/$(file)
+run-my-tests:
+	docker compose run --build backend poetry run pytest src/backend/tests/routers/test_chat.py
 run-community-tests:
 	docker compose run --build backend poetry run pytest src/community/tests/$(file)
 attach: 

--- a/src/backend/chat/custom/custom.py
+++ b/src/backend/chat/custom/custom.py
@@ -133,6 +133,7 @@ class CustomChat(BaseChat):
         trace_id = kwargs.get("trace_id", "")
         user_id = kwargs.get("user_id", "")
         agent_id = kwargs.get("agent_id", "")
+        model = kwargs.get("model", [])
         managed_tools = self.get_managed_tools(chat_request)
 
         tool_names = []
@@ -178,7 +179,11 @@ class CustomChat(BaseChat):
             # Invoke chat stream
             has_tool_calls = False
             async for event in deployment_model.invoke_chat_stream(
-                chat_request, trace_id=trace_id, user_id=user_id, agent_id=agent_id
+                chat_request,
+                trace_id=trace_id,
+                user_id=user_id,
+                agent_id=agent_id,
+                model=model,
             ):
                 if event["event_type"] == StreamEvent.STREAM_END:
                     chat_request.chat_history = event["response"].get(

--- a/src/backend/routers/chat.py
+++ b/src/backend/routers/chat.py
@@ -51,9 +51,7 @@ async def chat_stream(
 
     user_id = request.headers.get("User-Id", None)
     agent_id = chat_request.agent_id
-    pdb.set_trace()
     add_model_to_request_state(request, chat_request)
-    pdb.set_trace()
 
     (
         session,
@@ -68,7 +66,6 @@ async def chat_stream(
         deployment_config,
         next_message_position,
     ) = process_chat(session, chat_request, request, agent_id)
-    pdb.set_trace()
 
     return EventSourceResponse(
         generate_chat_stream(

--- a/src/backend/routers/chat.py
+++ b/src/backend/routers/chat.py
@@ -52,6 +52,7 @@ async def chat_stream(
     user_id = request.headers.get("User-Id", None)
     agent_id = chat_request.agent_id
     add_model_to_request_state(request, chat_request)
+    req_model = chat_request.model[:]
 
     (
         session,
@@ -82,6 +83,7 @@ async def chat_stream(
                 user_id=user_id,
                 trace_id=trace_id,
                 agent_id=agent_id,
+                model=req_model,
             ),
             response_message,
             conversation_id,
@@ -116,6 +118,8 @@ async def chat(
 
     user_id = request.headers.get("User-Id", None)
     agent_id = chat_request.agent_id
+    # warning: process_chat currently mutates chat_request.model
+    req_model = chat_request.model[:]
     add_model_to_request_state(request, chat_request)
     (
         session,
@@ -143,6 +147,7 @@ async def chat(
             trace_id=trace_id,
             user_id=user_id,
             agent_id=agent_id,
+            model=req_model,
         ),
         response_message,
         conversation_id,

--- a/src/backend/routers/chat.py
+++ b/src/backend/routers/chat.py
@@ -9,6 +9,7 @@ from backend.chat.custom.custom import CustomChat
 from backend.chat.custom.langchain import LangChainChat
 from backend.config.routers import RouterName
 from backend.database_models.database import DBSessionDep
+from backend.routers.utils import add_model_to_request_state
 from backend.schemas.chat import ChatResponseEvent, NonStreamedChatResponse
 from backend.schemas.cohere_chat import CohereChatRequest
 from backend.schemas.langchain_chat import LangchainChatRequest
@@ -19,6 +20,7 @@ from backend.services.chat import (
     process_chat,
 )
 from backend.services.request_validators import validate_deployment_header
+import pdb
 
 router = APIRouter(
     prefix="/v1",
@@ -49,6 +51,10 @@ async def chat_stream(
 
     user_id = request.headers.get("User-Id", None)
     agent_id = chat_request.agent_id
+    pdb.set_trace()
+    add_model_to_request_state(request, chat_request)
+    pdb.set_trace()
+
     (
         session,
         chat_request,
@@ -62,6 +68,7 @@ async def chat_stream(
         deployment_config,
         next_message_position,
     ) = process_chat(session, chat_request, request, agent_id)
+    pdb.set_trace()
 
     return EventSourceResponse(
         generate_chat_stream(
@@ -112,7 +119,7 @@ async def chat(
 
     user_id = request.headers.get("User-Id", None)
     agent_id = chat_request.agent_id
-
+    add_model_to_request_state(request, chat_request)
     (
         session,
         chat_request,

--- a/src/backend/routers/utils.py
+++ b/src/backend/routers/utils.py
@@ -41,6 +41,5 @@ def add_user_to_request_state(request: Request, user: User):
 
 
 def add_model_to_request_state(request: Request, chat_request: CohereChatRequest):
-    pdb.set_trace()
     if chat_request.model:
         request.state.model = chat_request.model[:]

--- a/src/backend/routers/utils.py
+++ b/src/backend/routers/utils.py
@@ -4,8 +4,10 @@ from backend.crud import user as user_crud
 from backend.database_models.database import DBSessionDep
 from backend.database_models.user import User
 from backend.schemas.agent import Agent
+from backend.schemas.cohere_chat import CohereChatRequest
 from backend.schemas.metrics import MetricsAgent, MetricsUser
 from backend.services.auth.utils import get_header_user_id
+import pdb
 
 
 def add_agent_to_request_state(request: Request, agent: Agent):
@@ -36,3 +38,9 @@ def add_user_to_request_state(request: Request, user: User):
         request.state.user = MetricsUser(
             id=user.id, email=user.email, fullname=user.fullname
         )
+
+
+def add_model_to_request_state(request: Request, chat_request: CohereChatRequest):
+    pdb.set_trace()
+    if chat_request.model:
+        request.state.model = chat_request.model[:]

--- a/src/backend/schemas/metrics.py
+++ b/src/backend/schemas/metrics.py
@@ -70,6 +70,11 @@ class MetricsData(MetricsDataBase):
     assistant: MetricsAgent | None = None
     user: MetricsUser | None = None
 
-
+# strict def for events with models
+class MetricsModel(BaseModel):
+    user_id: str
+    assistant_id: str
+    model: str
+    
 class MetricsSignal(BaseModel):
     signal: MetricsData

--- a/src/backend/services/chat.py
+++ b/src/backend/services/chat.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import pdb
 from typing import Any, AsyncGenerator, Generator, List, Union
 from uuid import uuid4
 
@@ -56,6 +57,7 @@ from backend.schemas.tool import Tool, ToolCall, ToolCallDelta
 from backend.services.auth.utils import get_header_user_id
 
 
+# TODO: @scott why is model being set to None below?
 def process_chat(
     session: DBSessionDep,
     chat_request: BaseChatRequest,
@@ -92,6 +94,7 @@ def process_chat(
 
         try:
             add_agent_to_request_state(request, agent)
+            pdb.set_trace()
         except ValidationError as exc:
             print(f"Validation error count: {exc.error_count()}")
             for err in exc.errors():

--- a/src/backend/services/chat.py
+++ b/src/backend/services/chat.py
@@ -94,7 +94,6 @@ def process_chat(
 
         try:
             add_agent_to_request_state(request, agent)
-            pdb.set_trace()
         except ValidationError as exc:
             print(f"Validation error count: {exc.error_count()}")
             for err in exc.errors():

--- a/src/backend/services/metrics.py
+++ b/src/backend/services/metrics.py
@@ -25,6 +25,7 @@ from backend.schemas.metrics import (
     MetricsUser,
 )
 from backend.services.auth.utils import get_header_user_id
+import pdb
 
 REPORT_ENDPOINT = os.getenv("REPORT_ENDPOINT", None)
 REPORT_SECRET = os.getenv("REPORT_SECRET", None)
@@ -74,12 +75,14 @@ class MetricsMiddleware(BaseHTTPMiddleware):
         request.state.trace_id = str(uuid.uuid4())
         request.state.agent = None
         request.state.user = None
+        request.state.model = None
 
         start_time = time.perf_counter()
         response = await call_next(request)
         duration_ms = time.perf_counter() - start_time
 
         data = self.get_event_data(request.scope, response, request, duration_ms)
+        pdb.set_trace()
         await run_loop(data)
         return response
 
@@ -109,6 +112,7 @@ class MetricsMiddleware(BaseHTTPMiddleware):
         user = self.get_user(request)
         object_ids = self.get_object_ids(request)
         event_id = str(uuid.uuid4())
+        pdb.set_trace()
 
         return MetricsData(
             id=event_id,
@@ -118,6 +122,7 @@ class MetricsMiddleware(BaseHTTPMiddleware):
             trace_id=request.state.trace_id,
             object_ids=object_ids,
             assistant=agent,
+            model=request.state.model,
             assistant_id=agent_id,
             duration_ms=duration_ms,
         )
@@ -208,6 +213,7 @@ class MetricsMiddleware(BaseHTTPMiddleware):
 
 
 async def report_metrics(data: MetricsData | None) -> None:
+    pdb.set_trace()
     if not data:
         raise ValueError("No metrics data to report")
 
@@ -265,6 +271,7 @@ async def run_loop(metrics_data: MetricsData) -> None:
         loop = asyncio.new_event_loop()
         asyncio.set_event_loop(loop)
 
+    pdb.set_trace()
     task = loop.create_task(report_metrics(metrics_data))
 
     async def callback_wrapper():

--- a/src/backend/services/metrics.py
+++ b/src/backend/services/metrics.py
@@ -94,7 +94,7 @@ class MetricsMiddleware(BaseHTTPMiddleware):
 
         if message_type == MetricsMessageType.UNKNOWN_SIGNAL:
             logger.warning(
-                f"cannot determine message type: {endpoint_name} | {method} | {is_success}"
+                f"cannot determine message type: {method} | {endpoint_name} | {is_success}"
             )
             return None
 

--- a/src/backend/services/metrics.py
+++ b/src/backend/services/metrics.py
@@ -256,9 +256,9 @@ def log_signal_curl(signal: MetricsSignal) -> None:
 
 
 async def run_loop(metrics_data: MetricsData) -> None:
-    async def task_exception_handler(task: asyncio.Task):
+    async def report_metrics_with_error_handling():
         try:
-            await task
+            await report_metrics(metrics_data)
         except Exception as e:
             logger.error(f"Failed to execute report_metrics task: {e}")
 
@@ -268,12 +268,7 @@ async def run_loop(metrics_data: MetricsData) -> None:
         loop = asyncio.new_event_loop()
         asyncio.set_event_loop(loop)
 
-    task = loop.create_task(report_metrics(metrics_data))
-
-    async def callback_wrapper():
-        await task_exception_handler(task)
-
-    loop.create_task(callback_wrapper())
+    task = loop.create_task(report_metrics_with_error_handling())
 
 
 # DECORATORS

--- a/src/backend/services/metrics.py
+++ b/src/backend/services/metrics.py
@@ -82,7 +82,6 @@ class MetricsMiddleware(BaseHTTPMiddleware):
         duration_ms = time.perf_counter() - start_time
 
         data = self.get_event_data(request.scope, response, request, duration_ms)
-        pdb.set_trace()
         await run_loop(data)
         return response
 
@@ -112,7 +111,6 @@ class MetricsMiddleware(BaseHTTPMiddleware):
         user = self.get_user(request)
         object_ids = self.get_object_ids(request)
         event_id = str(uuid.uuid4())
-        pdb.set_trace()
 
         return MetricsData(
             id=event_id,
@@ -213,7 +211,6 @@ class MetricsMiddleware(BaseHTTPMiddleware):
 
 
 async def report_metrics(data: MetricsData | None) -> None:
-    pdb.set_trace()
     if not data:
         raise ValueError("No metrics data to report")
 
@@ -271,7 +268,6 @@ async def run_loop(metrics_data: MetricsData) -> None:
         loop = asyncio.new_event_loop()
         asyncio.set_event_loop(loop)
 
-    pdb.set_trace()
     task = loop.create_task(report_metrics(metrics_data))
 
     async def callback_wrapper():

--- a/src/backend/services/metrics.py
+++ b/src/backend/services/metrics.py
@@ -297,7 +297,7 @@ def collect_metrics_chat(func: Callable) -> Callable:
 
     return wrapper
 
-
+import pdb
 def collect_metrics_chat_stream(func: Callable) -> Callable:
     @wraps(func)
     async def wrapper(self, chat_request: CohereChatRequest, **kwargs: Any) -> Any:
@@ -305,11 +305,11 @@ def collect_metrics_chat_stream(func: Callable) -> Callable:
         metrics_data, kwargs = initialize_sdk_metrics_data(
             "chat", chat_request, **kwargs
         )
-
         stream = func(self, chat_request, **kwargs)
 
         try:
             async for event in stream:
+                pdb.set_trace()
                 event_dict = to_dict(event)
 
                 if is_event_end_with_error(event_dict):
@@ -361,6 +361,10 @@ def initialize_sdk_metrics_data(
     func_name: str, chat_request: CohereChatRequest, **kwargs: Any
 ) -> tuple[MetricsData, Any]:
 
+    model = kwargs.get("model", None)
+    trace_id = kwargs.get("trace_id", None)
+    user_id = kwargs.get("user_id", None)
+    assistant_id = kwargs.get("agent_id", None)
     method = "POST"
     endpoint_name = f"co.{func_name}"
     is_success = True
@@ -370,10 +374,10 @@ def initialize_sdk_metrics_data(
         MetricsData(
             id=str(uuid.uuid4()),
             message_type=message_type,
-            trace_id=kwargs.get("trace_id", None),
-            user_id=kwargs.get("user_id", None),
-            assistant_id=kwargs.get("agent_id", None),
-            model=chat_request.model if chat_request else None,
+            trace_id=trace_id,
+            user_id=user_id,
+            assistant_id=assistant_id,
+            model=model,
         ),
         kwargs,
     )

--- a/src/backend/tests/routers/test_chat.py
+++ b/src/backend/tests/routers/test_chat.py
@@ -30,7 +30,8 @@ def user(session_chat: Session) -> User:
 
 
 # STREAMING CHAT TESTS
-"""
+
+
 @pytest.mark.skipif(not is_cohere_env_set, reason="Cohere API key not set")
 def test_streaming_new_chat(
     session_client_chat: TestClient, session_chat: Session, user: User
@@ -74,7 +75,6 @@ def test_streaming_new_chat_with_agent(
     validate_chat_streaming_response(
         response, user, session_chat, session_client_chat, 2
     )
-"""
 
 
 @pytest.mark.skipif(not is_cohere_env_set, reason="Cohere API key not set")
@@ -111,7 +111,7 @@ def test_streaming_new_chat_with_agent_reports_metrics(
         m_args_list: MetricsData = mock_metrics.await_args_list
         input_nb_tokens_sum = 0
         output_nb_tokens_sum = 0
-        
+
         for ma in m_args_list:
             m_args = ma[0][0]
             # pdb.set_trace()
@@ -126,7 +126,7 @@ def test_streaming_new_chat_with_agent_reports_metrics(
         assert input_nb_tokens_sum > 0
         assert output_nb_tokens_sum > 0
 
-"""
+
 @pytest.mark.skipif(not is_cohere_env_set, reason="Cohere API key not set")
 def test_streaming_new_chat_with_agent_existing_conversation(
     session_client_chat: TestClient, session_chat: Session, user: User
@@ -810,8 +810,6 @@ def test_non_streaming_existing_chat_with_attached_files_does_not_attach(
     # Files link not changed
     assert file1.message_id == existing_message.id
     assert file2.message_id == existing_message.id
-
-"""
 
 
 def validate_chat_streaming_response(

--- a/src/backend/tests/routers/test_chat.py
+++ b/src/backend/tests/routers/test_chat.py
@@ -114,7 +114,7 @@ def test_streaming_new_chat_with_agent_reports_metrics(
         
         for ma in m_args_list:
             m_args = ma[0][0]
-            pdb.set_trace()
+            # pdb.set_trace()
             assert m_args.user_id == user.id
             assert m_args.message_type == MetricsMessageType.CHAT_API_SUCCESS
             if m_args.input_nb_tokens:
@@ -122,7 +122,7 @@ def test_streaming_new_chat_with_agent_reports_metrics(
             if m_args.output_nb_tokens:
                 output_nb_tokens_sum += m_args.output_nb_tokens
             assert m_args.assistant_id == agent.id
-            # assert m_args.model == "command-r"
+            assert m_args.model == "command-r"
         assert input_nb_tokens_sum > 0
         assert output_nb_tokens_sum > 0
 

--- a/src/backend/tests/routers/test_chat.py
+++ b/src/backend/tests/routers/test_chat.py
@@ -16,6 +16,7 @@ from backend.database_models.message import Message, MessageAgent
 from backend.database_models.user import User
 from backend.schemas.tool import Category
 from backend.tests.factories import get_factory
+import pdb
 
 is_cohere_env_set = (
     os.environ.get("COHERE_API_KEY") is not None
@@ -29,7 +30,7 @@ def user(session_chat: Session) -> User:
 
 
 # STREAMING CHAT TESTS
-'''
+"""
 @pytest.mark.skipif(not is_cohere_env_set, reason="Cohere API key not set")
 def test_streaming_new_chat(
     session_client_chat: TestClient, session_chat: Session, user: User
@@ -73,7 +74,8 @@ def test_streaming_new_chat_with_agent(
     validate_chat_streaming_response(
         response, user, session_chat, session_client_chat, 2
     )
-'''
+"""
+
 
 @pytest.mark.skipif(not is_cohere_env_set, reason="Cohere API key not set")
 @pytest.mark.asyncio
@@ -96,17 +98,24 @@ def test_streaming_new_chat_with_agent_reports_metrics(
                 "User-Id": user.id,
                 "Deployment-Name": ModelDeploymentName.CoherePlatform,
             },
-            params={"agent_id": agent.id},
-            json={"message": "Hello", "max_tokens": 10},
+            params={},
+            json={
+                "message": "Hello",
+                "max_tokens": 10,
+                "agent_id": agent.id,
+                "model": "command-r",
+            },
         )
 
         assert response.status_code == 200
         m_args: MetricsData = mock_metrics.await_args.args[0]
+        pdb.set_trace()
         assert m_args.user_id == user.id
-        assert m_args.assistant_id == agent.id
         assert m_args.message_type == MetricsMessageType.CHAT_API_SUCCESS
-        assert m_args.assistant.name == agent.name
-        assert m_args.user.fullname == user.fullname
+        assert m_args.input_nb_tokens > 0
+        assert m_args.output_nb_tokens > 0
+        assert m_args.assistant_id == agent.id
+        assert m_args.model == "command-r"
 
 
 """

--- a/src/backend/tests/routers/test_chat.py
+++ b/src/backend/tests/routers/test_chat.py
@@ -108,14 +108,16 @@ def test_streaming_new_chat_with_agent_reports_metrics(
         )
 
         assert response.status_code == 200
-        m_args: MetricsData = mock_metrics.await_args.args[0]
-        pdb.set_trace()
-        assert m_args.user_id == user.id
-        assert m_args.message_type == MetricsMessageType.CHAT_API_SUCCESS
-        assert m_args.input_nb_tokens > 0
-        assert m_args.output_nb_tokens > 0
-        assert m_args.assistant_id == agent.id
-        assert m_args.model == "command-r"
+        m_args_list: MetricsData = mock_metrics.await_args_list
+        for ma in m_args_list:
+            m_args = ma[0][0]
+            pdb.set_trace()
+            assert m_args.user_id == user.id
+            assert m_args.message_type == MetricsMessageType.CHAT_API_SUCCESS
+            assert m_args.input_nb_tokens is not None and m_args.input_nb_tokens > 0
+            assert m_args.output_nb_tokens is not None and m_args.output_nb_tokens > 0
+            assert m_args.assistant_id == agent.id
+            assert m_args.model == "command-r"
 
 
 """

--- a/src/backend/tests/routers/test_chat.py
+++ b/src/backend/tests/routers/test_chat.py
@@ -109,16 +109,22 @@ def test_streaming_new_chat_with_agent_reports_metrics(
 
         assert response.status_code == 200
         m_args_list: MetricsData = mock_metrics.await_args_list
+        input_nb_tokens_sum = 0
+        output_nb_tokens_sum = 0
+        
         for ma in m_args_list:
             m_args = ma[0][0]
             pdb.set_trace()
             assert m_args.user_id == user.id
             assert m_args.message_type == MetricsMessageType.CHAT_API_SUCCESS
-            assert m_args.input_nb_tokens is not None and m_args.input_nb_tokens > 0
-            assert m_args.output_nb_tokens is not None and m_args.output_nb_tokens > 0
+            if m_args.input_nb_tokens:
+                input_nb_tokens_sum += m_args.input_nb_tokens
+            if m_args.output_nb_tokens:
+                output_nb_tokens_sum += m_args.output_nb_tokens
             assert m_args.assistant_id == agent.id
-            assert m_args.model == "command-r"
-
+            # assert m_args.model == "command-r"
+        assert input_nb_tokens_sum > 0
+        assert output_nb_tokens_sum > 0
 
 """
 @pytest.mark.skipif(not is_cohere_env_set, reason="Cohere API key not set")


### PR DESCRIPTION
- **Change**
- **coral-web: make agents the default page (#300)**
- **GDrive Connector with Compass (#277)**
- **update .env.example**
- **revert .env.example, update .env.template**
- **Single container deployment**
- **Assistants/main  - FE code cleanup (#306)**
- **fix(frontend): tools display name**
- **fix(frontend): use DEPLOYMENT_SINGLE_CONTAINER default**
- **show tool description**
- **Remove model**
- **Change**
- **Google Drive picker with no reuath**
- **coral-web: preselect + hide read_document and search_file tools in agent form (#310)**
- **add file picker to create agent**
- **pass through redirect uri**
- **more redirect_url**
- **p=t**
- **update redirect url**
- **add google drive auth and picker**
- **fix prefetch queries**
- **cleanup GDrive UI implementation (#317)**
- **delete agents**
- **fix routing**
- **send google drive file/folder ids to create agent**
- **fix tools sent to /chat**
- **fix useListAgentToolsMetadata**
- **Chat: add agent_id (#319)**
- **Chat: fix infinite loop (#321)**
- **google drive files as tools metadata**
- **Reverting prod targets**
- **fix key console error**
- **improvements to google drive picker**
- **code cleanup unused vars**
- **Some fixes for agents + tools (#325)**
- **chore(toolkit): cleanup and improve code for google drive file picker (#329)**
- **google picker custom styles**
- **fix create assistant with stored values**
- **UI nits**
- **add edit to agents settings**
- **improvements to UX**
- **fix(toolkit): refactor agent components to improve data flow and type-safety (#338)**
- **gdrive docs with compass context for updates and URL**
- **compass update interval**
- **fix comment**
- **unique Compass index per agent per tool**
- **Fixing prod target for next.js + CD for github (#334)**
- **feat(toolkit):  connect update agent to update tool metadata (#342)**
- **fix AgentForm**
- **restrict agent to artifacts + GDrive shortcut mimetype**
- **add compass index refresh**
- **fix mobile create agent**
- **add title in google drive search results**
- **chore(toolkit) merge main into assistants/main (#346)**
- **bring upgrade from openapi to assistants/main (#347)**
- **Fix types for update agent tool metadata**
- **add search results event in UI**
- **fix(tookit): tags in chat history are getting removed after submitting (#351)**
- **feat(toolkit): Improve artifacts UI (#353)**
- **Metrics: fix error when data is None and improve logger (#348)**
- **fix dupe edit icon**
- **Logs: add more logs to chat (#355)**
- **Metrics: return sync generator (#364)**
- **fix(frontend): redirect on 401 (#359)**
- **Metrics: make everything async (#365)**
- **fix rebase**
- **fix generate title**
- **fix search conversation**
- **fix UI**
- **feat(toolkit): Dedupe links when URL is cited multiple times in the references (#371)**
- **Make tool calls async (#373)**
- **metrics: allow suppressing curl logs (#372)**
- **Fix  google drive merge (#370)**
- **regenerate client**
- **add stream_search_results in StreamToolCallsGeneration**
- **add back stream search results UI event**
- **fix(toolkit): multi tool status on latest message only (#378)**
- **fix update panel UI**
- **fix(toolkit): Requests will go into pending on window visibility hidden (#379)**
- **fix(toolkit): disable file picker component for non-owners (#380)**
- **backend: fix all unit tests for assistants/main (#377)**
- **fix agentForm**
- **support all drives plus gdrive error handling**
- **fix on local variable not found**
- **support gdrive without Compass**
- **escaping single quotes**
- **patch share drive query list**
- **nits on gdrive**
- **Update docker_push_frontend.yml**
- **Python interpreter: make call async (#386)**
- **fix CI**
- **metrics: add event types (#376)**
- **feat(toolkit): protect pages before rendering (#388)**
- **Files: add more file types to assistants/main (#375)**
- **PDF parsing**
- **add docx and fix non-agent chatbot**
- **Remove logs**
- **fix lint**
- **infra(toolkit): fix deployment target for UI on prod and dev (#394)**
- **fix docker**
- **fix placeholder text**
- **disable composer on empty message**
- **backend: web scraping in tools + fix metrics data use in tools (#393)**
- **temp: /tool/auth**
- **temp: fixing deployment**
- **temp: fixing deployment**
- **temp: fixing deployment**
- **start testing chat events**

Thank you for contributing to the Cohere Toolkit!

- [ ] **PR title**: "area: description"
  - Where "area" is whichever of interface, frontend, model, tools, backend, etc. is being modified. Use "docs: ..." for purely docs changes, "infra: ..." for CI changes.
  - Example: "deployment: add Azure model option"


- [ ] **PR message**: ***Delete this entire checklist*** and replace with
    - **Description:** a description of the change
    - **Issue:** the issue # it fixes, if applicable
    - **Dependencies:** any dependencies required for this change


- [ ] **Add tests and docs**: Please include testing and documentation for your changes
- [ ] **Lint and test**: Run `make lint` and `make run-tests`

**AI Description**

<!-- begin-generated-description -->

This PR makes changes to multiple files, including:

- **.env-template**: Added configuration for Compass and Google Drive.
- **.github/workflows/docker_push_frontend.yml**: Minor formatting change.
- **.pre-commit-config.yaml**: Updated the rev for black to 24.3.0 and for ruff-pre-commit to v0.4.10.
- **Makefile**: Added a new command `run-my-tests` and updated the `attach` command.
- **docker-compose.yml**: Updated the `test_db` service and made minor changes to the `backend` and `frontend` services.
- **docs/custom_tool_guides/tool_guide.md**: Modified the `call` function to be asynchronous.
- **helper_scripts/metrics_helper.py**: Added new fields to the JSON object created in the `agents` function and added a check before deleting an agent in the `cleanup` function. Also, added a TODO comment.
- **poetry.lock**: Updated multiple package versions, including boto3, botocore, faker, openai, openpyxl, pytest-asyncio, and tenacity.
- **pyproject.toml**: Added openpyxl, Compass dependencies, and pytest-asyncio.
- **src/backend/Dockerfile**: Added a new line to prevent Python from generating `.pyc` files in the container.
- **src/backend/chat/collate.py**: Modified the `rerank_and_chunk` function to be asynchronous.
- **src/backend/chat/custom/custom.py**: Removed the `logging` import and modified the `rerank_and_chunk, `chat, `call_chat, and `call_tools` functions to be asynchronous. Also, added log messages using the `send_log_message` function.
- **src/backend/cli/main.py**: Added a new `BuildTarget` enum and a `build_target_prompt` function.
- **src/backend/compass_sdk/__init__.py**: Added a new `CompassSdk` module with classes for Compass document processing and metadata detection.
- **src/backend/compass_sdk/compass.py**: Added a new `CompassClient` class for interacting with the Compass API.
- **src/backend/compass_sdk/constants.py**: Added constants for the Compass SDK.
- **src/backend/compass_sdk/parser.py**: Added a new `CompassParserClient` class for interacting with the CompassParser API.
- **src/backend/compass_sdk/utils.py**: Added utility functions for the Compass SDK.
- **src/backend/config/auth.py**: Added a check for the `SKIP_AUTH` environment variable and enabled the `OpenIDConnect` auth strategy.
- **src/backend/config/routers.py**: Added `Depends(get_session)` to the default list of middlewares for the `TOOL` router.
- **src/backend/config/tools.py**: Added a new `WebScrapeTool` and updated the `ALL_TOOLS` dictionary.
- **src/backend/crud/file.py**: Added a new function `get_files_by_user_id` to list files by user ID.
- **src/backend/model_deployments/azure.py**: Modified the `invoke_chat, `invoke_chat_stream, and `invoke_rerank` functions to be asynchronous.
- **src/backend/model_deployments/base.py**: Modified the `invoke_chat, `invoke_chat_stream, and `invoke_rerank` functions to be asynchronous.
- **src/backend/model_deployments/bedrock.py**: Modified the `invoke_chat, `invoke_chat_stream, and `invoke_rerank` functions to be asynchronous.
- **src/backend/model_deployments/cohere_platform.py**: Modified the `invoke_chat, `invoke_chat_stream, and `invoke_rerank` functions to be asynchronous.
- **src/backend/model_deployments/sagemaker.py**: Modified the `invoke_chat_stream` and `invoke_rerank` functions to be asynchronous.
- **src/backend/model_deployments/single_container.py**: Modified the `invoke_chat, `invoke_chat_stream, and `invoke_rerank` functions to be asynchronous.

<!-- end-generated-description -->
