### PR TITLE
GDrive: make it async again

### DIFF
--- a/src/backend/tools/google_drive/tool.py
+++ b/src/backend/tools/google_drive/tool.py
@@ -60,7 +60,7 @@ class GoogleDrive(BaseTool):
         logger.error(message)
         raise Exception(message)
 
-    def call(self, parameters: dict, **kwargs: Any) -> List[Dict[str, Any]]:
+    async def call(self, parameters: dict, **kwargs: Any) -> List[Dict[str, Any]]:
         """
         Google Drive logic
         """
@@ -166,7 +166,7 @@ class GoogleDrive(BaseTool):
         ]
         id_to_urls = extract_links(native_files)
         if id_to_urls:
-            id_to_texts = async_download.sync_perform(id_to_urls, creds.token)
+            id_to_texts = await async_download.async_perform(id_to_urls, creds.token)
 
         # initialize Compass
         compass = None
@@ -188,7 +188,7 @@ class GoogleDrive(BaseTool):
         non_native_files = [
             x for x in processed_files if x["mimeType"] in NON_NATIVE_SEARCH_MIME_TYPES
         ]
-        non_native_results = non_native_files_perform(
+        non_native_results = await non_native_files_perform(
             service=service, compass=compass, files=non_native_files
         )
         id_to_texts = {

--- a/src/backend/tools/google_drive/utils.py
+++ b/src/backend/tools/google_drive/utils.py
@@ -76,10 +76,10 @@ def process_shortcut_files(service: Any, files: List[Dict[str, str]]) -> Dict[st
     return processed_files
 
 
-def non_native_files_perform(
+async def non_native_files_perform(
     service: Any, compass: Compass, files: List[Dict[str, str]]
 ) -> dict[str, str]:
-    return asyncio.run(_download_non_native_files(service, compass, files))
+    return await _download_non_native_files(service, compass, files)
 
 
 async def _download_non_native_files(


### PR DESCRIPTION
Thank you for contributing to the Cohere Toolkit!

- [ ] **PR title**: "area: description"
  - Where "area" is whichever of interface, frontend, model, tools, backend, etc. is being modified. Use "docs: ..." for purely docs changes, "infra: ..." for CI changes.
  - Example: "deployment: add Azure model option"


- [ ] **PR message**: ***Delete this entire checklist*** and replace with
    - **Description:** a description of the change
    - **Issue:** the issue # it fixes, if applicable
    - **Dependencies:** any dependencies required for this change


- [ ] **Add tests and docs**: Please include testing and documentation for your changes
- [ ] **Lint and test**: Run `make lint` and `make run-tests`

**AI Description**

<!-- begin-generated-description -->

This pull request introduces changes to `tool.py` and `utils.py` within the `src/backend/tools/google_drive/` directory. The modifications involve converting specific functions to be asynchronous by adding the `async` keyword before their definitions. This change allows these functions to run concurrently and efficiently handle tasks that involve waiting for I/O or other asynchronous operations.

**Changes:**
- Modified the `call` function in `tool.py` to be asynchronous by adding the `async` keyword before its definition.
- Updated the return type of the `call` function in `tool.py` to `List [Dict [str, Any]]`.
- Changed `async_download.sync_perform` to `async_download.async_perform` in `tool.py` to align with the asynchronous nature of the function.
- Modified `non_native_files_perform` in `utils.py` to be asynchronous by adding the `async` keyword and updating the return statement to use `await` instead of `asyncio.run`.

<!-- end-generated-description -->
