### PR TITLE
fix: increase toolEvents when pushing search results event

### DIFF
--- a/src/interfaces/coral_web/src/hooks/chat.ts
+++ b/src/interfaces/coral_web/src/hooks/chat.ts
@@ -274,10 +274,19 @@ export const useChat = (config?: { onSend?: (msg: string) => void }) => {
                 mapDocuments(documents);
               documentsMap = { ...documentsMap, ...newDocumentsMap };
               outputFiles = { ...outputFiles, ...newOutputFilesMap };
-              toolEvents.push({
-                text: '',
-                stream_search_results: data,
-              } as StreamToolCallsGeneration);
+              // we are only interested in web_search results
+              // ignore search results of pyhton interpreter tool
+              if (
+                toolEvents[currentToolEventIndex - 1]?.tool_calls?.[0]?.name !==
+                TOOL_PYTHON_INTERPRETER_ID
+              ) {
+                toolEvents.push({
+                  text: '',
+                  stream_search_results: data,
+                  tool_calls: [],
+                } as StreamToolCallsGeneration);
+                currentToolEventIndex += 1;
+              }
               break;
             }
 


### PR DESCRIPTION
## Description

Before this fix, when we received a `search-results` event, we didn't increase the `currentToolEventIndex`. The same event was used when we received a new `tool-call-chunk`. This one didn't have the `tool_calls` property initialized, and it failed to add the first "chunk" of the stream, which was the name, so the whole stream event was lost. 

Also, I ignored the `search results` from a `python_interpreter` because they are not really formatted or prepared to be shown, and they are not required.

Closes OS-2284