### PR TITLE
coral-web: hide agents views components behind env variable

### DIFF
--- a/src/interfaces/coral_web/src/components/Conversation/Composer/ComposerError.tsx
+++ b/src/interfaces/coral_web/src/components/Conversation/Composer/ComposerError.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 
 import { FileError } from '@/components/FileError';
 import { Button, Text } from '@/components/Shared';
+import { useExperimentalFeatures } from '@/hooks/experimentalFeatures';
 import { useUnauthedTools } from '@/hooks/tools';
 import { useFilesStore, useSettingsStore } from '@/stores';
 import { cn } from '@/utils';
@@ -17,6 +18,8 @@ export const ComposerError: React.FC<Props> = ({ className = '' }) => {
   const {
     files: { uploadingFiles },
   } = useFilesStore();
+  const { data: experimentalFeatures } = useExperimentalFeatures();
+  const isAgentsModeOn = !!experimentalFeatures?.USE_AGENTS_VIEW;
   const { unauthedTools } = useUnauthedTools();
   const latestFile = uploadingFiles[uploadingFiles.length - 1];
   // Only use the first tool that requires auth for now since it is unclear how to handle multiple tools
@@ -26,7 +29,7 @@ export const ComposerError: React.FC<Props> = ({ className = '' }) => {
     setSettings({ isConfigDrawerOpen: true });
   };
 
-  if (!!unauthedTool) {
+  if (!!unauthedTool && isAgentsModeOn) {
     return (
       <Text className="mt-2 text-danger-500">
         You need to connect {unauthedTool.display_name} before you can use this assistant.

--- a/src/interfaces/coral_web/src/components/Conversation/Composer/index.tsx
+++ b/src/interfaces/coral_web/src/components/Conversation/Composer/index.tsx
@@ -9,6 +9,7 @@ import { FirstTurnSuggestions } from '@/components/FirstTurnSuggestions';
 import { Icon, STYLE_LEVEL_TO_CLASSES } from '@/components/Shared';
 import { CHAT_COMPOSER_TEXTAREA_ID } from '@/constants';
 import { useBreakpoint, useIsDesktop } from '@/hooks/breakpoint';
+import { useExperimentalFeatures } from '@/hooks/experimentalFeatures';
 import { useSlugRoutes } from '@/hooks/slugRoutes';
 import { useDataSourceTags } from '@/hooks/tags';
 import { useUnauthedTools } from '@/hooks/tools';
@@ -53,6 +54,7 @@ export const Composer: React.FC<Props> = ({
   const { suggestedTags, totalTags, setTagQuery, tagQuery, getTagQuery } = useDataSourceTags({
     requiredTools,
   });
+  const { data: experimentalFeatures } = useExperimentalFeatures();
 
   const [isComposing, setIsComposing] = useState(false);
   const [chatWindowHeight, setChatWindowHeight] = useState(0);
@@ -60,7 +62,9 @@ export const Composer: React.FC<Props> = ({
   const [showDataSourceMenu, setShowDataSourceMenu] = useState(false);
 
   const isReadyToReceiveMessage = !isStreaming;
-  const canSend = isReadyToReceiveMessage && value.trim().length > 0 && !isToolAuthRequired;
+  const isAgentsModeOn = !!experimentalFeatures?.USE_AGENTS_VIEW;
+  const isComposerDisabled = isToolAuthRequired && isAgentsModeOn;
+  const canSend = isReadyToReceiveMessage && value.trim().length > 0 && !isComposerDisabled;
 
   const handleCompositionStart = () => {
     setIsComposing(true);
@@ -86,7 +90,7 @@ export const Composer: React.FC<Props> = ({
   };
 
   const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
-    if (isToolAuthRequired) {
+    if (isComposerDisabled) {
       return;
     }
 
@@ -169,7 +173,7 @@ export const Composer: React.FC<Props> = ({
           'rounded border bg-marble-100',
           'border-marble-500 focus-within:border-secondary-700',
           {
-            'border-marble-500 bg-marble-300': isToolAuthRequired,
+            'border-marble-500 bg-marble-300': isComposerDisabled,
           }
         )}
         onDragEnter={() => setIsDragDropInputActive(true)}
@@ -200,7 +204,7 @@ export const Composer: React.FC<Props> = ({
               STYLE_LEVEL_TO_CLASSES.p,
               'leading-[150%]',
               {
-                'bg-marble-300': isToolAuthRequired,
+                'bg-marble-300': isComposerDisabled,
               }
             )}
             style={{
@@ -211,7 +215,7 @@ export const Composer: React.FC<Props> = ({
             rows={1}
             onKeyDown={handleKeyDown}
             onChange={handleChange}
-            disabled={isToolAuthRequired}
+            disabled={isComposerDisabled}
           />
           <button
             className={cn(

--- a/src/interfaces/coral_web/src/components/Layout.tsx
+++ b/src/interfaces/coral_web/src/components/Layout.tsx
@@ -1,16 +1,149 @@
+import { Transition } from '@headlessui/react';
 import { capitalize } from 'lodash';
-import React, { Children, PropsWithChildren } from 'react';
+import React, { Children, PropsWithChildren, useContext, useEffect, useState } from 'react';
 
 import { AgentsSidePanel } from '@/components/Agents/AgentsSidePanel';
+import { DeploymentsDropdown } from '@/components/DeploymentsDropdown';
+import { EditEnvVariablesButton } from '@/components/EditEnvVariablesButton';
 import { MobileHeader } from '@/components/MobileHeader';
+import { NavigationUserMenu } from '@/components/NavigationUserMenu';
 import { SettingsDrawer } from '@/components/Settings/SettingsDrawer';
+import { Banner } from '@/components/Shared';
+import { NavigationBar } from '@/components/Shared/NavigationBar/NavigationBar';
 import { PageHead } from '@/components/Shared/PageHead';
+import { BannerContext } from '@/context/BannerContext';
+import { useIsDesktop } from '@/hooks/breakpoint';
+import { useSession } from '@/hooks/session';
+import { useSettingsStore } from '@/stores';
 import { cn } from '@/utils/cn';
 
 export const LeftSection: React.FC<React.PropsWithChildren> = ({ children }) => <>{children}</>;
 export const MainSection: React.FC<React.PropsWithChildren> = ({ children }) => <>{children}</>;
 
-type Props = {
+type LayoutProps = {
+  title?: string;
+} & PropsWithChildren;
+
+/**
+ * This component is in charge of layout out the entire page.
+ * It shows the navigation bar, the left drawer and main content.
+ * On small devices (e.g. mobile), the left drawer and main section are stacked vertically.
+ */
+export const Layout: React.FC<LayoutProps> = ({ title = 'Chat', children }) => {
+  const { message: bannerMessage } = useContext(BannerContext);
+  const {
+    settings: { isConvListPanelOpen, isMobileConvListPanelOpen },
+  } = useSettingsStore();
+  const isDesktop = useIsDesktop();
+  const { session } = useSession();
+
+  let leftDrawerElement: React.ReactNode = null;
+  let mainElement: React.ReactNode = null;
+
+  Children.toArray(children).forEach((child: React.ReactNode) => {
+    const element = child as React.ReactElement;
+    const { type } = element;
+
+    switch (type) {
+      case LeftSection:
+        leftDrawerElement = child;
+        break;
+      case MainSection:
+        mainElement = child;
+        break;
+      default:
+        break;
+    }
+  });
+
+  const [userMenu, setUserMenu] = useState<React.ReactNode>(null);
+
+  useEffect(() => {
+    if (session && session.email) {
+      setUserMenu(<NavigationUserMenu userEmail={session.email} />);
+    }
+  }, [session]);
+
+  return (
+    <>
+      <PageHead title={capitalize(title)} />
+      <div className="flex h-screen w-full flex-1 flex-col gap-3 bg-secondary-100 p-3">
+        <NavigationBar>
+          <span className="flex items-center gap-x-2">
+            <DeploymentsDropdown />
+            <EditEnvVariablesButton className="py-0" />
+            {userMenu}
+          </span>
+        </NavigationBar>
+        {bannerMessage && <Banner size="sm">{bannerMessage}</Banner>}
+
+        <div className={cn('relative flex h-full flex-grow flex-nowrap overflow-hidden')}>
+          <Transition
+            as="div"
+            show={isMobileConvListPanelOpen || (isConvListPanelOpen && isDesktop)}
+            enterFrom={cn(
+              '-translate-x-full lg:translate-x-0',
+              'lg:mr-0 lg:opacity-0 lg:min-w-0 lg:max-w-0'
+            )}
+            enterTo={cn(
+              'translate-x-0',
+              'lg:mr-3 lg:opacity-100',
+              'lg:min-w-left-panel-lg 2xl:min-w-left-panel-2xl 3xl:min-w-left-panel-3xl',
+              'lg:max-w-left-panel-lg 2xl:max-w-left-panel-2xl 3xl:max-w-left-panel-3xl'
+            )}
+            leaveFrom={cn(
+              'translate-x-0',
+              'lg:mr-3 lg:opacity-100',
+              'lg:min-w-left-panel-lg 2xl:min-w-left-panel-2xl 3xl:min-w-left-panel-3xl',
+              'lg:max-w-left-panel-lg 2xl:max-w-left-panel-2xl 3xl:max-w-left-panel-3xl'
+            )}
+            leaveTo={cn(
+              '-translate-x-full lg:translate-x-0',
+              'lg:mr-0 lg:opacity-0 lg:border-0 lg:min-w-0 lg:max-w-0'
+            )}
+            className={cn(
+              'lg:flex-grow-0',
+              'transition-transform duration-500 ease-in-out',
+              'lg:transition-[min-width,max-width,margin,opacity,border-width] lg:duration-300',
+              'w-full',
+              'flex flex-grow flex-col rounded-lg border',
+              'border-marble-400 bg-marble-100'
+            )}
+          >
+            {leftDrawerElement}
+          </Transition>
+          <Transition
+            as="main"
+            show={!isMobileConvListPanelOpen || isDesktop}
+            enterFrom="translate-x-full lg:translate-x-0"
+            enterTo="translate-x-0"
+            leaveFrom="translate-x-0"
+            leaveTo="translate-x-full lg:translate-x-0"
+            className={cn(
+              'z-main-section flex flex-grow lg:min-w-0',
+              'absolute h-full w-full lg:static lg:h-auto',
+              'transition-transform duration-500 ease-in-out lg:transition-none'
+            )}
+          >
+            <section
+              className={cn(
+                'relative flex h-full min-w-0 flex-grow flex-col',
+                'rounded-lg border',
+                'border-marble-400 bg-marble-100',
+                'overflow-hidden'
+              )}
+            >
+              {mainElement}
+            </section>
+          </Transition>
+          <SettingsDrawer />
+        </div>
+      </div>
+    </>
+  );
+};
+
+type AgentsLayoutProps = {
   title?: string;
   showSettingsDrawer?: boolean;
 } & PropsWithChildren;
@@ -20,7 +153,7 @@ type Props = {
   It shows the navigation bar, the left drawer and main content.
   On small devices (e.g. mobile), the left drawer and main section are stacked vertically.
  */
-export const Layout: React.FC<Props> = ({
+export const AgentsLayout: React.FC<AgentsLayoutProps> = ({
   title = 'Chat',
   showSettingsDrawer = false,
   children,

--- a/src/interfaces/coral_web/src/components/Layout.tsx
+++ b/src/interfaces/coral_web/src/components/Layout.tsx
@@ -149,7 +149,7 @@ type AgentsLayoutProps = {
 } & PropsWithChildren;
 
 /**
- * @description This component is in charge of layout out the entire page.
+ * @description This component is in charge of layout out the entire page when agents are available.
   It shows the navigation bar, the left drawer and main content.
   On small devices (e.g. mobile), the left drawer and main section are stacked vertically.
  */

--- a/src/interfaces/coral_web/src/components/Settings/AgentsToolsTab.tsx
+++ b/src/interfaces/coral_web/src/components/Settings/AgentsToolsTab.tsx
@@ -2,12 +2,14 @@ import React, { useMemo } from 'react';
 
 import { ManagedTool } from '@/cohere-client';
 import { ToolsInfoBox } from '@/components/Settings/ToolsInfoBox';
-import { Text } from '@/components/Shared';
+import { Button, Icon, Text } from '@/components/Shared';
 import { ToggleCard } from '@/components/ToggleCard';
 import { WelcomeGuideTooltip } from '@/components/WelcomeGuideTooltip';
 import { TOOL_FALLBACK_ICON, TOOL_ID_TO_DISPLAY_INFO } from '@/constants';
+import { useAgent } from '@/hooks/agents';
 import { useDefaultFileLoaderTool } from '@/hooks/files';
-import { useListTools } from '@/hooks/tools';
+import { useSlugRoutes } from '@/hooks/slugRoutes';
+import { useListTools, useUnauthedTools } from '@/hooks/tools';
 import { useFilesStore, useParamsStore } from '@/stores';
 import { ConfigurableParams } from '@/stores/slices/paramsSlice';
 import { cn } from '@/utils';
@@ -15,43 +17,33 @@ import { cn } from '@/utils';
 /**
  * @description Tools tab content that shows a list of available tools and files
  */
-export const ToolsTab: React.FC<{ className?: string }> = ({ className = '' }) => {
+export const AgentsToolsTab: React.FC<{
+  requiredTools: string[] | undefined;
+  className?: string;
+}> = ({ requiredTools, className = '' }) => {
+  const { agentId } = useSlugRoutes();
+  const { data: agent } = useAgent({ agentId });
   const { params, setParams } = useParamsStore();
   const { data } = useListTools();
   const { tools: paramTools } = params;
+  const enabledTools = paramTools ?? [];
   const { defaultFileLoaderTool } = useDefaultFileLoaderTool();
   const { clearComposerFiles } = useFilesStore();
 
-  const { availableTools, unavailableTools } = useMemo(() => {
-    return (data ?? [])
-      .filter((t) => t.is_visible)
-      .reduce<{ availableTools: ManagedTool[]; unavailableTools: ManagedTool[] }>(
-        (acc, tool) => {
-          if (tool.is_available) {
-            acc.availableTools.push(tool);
-          } else {
-            acc.unavailableTools.push(tool);
-          }
-          return acc;
-        },
-        { availableTools: [], unavailableTools: [] }
-      );
-  }, [data]);
-  const enabledTools = paramTools
-    ? availableTools.filter((t) => paramTools.map((t) => t.name).includes(t.name))
-    : [];
+  const { unauthedTools } = useUnauthedTools();
+  const availableTools = useMemo(() => {
+    return (data ?? []).filter(
+      (t) =>
+        t.is_visible &&
+        t.is_available &&
+        (!requiredTools || requiredTools.some((rt) => rt === t.name))
+    );
+  }, [data, requiredTools]);
 
   const handleToggle = (name: string, checked: boolean) => {
-    let tool = availableTools.find((tool) => tool.name === name);
-    if (tool === undefined) {
-      return;
-    }
-    if (tool.is_auth_required && tool.auth_url !== null) {
-      window.location.assign(tool.auth_url!);
-    }
     const newParams: Partial<ConfigurableParams> = {
       tools: checked
-        ? [...enabledTools, tool]
+        ? [...enabledTools, { name }]
         : enabledTools.filter((enabledTool) => enabledTool.name !== name),
     };
 
@@ -68,35 +60,24 @@ export const ToolsTab: React.FC<{ className?: string }> = ({ className = '' }) =
       <ToolsInfoBox />
       <article className={cn('flex flex-col gap-y-5 pb-10')}>
         <Text styleAs="p-sm" className="text-secondary-800">
-          Tools are data sources the assistant can search such as databases or the internet.
+          {availableTools.length === 0
+            ? `${agent?.name} does not use any tools.`
+            : 'Tools are data sources the assistant can search such as databases or the internet.'}
         </Text>
 
-        {unavailableTools.length > 0 && (
+        {unauthedTools.length > 0 && (
           <>
-            <Text as="span" styleAs="label" className="font-medium">
-              Action Required
-            </Text>
-
-            <div className="flex flex-col gap-y-5">
-              {unavailableTools.map(({ name, display_name, description, error_message }) => {
-                return (
-                  <ToggleCard
-                    key={name}
-                    disabled
-                    errorMessage={error_message}
-                    checked={false}
-                    label={display_name ?? name ?? ''}
-                    icon={TOOL_ID_TO_DISPLAY_INFO[name ?? '']?.icon ?? TOOL_FALLBACK_ICON}
-                    description={description ?? ''}
-                    onToggle={(checked) => handleToggle(name ?? '', checked)}
-                  />
-                );
-              })}
+            <div className="flex items-center justify-between">
+              <Text as="span" styleAs="label" className="font-medium">
+                Action Required
+              </Text>
+              <Icon name="warning" kind="outline" />
             </div>
+            <ConnectDataBox tools={unauthedTools} />
           </>
         )}
 
-        {unavailableTools.length > 0 && availableTools.length > 0 && (
+        {unauthedTools.length > 0 && availableTools.length > 0 && (
           <hr className="border-t border-marble-400" />
         )}
 
@@ -110,10 +91,12 @@ export const ToolsTab: React.FC<{ className?: string }> = ({ className = '' }) =
               {availableTools.map(({ name, display_name, description, error_message }) => {
                 const enabledTool = enabledTools.find((enabledTool) => enabledTool.name === name);
                 const checked = !!enabledTool;
+                const disabled = !!requiredTools;
 
                 return (
                   <ToggleCard
                     key={name}
+                    disabled={disabled}
                     errorMessage={error_message}
                     checked={checked}
                     label={display_name ?? name ?? ''}
@@ -129,5 +112,35 @@ export const ToolsTab: React.FC<{ className?: string }> = ({ className = '' }) =
       </article>
       <WelcomeGuideTooltip step={2} className="fixed right-0 mr-3 mt-12 md:right-full md:mt-0" />
     </section>
+  );
+};
+
+/**
+ * @description Info box that prompts the user to connect their data to enable tools
+ */
+const ConnectDataBox: React.FC<{
+  tools: ManagedTool[];
+}> = ({ tools }) => {
+  return (
+    <div className="flex flex-col gap-y-4 rounded border border-dashed border-primary-400 bg-primary-200 p-4">
+      <div className="flex flex-col gap-y-3">
+        <Text styleAs="h5">Connect your data</Text>
+        <Text>
+          In order to get the most accurate answers grounded on your data, connect the following:
+        </Text>
+      </div>
+      <div className="flex flex-col gap-y-1">
+        {tools.map((tool) => (
+          <Button
+            key={tool.name}
+            kind="secondary"
+            href={tool.auth_url ?? ''}
+            endIcon={<Icon name="arrow-up-right" className="ml-1" />}
+          >
+            {tool.display_name}
+          </Button>
+        ))}
+      </div>
+    </div>
   );
 };

--- a/src/interfaces/coral_web/src/components/Settings/SettingsDrawer.tsx
+++ b/src/interfaces/coral_web/src/components/Settings/SettingsDrawer.tsx
@@ -2,11 +2,14 @@ import { Transition } from '@headlessui/react';
 import React, { useMemo, useState } from 'react';
 
 import { IconButton } from '@/components/IconButton';
+import { AgentsToolsTab } from '@/components/Settings/AgentsToolsTab';
 import { FilesTab } from '@/components/Settings/FilesTab';
+import { SettingsTab } from '@/components/Settings/SettingsTab';
 import { ToolsTab } from '@/components/Settings/ToolsTab';
 import { Icon, Tabs, Text } from '@/components/Shared';
 import { SETTINGS_DRAWER_ID } from '@/constants';
 import { useAgent } from '@/hooks/agents';
+import { useExperimentalFeatures } from '@/hooks/experimentalFeatures';
 import { useFilesInConversation } from '@/hooks/files';
 import { useSlugRoutes } from '@/hooks/slugRoutes';
 import { useCitationsStore, useConversationStore, useSettingsStore } from '@/stores';
@@ -31,14 +34,28 @@ export const SettingsDrawer: React.FC = () => {
   const { files } = useFilesInConversation();
   const { agentId } = useSlugRoutes();
   const { data: agent } = useAgent({ agentId });
+  const { data: experimentalFeatures } = useExperimentalFeatures();
+  const isAgentsModeOn = experimentalFeatures?.USE_AGENTS_VIEW;
 
   const tabs = useMemo(() => {
+    if (isAgentsModeOn) {
+      return files.length > 0 && conversationId
+        ? [
+            { name: 'Tools', component: <AgentsToolsTab requiredTools={agent?.tools} /> },
+            { name: 'Files', component: <FilesTab /> },
+          ]
+        : [{ name: 'Tools', component: <AgentsToolsTab requiredTools={agent?.tools} /> }];
+    }
     return files.length > 0 && conversationId
       ? [
-          { name: 'Tools', component: <ToolsTab requiredTools={agent?.tools} /> },
+          { name: 'Tools', component: <ToolsTab requiredTools={[]} /> },
           { name: 'Files', component: <FilesTab /> },
+          { name: 'Settings', component: <SettingsTab /> },
         ]
-      : [{ name: 'Tools', component: <ToolsTab requiredTools={agent?.tools} /> }];
+      : [
+          { name: 'Tools', component: <ToolsTab requiredTools={[]} /> },
+          { name: 'Settings', component: <SettingsTab /> },
+        ];
   }, [files.length, conversationId, agent?.tools]);
 
   return (

--- a/src/interfaces/coral_web/src/components/Settings/SettingsDrawer.tsx
+++ b/src/interfaces/coral_web/src/components/Settings/SettingsDrawer.tsx
@@ -48,12 +48,12 @@ export const SettingsDrawer: React.FC = () => {
     }
     return files.length > 0 && conversationId
       ? [
-          { name: 'Tools', component: <ToolsTab requiredTools={[]} /> },
+          { name: 'Tools', component: <ToolsTab /> },
           { name: 'Files', component: <FilesTab /> },
           { name: 'Settings', component: <SettingsTab /> },
         ]
       : [
-          { name: 'Tools', component: <ToolsTab requiredTools={[]} /> },
+          { name: 'Tools', component: <ToolsTab /> },
           { name: 'Settings', component: <SettingsTab /> },
         ];
   }, [files.length, conversationId, agent?.tools]);

--- a/src/interfaces/coral_web/src/components/Settings/SettingsTab.tsx
+++ b/src/interfaces/coral_web/src/components/Settings/SettingsTab.tsx
@@ -1,0 +1,98 @@
+import { Dropdown, InputLabel, STYLE_LEVEL_TO_CLASSES, Slider, Text } from '@/components/Shared';
+import { useModels } from '@/hooks/deployments';
+import { useExperimentalFeatures } from '@/hooks/experimentalFeatures';
+import { useSettingsDefaults } from '@/hooks/settings';
+import { useParamsStore } from '@/stores';
+import { cn } from '@/utils';
+
+/**
+ * @description Settings tab to adjust endpoint params like preamble and temperature.
+ */
+export const SettingsTab: React.FC = () => {
+  const {
+    params: { deployment, temperature, preamble, model },
+    setParams,
+  } = useParamsStore();
+  const defaults = useSettingsDefaults();
+  const { data: experimentalFeatures } = useExperimentalFeatures();
+  const isLangchainModeOn = !!experimentalFeatures?.USE_EXPERIMENTAL_LANGCHAIN;
+  const { models } = useModels(deployment ?? '');
+  const modelOptions = [
+    {
+      options: models.map((model) => ({
+        label: model,
+        value: model,
+      })),
+    },
+  ];
+
+  const reset = () => {
+    setParams({
+      ...defaults,
+      tools: defaults.tools,
+    });
+  };
+
+  if (isLangchainModeOn) {
+    return (
+      <div className="flex items-center justify-center px-5">
+        <Text styleAs="p-lg" className="select-none text-center text-volcanic-900">
+          Currently settings are disabled with experimental Langchain multihop
+        </Text>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-y-6 px-5 pb-10">
+      <Dropdown
+        className="w-full"
+        label="Model"
+        kind="default"
+        value={model}
+        onChange={(model: string) => setParams({ model })}
+        optionGroups={modelOptions}
+      />
+      <Slider
+        className="w-full"
+        label="Temperature"
+        min={0}
+        max={1}
+        step={0.1}
+        value={temperature || 0}
+        onChange={(temperature: number) => setParams({ temperature })}
+        dataTestId="slider-temperature"
+      />
+
+      <InputLabel label="Preamble">
+        <textarea
+          value={preamble}
+          placeholder="e.g. You are Coral, a large language model trained to have polite, helpful, inclusive conversations with people."
+          className={cn(
+            'mt-2 w-full flex-1 resize-none p-3',
+            'transition ease-in-out',
+            'rounded-lg border',
+            'bg-marble-100',
+            'border-marble-500 placeholder:text-volcanic-700 focus:border-secondary-700',
+            'focus-visible:outline focus-visible:outline-1 focus-visible:outline-offset-4 focus-visible:outline-volcanic-900',
+            STYLE_LEVEL_TO_CLASSES.p
+          )}
+          rows={5}
+          onChange={(e) => setParams({ preamble: e.target.value })}
+          data-testid="input-preamble"
+        />
+      </InputLabel>
+
+      <div className="flex w-full justify-end">
+        <button type="button" onClick={reset}>
+          <Text
+            as="span"
+            className="text-secondary-800 transition ease-in-out hover:text-volcanic-900"
+          >
+            Reset
+          </Text>
+        </button>
+      </div>
+    </div>
+  );
+};

--- a/src/interfaces/coral_web/src/pages/[[...slug]].tsx
+++ b/src/interfaces/coral_web/src/pages/[[...slug]].tsx
@@ -169,6 +169,7 @@ const Page: NextPage = () => {
             <div className="flex h-full">
               <Transition
                 as="section"
+                appear
                 show={(isMobileConvListPanelOpen && isMobile) || (isConvListPanelOpen && isDesktop)}
                 enterFrom="translate-x-full lg:translate-x-0 lg:min-w-0 lg:max-w-0"
                 enterTo="translate-x-0 lg:min-w-[300px] lg:max-w-[300px]"

--- a/src/interfaces/coral_web/src/pages/[[...slug]].tsx
+++ b/src/interfaces/coral_web/src/pages/[[...slug]].tsx
@@ -217,14 +217,16 @@ const Page: NextPage = () => {
   }
 
   return (
-    <Layout>
-      <LeftSection>
-        <ConversationListPanel />
-      </LeftSection>
-      <MainSection>
-        <Conversation conversationId={conversation?.id} startOptionsEnabled />
-      </MainSection>
-    </Layout>
+    <ProtectedPage>
+      <Layout>
+        <LeftSection>
+          <ConversationListPanel />
+        </LeftSection>
+        <MainSection>
+          <Conversation conversationId={conversation?.id} startOptionsEnabled />
+        </MainSection>
+      </Layout>
+    </ProtectedPage>
   );
 };
 

--- a/src/interfaces/coral_web/src/pages/[[...slug]].tsx
+++ b/src/interfaces/coral_web/src/pages/[[...slug]].tsx
@@ -215,6 +215,7 @@ const Page: NextPage = () => {
       </ProtectedPage>
     );
   }
+
   return (
     <Layout>
       <LeftSection>

--- a/src/interfaces/coral_web/src/pages/discover.tsx
+++ b/src/interfaces/coral_web/src/pages/discover.tsx
@@ -6,7 +6,7 @@ import { useEffect, useState } from 'react';
 import { CohereClient } from '@/cohere-client';
 import { AgentsList } from '@/components/Agents/AgentsList';
 import { DiscoverAgentCard } from '@/components/Agents/DiscoverAgentCard';
-import { Layout, LeftSection, MainSection } from '@/components/Layout';
+import { AgentsLayout, LeftSection, MainSection } from '@/components/Layout';
 import { ProtectedPage } from '@/components/ProtectedPage';
 import { Input, Text } from '@/components/Shared';
 import { useListAgents } from '@/hooks/agents';
@@ -40,7 +40,7 @@ const AgentsNewPage: NextPage<Props> = () => {
 
   return (
     <ProtectedPage>
-      <Layout>
+      <AgentsLayout>
         <LeftSection>
           <AgentsList />
         </LeftSection>
@@ -95,7 +95,7 @@ const AgentsNewPage: NextPage<Props> = () => {
             </div>
           </div>
         </MainSection>
-      </Layout>
+      </AgentsLayout>
     </ProtectedPage>
   );
 };

--- a/src/interfaces/coral_web/src/pages/new.tsx
+++ b/src/interfaces/coral_web/src/pages/new.tsx
@@ -4,7 +4,7 @@ import { GetServerSideProps, NextPage } from 'next';
 import { CohereClient } from '@/cohere-client';
 import { AgentsList } from '@/components/Agents/AgentsList';
 import { CreateAgent } from '@/components/Agents/CreateAgent';
-import { Layout, LeftSection, MainSection } from '@/components/Layout';
+import { AgentsLayout, LeftSection, MainSection } from '@/components/Layout';
 import { ProtectedPage } from '@/components/ProtectedPage';
 import { appSSR } from '@/pages/_app';
 
@@ -13,14 +13,14 @@ type Props = {};
 const AgentsNewPage: NextPage<Props> = () => {
   return (
     <ProtectedPage>
-      <Layout>
+      <AgentsLayout>
         <LeftSection>
           <AgentsList />
         </LeftSection>
         <MainSection>
           <CreateAgent />
         </MainSection>
-      </Layout>
+      </AgentsLayout>
     </ProtectedPage>
   );
 };


### PR DESCRIPTION
Hides agents related UI additions behind the `USE_AGENTS_VIEW` environment variable

## `USE_AGENTS_VIEW=False`

https://github.com/user-attachments/assets/6945d6b3-d7a3-47eb-88c2-642171c3f038

## `USE_AGENTS_VIEW=True`


https://github.com/user-attachments/assets/b2122b40-b132-43a2-ae1f-621b85eaf5b8


**AI Description**

<!-- begin-generated-description -->

This PR introduces a new `AgentsLayout` component and makes changes to the `Layout` component. It also adds a new `SettingsTab` component and modifies the `ToolsTab` component.

## Summary
- The `Layout` component now includes additional imports, props, and state/context usage. It renders the `NavigationBar`, `Banner`, and `SettingsDrawer` components, and manages the layout for different device sizes.
- The new `AgentsLayout` component is introduced, which seems to be a variation of the `Layout` component with some differences in the rendered elements and styles.
- The `SettingsTab` component is added to allow adjusting endpoint parameters like model, temperature, and preamble.
- The `ToolsTab` component is modified to include a new `SettingsTab` component and update the handling of available and unavailable tools.

## Changes
- **New files:**
  - `SettingsTab`

- **Modified files:**
  - `Layout`
  - `ToolsTab`

- **Newly introduced components:**
  - `AgentsLayout`
  - `SettingsTab`

- **Modified components:**
  - `Layout`
  - `ToolsTab`

<!-- end-generated-description -->
