### PR TITLE
backend: Show logs when running make dev command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,9 @@
 dev:
-	@docker compose watch
+	make -j 2 watch up
+watch:
+	@docker compose watch --no-up
+up:
+	@docker compose up
 down:
 	@docker compose down
 run-tests:


### PR DESCRIPTION
**Description:**

This PR changes the `make dev` command so that it both watches the files with `docker compose watch`, and runs `docker compose up` explicitly so that the logs show up in the console.

The `docker compose watch` command previously being used starts the services up, but it suppresses log output. That is by design and there is no flag to make it show the log output from the services. To get around this, the change in this PR takes the approach of running both commands in separate processes. The flag `--no-up` is added to `docker compose watch`, which changes its behavour to only watch, and not start the services up automatically.

**AI Description**

<!-- begin-generated-description -->

The `Makefile` has been updated to include new targets and modify the existing `dev` target.

- The `dev` target now invokes the `make` command with the `-j 2 watch up` options, replacing the previous `@docker compose watch` command.
- Three new targets, `watch`, `up`, and `down`, have been added to the `Makefile`.
  - The `watch` target uses the `@docker compose watch --no-up` command.
  - The `up` target uses the `@docker compose up` command.
  - The `down` target uses the `@docker compose down` command.

<!-- end-generated-description -->
