### PR TITLE
chore: test dependabot prs skip pytest

### DIFF
--- a/.github/workflows/backend_tests.yml
+++ b/.github/workflows/backend_tests.yml
@@ -21,6 +21,7 @@ jobs:
       - name: Setup Docker
         run: docker compose up test_db -d
       - name: Run tests
+        if: github.actor != 'dependabot[bot]'
         run: |
           mkdir -p coverage
           docker compose build --build-arg INSTALL_COMMUNITY_DEPS=true backend


### PR DESCRIPTION
Thank you for contributing to the Cohere Toolkit!

- [x] **PR title**: "area: description"
  - Workflow, security change

- [x] **PR message**: ***Delete this entire checklist*** and replace with
    - Test Dependabot PRs skipping `pytest` using `actor`
    - Verified this is the [correct supported, documented syntax](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions) ✅ 

- [x] **Add tests and docs**: Please include testing and documentation for your changes
- [NA] **Lint and test**: Run `make lint` and `make run-tests`

**AI Description**

<!-- begin-generated-description -->

This pull request updates the `backend_tests.yml` file to include a new condition for running tests. 

## Summary
The `backend_tests.yml` file, which is part of the GitHub workflow configuration, has been modified to add a new condition for executing tests. Specifically, the `if: github.actor != 'dependabot[bot]'` condition ensures that tests are only run when the GitHub actor is not the `dependabot[bot]`. 

## Changes
- Added a new condition, `if: github.actor != 'dependabot[bot]', to control when tests are executed.

<!-- end-generated-description -->
