### PR TITLE
frontend: Add back the Register link if basic auth is enabled

### DIFF
--- a/src/interfaces/coral_web/src/cohere-client/client.ts
+++ b/src/interfaces/coral_web/src/cohere-client/client.ts
@@ -39,7 +39,7 @@ export class CohereClient {
     this.authToken = authToken;
     this.cohereService = new CohereClientGenerated({
       BASE: hostname,
-      HEADERS: this.getHeaders(true),
+      HEADERS: async () => this.getHeaders(true),
     });
   }
 

--- a/src/interfaces/coral_web/src/pages/_app.tsx
+++ b/src/interfaces/coral_web/src/pages/_app.tsx
@@ -68,7 +68,7 @@ const App: React.FC<Props> = ({ Component, pageProps, ...props }) => {
       new QueryClient({
         queryCache: new QueryCache({
           onError: (error) => {
-            if (error instanceof CohereUnauthorizedError) {
+            if (error instanceof Error && error.message === "Unauthorized") {
               clearAuthToken();
               // Extract the current URL without query parameters or host.
               const currentPath = window.location.pathname + window.location.hash;

--- a/src/interfaces/coral_web/src/pages/login.tsx
+++ b/src/interfaces/coral_web/src/pages/login.tsx
@@ -5,6 +5,7 @@ import { useMemo, useState } from 'react';
 import { SubmitHandler, useForm } from 'react-hook-form';
 
 import { CohereClient, CohereUnauthorizedError, ListAuthStrategy } from '@/cohere-client';
+import { AuthLink } from '@/components/AuthLink';
 import { Button, Input, Text } from '@/components/Shared';
 import { OidcSSOButton } from '@/components/Welcome/OidcSSOButton';
 import { WelcomePage } from '@/components/WelcomePage';
@@ -85,8 +86,13 @@ const LoginPage: NextPage<Props> = () => {
     });
   };
 
+  const welcomePageProps: { title: string; navigationAction?: 'register' | 'login' } = {
+    title: 'Login',
+    navigationAction: hasBasicAuth ? 'register' : undefined,
+  };
+
   return (
-    <WelcomePage title="Login">
+    <WelcomePage {...welcomePageProps}>
       <div className="flex flex-col items-center justify-center">
         <Text
           as="h1"
@@ -116,54 +122,68 @@ const LoginPage: NextPage<Props> = () => {
         </div>
 
         {hasBasicAuth && (
-          <form
-            onSubmit={handleSubmit(onSubmit)}
-            onChange={() => setErrors([])}
-            className="mt-10 flex w-full flex-col"
-          >
-            <Input
-              className="w-full"
-              label="Email"
-              placeholder="yourname@email.com"
-              type="email"
-              stackPosition="start"
-              hasError={!!formState.errors.email}
-              errorText="Please enter a valid email address"
-              {...register('email', {
-                required: true,
-                validate: (value) => simpleEmailValidation(value),
-              })}
-            />
+          <>
+            <form
+              onSubmit={handleSubmit(onSubmit)}
+              onChange={() => setErrors([])}
+              className="mt-10 flex w-full flex-col"
+            >
+              <Input
+                className="w-full"
+                label="Email"
+                placeholder="yourname@email.com"
+                type="email"
+                stackPosition="start"
+                hasError={!!formState.errors.email}
+                errorText="Please enter a valid email address"
+                {...register('email', {
+                  required: true,
+                  validate: (value) => simpleEmailValidation(value),
+                })}
+              />
 
-            <Input
-              className="mb-2 w-full"
-              label="Password"
-              placeholder="••••••••••••"
-              type="password"
-              actionType="revealable"
-              stackPosition="end"
-              hasError={!!formState.errors.password}
-              errorText="Please enter a valid password"
-              {...register('password', { required: true })}
-            />
+              <Input
+                className="mb-2 w-full"
+                label="Password"
+                placeholder="••••••••••••"
+                type="password"
+                actionType="revealable"
+                stackPosition="end"
+                hasError={!!formState.errors.password}
+                errorText="Please enter a valid password"
+                {...register('password', { required: true })}
+              />
 
-            {errors.map(
-              (error) =>
-                error && (
-                  <Text key={error} className="mt-4 text-danger-500 first-letter:uppercase">
-                    {error}
-                  </Text>
-                )
-            )}
+              {errors.map(
+                (error) =>
+                  error && (
+                    <Text key={error} className="mt-4 text-danger-500 first-letter:uppercase">
+                      {error}
+                    </Text>
+                  )
+              )}
 
-            <Button
-              disabled={loginStatus === 'pending' || !formState.isValid}
-              label={loginStatus === 'pending' ? 'Logging in...' : 'Log in'}
-              type="submit"
-              className="mt-10 w-full self-center md:w-fit"
-              splitIcon="arrow-right"
-            />
-          </form>
+              <Button
+                disabled={loginStatus === 'pending' || !formState.isValid}
+                label={loginStatus === 'pending' ? 'Logging in...' : 'Log in'}
+                type="submit"
+                className="mt-10 w-full self-center md:w-fit"
+                splitIcon="arrow-right"
+              />
+            </form>
+
+            <Text
+              as="div"
+              className="mt-10 flex w-full items-center justify-between text-volcanic-700"
+            >
+              New user?
+              <AuthLink
+                redirect={redirect !== '/' ? redirect : undefined}
+                action="register"
+                className="text-green-700 no-underline"
+              />
+            </Text>
+          </>
         )}
       </div>
     </WelcomePage>


### PR DESCRIPTION
Restore the link to the Register page if the backend has been configured for login with a username and password.

Also fixes an issue introduced with the change to the new API client that broke Authorization headers.

**AI Description**

<!-- begin-generated-description -->

This pull request makes changes to the `src/interfaces/coral_web/src/cohere-client/client.ts` and `src/interfaces/coral_web/src/pages/login.tsx` files.

## Summary
The changes in this PR mainly involve updating the `HEADERS` property in the `CohereClient` class and modifying the `LoginPage` component in the `login.tsx` file.

## Changes
- Modified the `HEADERS` property in the `CohereClient` class to be an async function that returns the headers.
- Added the `AuthLink` component import from `'@/components/AuthLink''.
- Introduced `welcomePageProps` to hold the `title` and `navigationAction` props for the `WelcomePage` component.
- Replaced the `WelcomePage` component invocation with its JSXS spread syntax, passing in the `welcomePageProps`.
- Wrapped the form and the new user text with the `AuthLink` component in a fragment `<>`.

<!-- end-generated-description -->
