### PR TITLE
fix(toolkit): Improves file upload component and user experience

### DIFF
--- a/src/interfaces/coral_web/src/components/Conversation/Composer/ComposerFiles.tsx
+++ b/src/interfaces/coral_web/src/components/Conversation/Composer/ComposerFiles.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { MessageFile } from '@/components/MessageFile';
-import { useFilesStore } from '@/stores';
+import { useFilesStore, useParamsStore } from '@/stores';
 
 /**
  * @description Displays files that have been prepared to be uploaded along with the next chat request
@@ -12,6 +12,19 @@ export const ComposerFiles = () => {
     deleteUploadingFile,
     deleteComposerFile,
   } = useFilesStore();
+
+  const {
+    params: { fileIds },
+    setParams,
+  } = useParamsStore();
+
+  const handleComposerFileDelete = (fileId: string) => {
+    deleteComposerFile(fileId);
+
+    if (fileIds?.some((d) => d === fileId)) {
+      setParams({ fileIds: fileIds.filter((d) => d !== fileId) });
+    }
+  };
 
   const noErrorUploadingFiles = uploadingFiles.filter((document) => !document.error);
 
@@ -26,7 +39,7 @@ export const ComposerFiles = () => {
           name={file.file_name ?? ''}
           size={file.file_size ?? 0}
           className="w-48 md:w-60"
-          onDelete={() => deleteComposerFile(file.id ?? '')}
+          onDelete={() => handleComposerFileDelete(file.id ?? '')}
         />
       ))}
       {noErrorUploadingFiles.map((document, index) => (

--- a/src/interfaces/coral_web/src/components/Conversation/Composer/ComposerToolbar.tsx
+++ b/src/interfaces/coral_web/src/components/Conversation/Composer/ComposerToolbar.tsx
@@ -32,7 +32,7 @@ export const ComposerToolbar: React.FC<Props> = ({ isStreaming, onUploadFile, me
       <input
         ref={fileInputRef}
         type="file"
-        accept={ACCEPTED_FILE_TYPES.join('')}
+        accept={ACCEPTED_FILE_TYPES.join(',')}
         className="hidden"
         onChange={onUploadFile}
       />

--- a/src/interfaces/coral_web/src/pages/[[...slug]].tsx
+++ b/src/interfaces/coral_web/src/pages/[[...slug]].tsx
@@ -167,6 +167,7 @@ const Page: NextPage = () => {
           <div className="flex h-full">
             <Transition
               as="section"
+              appear
               show={(isMobileConvListPanelOpen && isMobile) || (isConvListPanelOpen && isDesktop)}
               enterFrom="translate-x-full lg:translate-x-0 lg:min-w-0 lg:max-w-0"
               enterTo="translate-x-0 lg:min-w-[300px] lg:max-w-[300px]"

--- a/src/interfaces/coral_web/src/utils/format.ts
+++ b/src/interfaces/coral_web/src/utils/format.ts
@@ -18,6 +18,13 @@ export const getWeeksAgo = (date: string | Date): { weeksAgo: number; weeksAgoSt
 };
 
 /**
+ * Converts a file size in megabytes to bytes
+ */
+export const fileSizeToBytes = (size: number): number => {
+  return size * 1024 * 1024;
+};
+
+/**
  * Converts a file size in bytes to megabytes
  * */
 export const fileSizeToMB = (size: number): number => {


### PR DESCRIPTION
Fixes bugs with the file upload component:

- Remove errors on new files uploaded
- Limit file size to 20mb
- When user removes a file, it is also removed from the composer tools
- Accept file types is not working as expected

**AI Description**

<!-- begin-generated-description -->

This pull request makes changes to the file uploading functionality. 

## Changes:
- Adds a new utility function, `fileSizeToBytes`, to convert file size from megabytes to bytes.
- Updates the `useFileActions` hook to:
  - Clean up uploading files with errors.
  - Validate the file size against a new constant, `MAX_FILE_SIZE`, before uploading.
- Updates the `ComposerFiles` component to:
  - Handle file deletion using a new `handleComposerFileDelete` function.
  - Use the `fileIds` param from the `useParamsStore` store.
- Updates the `ComposerToolbar` component to change the `accept` prop of the file input element by joining the `ACCEPTED_FILE_TYPES` with a comma instead of leaving it empty.
- Adds an `appear` prop to the `Transition` component in the `Page` component.

<!-- end-generated-description -->
