### PR TITLE
fix(toolkit): make google drive env vars optional

### DIFF
--- a/src/interfaces/coral_web/src/env.mjs
+++ b/src/interfaces/coral_web/src/env.mjs
@@ -7,8 +7,8 @@ export const env = createEnv({
   client: {
     NEXT_PUBLIC_API_HOSTNAME: z.string(),
     NEXT_PUBLIC_FRONTEND_HOSTNAME: z.string().optional().default('http://localhost:4000'),
-    NEXT_PUBLIC_GOOGLE_DRIVE_CLIENT_ID: z.string(),
-    NEXT_PUBLIC_GOOGLE_DRIVE_DEVELOPER_KEY: z.string(),
+    NEXT_PUBLIC_GOOGLE_DRIVE_CLIENT_ID: z.string().optional(),
+    NEXT_PUBLIC_GOOGLE_DRIVE_DEVELOPER_KEY: z.string().optional(),
     NEXT_PUBLIC_HAS_CUSTOM_LOGO: z.string().optional().default('false'),
   },
   runtimeEnv: {

--- a/src/interfaces/coral_web/src/hooks/tools.ts
+++ b/src/interfaces/coral_web/src/hooks/tools.ts
@@ -68,10 +68,18 @@ export const useOpenGoogleDrivePicker = (callbackFunction: (data: PickerCallback
     callbackFunction(data);
   };
 
+  const googleDriveClientId = env.NEXT_PUBLIC_GOOGLE_DRIVE_CLIENT_ID;
+  const googleDriveDeveloperKey = env.NEXT_PUBLIC_GOOGLE_DRIVE_DEVELOPER_KEY;
+  if (!googleDriveClientId || !googleDriveDeveloperKey) {
+    return () => {
+      info('Google Drive is not available at the moment.');
+    };
+  }
+
   return () =>
     openPicker({
-      clientId: env.NEXT_PUBLIC_GOOGLE_DRIVE_CLIENT_ID,
-      developerKey: env.NEXT_PUBLIC_GOOGLE_DRIVE_DEVELOPER_KEY,
+      clientId: googleDriveClientId,
+      developerKey: googleDriveDeveloperKey,
       token: googleDriveTool?.token || '',
       setIncludeFolders: true,
       setSelectFolderEnabled: true,


### PR DESCRIPTION

**AI Description**

<!-- begin-generated-description -->

This pull request makes Google Drive integration optional in the `coral_web` interface. 

Previously, the `NEXT_PUBLIC_GOOGLE_DRIVE_CLIENT_ID` and `NEXT_PUBLIC_GOOGLE_DRIVE_DEVELOPER_KEY` environment variables were required for the Google Drive picker to function. Now, these variables are optional, and the picker will display an informational message if Google Drive is unavailable due to missing credentials.

**Code Changes:**
- In `env.mjs`, the `NEXT_PUBLIC_GOOGLE_DRIVE_CLIENT_ID` and `NEXT_PUBLIC_GOOGLE_DRIVE_DEVELOPER_KEY` variables are now marked as `optional`.
- In `tools.ts`, added a check to display an informational message if `NEXT_PUBLIC_GOOGLE_DRIVE_CLIENT_ID` or `NEXT_PUBLIC_GOOGLE_DRIVE_DEVELOPER_KEY` are missing.
- Updated the `clientId` and `developerKey` values in `tools.ts` to use the new optional environment variables.

<!-- end-generated-description -->
