### PR TITLE
tanzim/default agent route v3

### DIFF
--- a/src/backend/config/routers.py
+++ b/src/backend/config/routers.py
@@ -21,6 +21,7 @@ class RouterName(StrEnum):
     TOOL = "tool"
     USER = "user"
     AGENT = "agent"
+    DEFAULT_AGENT = "default_agent"
     SNAPSHOT = "snapshot"
 
 
@@ -93,6 +94,16 @@ ROUTER_DEPENDENCIES = {
         ],
     },
     RouterName.AGENT: {
+        "default": [
+            Depends(get_session),
+        ],
+        "auth": [
+            Depends(get_session),
+            # TODO: Add if the router's have to have authorization
+            # Depends(validate_authorization),
+        ],
+    },
+    RouterName.DEFAULT_AGENT: {
         "default": [
             Depends(get_session),
         ],

--- a/src/backend/main.py
+++ b/src/backend/main.py
@@ -14,6 +14,7 @@ from backend.config.auth import (
     verify_migrate_token,
 )
 from backend.config.routers import ROUTER_DEPENDENCIES
+from backend.routers.agent import default_agent_router
 from backend.routers.agent import router as agent_router
 from backend.routers.auth import router as auth_router
 from backend.routers.chat import router as chat_router
@@ -46,6 +47,7 @@ def create_app():
         deployment_router,
         experimental_feature_router,
         agent_router,
+        default_agent_router,
         snapshot_router,
     ]
 

--- a/src/backend/routers/agent.py
+++ b/src/backend/routers/agent.py
@@ -128,7 +128,7 @@ default_agent_router = APIRouter(
 default_agent_router.name = RouterName.DEFAULT_AGENT
 
 
-@default_agent_router.get("/", response_model=ResponseMessage)
+@default_agent_router.get("/", response_model=GenericResponseMessage)
 async def get_default_agent(session: DBSessionDep, request: Request):
     add_event_type_to_request_state(request, MetricsMessageType.ASSISTANT_ACCESSED)
     add_default_agent_to_request_state(request)

--- a/src/backend/routers/agent.py
+++ b/src/backend/routers/agent.py
@@ -11,6 +11,7 @@ from backend.database_models.database import DBSessionDep
 from backend.routers.utils import (
     add_agent_to_request_state,
     add_agent_tool_metadata_to_request_state,
+    add_default_agent_to_request_state,
     add_event_type_to_request_state,
     add_session_user_to_request_state,
 )
@@ -118,6 +119,20 @@ async def list_agents(
         return agent_crud.get_agents(session, offset=offset, limit=limit)
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
+
+
+# simply for logging purposes
+default_agent_router = APIRouter(
+    prefix="/v1/default_agent",
+)
+default_agent_router.name = RouterName.DEFAULT_AGENT
+
+
+@default_agent_router.get("/")
+async def get_default_agent(session: DBSessionDep, request: Request):
+    add_event_type_to_request_state(request, MetricsMessageType.ASSISTANT_ACCESSED)
+    add_default_agent_to_request_state(request)
+    return {"message": "OK"}
 
 
 @router.get("/{agent_id}", response_model=Agent)

--- a/src/backend/routers/agent.py
+++ b/src/backend/routers/agent.py
@@ -27,7 +27,7 @@ from backend.schemas.agent import (
     UpdateAgent,
     UpdateAgentToolMetadata,
 )
-from backend.schemas.metrics import MetricsMessageType, GenericResponseMessage
+from backend.schemas.metrics import GenericResponseMessage, MetricsMessageType
 from backend.services.agent import (
     raise_db_error,
     validate_agent_exists,

--- a/src/backend/routers/agent.py
+++ b/src/backend/routers/agent.py
@@ -27,7 +27,7 @@ from backend.schemas.agent import (
     UpdateAgent,
     UpdateAgentToolMetadata,
 )
-from backend.schemas.metrics import MetricsMessageType
+from backend.schemas.metrics import MetricsMessageType, GenericResponseMessage
 from backend.services.agent import (
     raise_db_error,
     validate_agent_exists,
@@ -128,7 +128,7 @@ default_agent_router = APIRouter(
 default_agent_router.name = RouterName.DEFAULT_AGENT
 
 
-@default_agent_router.get("/")
+@default_agent_router.get("/", response_model=ResponseMessage)
 async def get_default_agent(session: DBSessionDep, request: Request):
     add_event_type_to_request_state(request, MetricsMessageType.ASSISTANT_ACCESSED)
     add_default_agent_to_request_state(request)

--- a/src/backend/routers/utils.py
+++ b/src/backend/routers/utils.py
@@ -7,9 +7,24 @@ from backend.schemas.agent import Agent, AgentToolMetadata
 from backend.schemas.metrics import MetricsAgent, MetricsMessageType, MetricsUser
 from backend.services.auth.utils import get_header_user_id
 
+DEFAULT_METRICS_AGENT = MetricsAgent(
+    id="9c300cfd-1506-408b-829d-a6464137a7c1",
+    version="1",
+    name="Default Agent",
+    temperature=0.3,
+    model="command-r-plus",
+    deployment="Cohere",
+    preamble="",
+    description="hardcoded default agent for logging purposes",
+)
+
 
 def add_event_type_to_request_state(request: Request, event_type: MetricsMessageType):
     request.state.event_type = event_type
+
+
+def add_default_agent_to_request_state(request: Request):
+    request.state.agent = DEFAULT_METRICS_AGENT
 
 
 def add_agent_to_request_state(request: Request, agent: Agent):

--- a/src/backend/routers/utils.py
+++ b/src/backend/routers/utils.py
@@ -15,7 +15,7 @@ DEFAULT_METRICS_AGENT = MetricsAgent(
     model="command-r-plus",
     deployment="Cohere",
     preamble="",
-    description="hardcoded default agent for logging purposes",
+    description="default",
 )
 
 

--- a/src/backend/schemas/metrics.py
+++ b/src/backend/schemas/metrics.py
@@ -6,6 +6,10 @@ from typing import Any
 from pydantic import BaseModel
 
 
+class GenericResponseMessage(BaseModel):
+    message: str
+
+
 class MetricsMessageType(str, Enum):
     # users: implemented, has tests
     USER_CREATED = "user_created"

--- a/src/backend/services/metrics.py
+++ b/src/backend/services/metrics.py
@@ -75,7 +75,7 @@ class MetricsMiddleware(BaseHTTPMiddleware):
         try:
             user_id = get_header_user_id(request)
         except:
-            logger.warning(f"Failed to get user id - {endpoint_name}")
+            logger.warning(f"Failed to get user id from headers")
             return None
 
         agent = self.get_agent(request)

--- a/src/backend/tests/routers/test_agent.py
+++ b/src/backend/tests/routers/test_agent.py
@@ -363,6 +363,24 @@ async def test_get_agent_mertic(
         assert m_args.assistant.name == agent.name
 
 
+@pytest.mark.asyncio
+async def test_get_default_agent_mertic(
+    session_client: TestClient, session: Session, user
+) -> None:
+
+    with patch(
+        "backend.services.metrics.report_metrics",
+        return_value=None,
+    ) as mock_metrics:
+        response = session_client.get(
+            f"/v1/default_agent", headers={"User-Id": user.id}
+        )
+        assert response.status_code == 200
+        m_args: MetricsData = mock_metrics.await_args.args[0].signal
+        assert m_args.message_type == MetricsMessageType.ASSISTANT_ACCESSED
+        assert m_args.assistant.name == "Default Agent"
+
+
 def test_get_agent(session_client: TestClient, session: Session, user) -> None:
     agent = get_factory("Agent", session).create(name="test agent")
     agent_tool_metadata = get_factory("AgentToolMetadata", session).create(

--- a/src/interfaces/coral_web/src/cohere-client/client.ts
+++ b/src/interfaces/coral_web/src/cohere-client/client.ts
@@ -266,6 +266,10 @@ export class CohereClient {
     return this.cohereService.default.getAgentByIdV1AgentsAgentIdGet({ agentId });
   }
 
+  public getDefaultAgent() {
+    return this.cohereService.default.getDefaultAgentV1DefaultAgentGet();
+  }
+
   public createAgent(requestBody: CreateAgent) {
     return this.cohereService.default.createAgentV1AgentsPost({ requestBody });
   }

--- a/src/interfaces/coral_web/src/cohere-client/generated/schemas.gen.ts
+++ b/src/interfaces/coral_web/src/cohere-client/generated/schemas.gen.ts
@@ -1391,6 +1391,18 @@ export const $GenerateTitle = {
   title: 'GenerateTitle',
 } as const;
 
+export const $GenericResponseMessage = {
+  properties: {
+    message: {
+      type: 'string',
+      title: 'Message',
+    },
+  },
+  type: 'object',
+  required: ['message'],
+  title: 'GenericResponseMessage',
+} as const;
+
 export const $HTTPValidationError = {
   properties: {
     detail: {

--- a/src/interfaces/coral_web/src/cohere-client/generated/services.gen.ts
+++ b/src/interfaces/coral_web/src/cohere-client/generated/services.gen.ts
@@ -39,6 +39,7 @@ import type {
   GetAgentByIdV1AgentsAgentIdGetResponse,
   GetConversationV1ConversationsConversationIdGetData,
   GetConversationV1ConversationsConversationIdGetResponse,
+  GetDefaultAgentV1DefaultAgentGetResponse,
   GetSnapshotV1SnapshotsLinkLinkIdGetData,
   GetSnapshotV1SnapshotsLinkLinkIdGetResponse,
   GetStrategiesV1AuthStrategiesGetResponse,
@@ -1270,6 +1271,18 @@ export class DefaultService {
       errors: {
         422: 'Validation Error',
       },
+    });
+  }
+
+  /**
+   * Get Default Agent
+   * @returns GenericResponseMessage Successful Response
+   * @throws ApiError
+   */
+  public getDefaultAgentV1DefaultAgentGet(): CancelablePromise<GetDefaultAgentV1DefaultAgentGetResponse> {
+    return this.httpRequest.request({
+      method: 'GET',
+      url: '/v1/default_agent/',
     });
   }
 

--- a/src/interfaces/coral_web/src/cohere-client/generated/types.gen.ts
+++ b/src/interfaces/coral_web/src/cohere-client/generated/types.gen.ts
@@ -265,6 +265,10 @@ export type GenerateTitle = {
   title: string;
 };
 
+export type GenericResponseMessage = {
+  message: string;
+};
+
 export type HTTPValidationError = {
   detail?: Array<ValidationError>;
 };
@@ -843,6 +847,8 @@ export type DeleteAgentToolMetadataV1AgentsAgentIdToolMetadataAgentToolMetadataI
 export type DeleteAgentToolMetadataV1AgentsAgentIdToolMetadataAgentToolMetadataIdDeleteResponse =
   DeleteAgentToolMetadata;
 
+export type GetDefaultAgentV1DefaultAgentGetResponse = GenericResponseMessage;
+
 export type ListSnapshotsV1SnapshotsGetResponse = Array<SnapshotWithLinks>;
 
 export type CreateSnapshotV1SnapshotsPostData = {
@@ -1384,6 +1390,16 @@ export type $OpenApiTs = {
          * Validation Error
          */
         422: HTTPValidationError;
+      };
+    };
+  };
+  '/v1/default_agent/': {
+    get: {
+      res: {
+        /**
+         * Successful Response
+         */
+        200: GenericResponseMessage;
       };
     };
   };

--- a/src/interfaces/coral_web/src/hooks/agents.ts
+++ b/src/interfaces/coral_web/src/hooks/agents.ts
@@ -60,6 +60,17 @@ export const useAgent = ({ agentId }: { agentId?: string }) => {
   });
 };
 
+export const useDefaultAgent = (enabled?: boolean) => {
+  const cohereClient = useCohereClient();
+  return useQuery({
+    queryKey: ['defaultAgent'],
+    enabled: enabled,
+    queryFn: async () => {
+      return await cohereClient.getDefaultAgent();
+    },
+  });
+};
+
 /**
  * @description Returns a function to check if an agent name is unique.
  */

--- a/src/interfaces/coral_web/src/pages/[[...slug]].tsx
+++ b/src/interfaces/coral_web/src/pages/[[...slug]].tsx
@@ -15,7 +15,7 @@ import { Spinner } from '@/components/Shared';
 import { TOOL_PYTHON_INTERPRETER_ID } from '@/constants';
 import { BannerContext } from '@/context/BannerContext';
 import { ModalContext } from '@/context/ModalContext';
-import { useAgent } from '@/hooks/agents';
+import { useAgent, useDefaultAgent } from '@/hooks/agents';
 import { useIsDesktop } from '@/hooks/breakpoint';
 import { useConversation } from '@/hooks/conversation';
 import { useListAllDeployments } from '@/hooks/deployments';
@@ -54,6 +54,7 @@ const Page: NextPage = () => {
   const { show: showUnauthedToolsModal, onDismissed } = useShowUnauthedToolsModal();
   const { data: allDeployments } = useListAllDeployments();
   const { data: agent } = useAgent({ agentId });
+  useDefaultAgent(!agentId);
   const { data: tools } = useListTools();
   const { data: experimentalFeatures } = useExperimentalFeatures();
   const isLangchainModeOn = !!experimentalFeatures?.USE_EXPERIMENTAL_LANGCHAIN;
@@ -262,6 +263,15 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
         queryKey: ['agent', agentId],
         queryFn: async () => {
           return await deps.cohereClient.getAgent(agentId);
+        },
+      })
+    );
+  } else {
+    prefetchQueries.push(
+      deps.queryClient.prefetchQuery({
+        queryKey: ['defaultAgent'],
+        queryFn: async () => {
+          return await deps.cohereClient.getDefaultAgent();
         },
       })
     );


### PR DESCRIPTION
<!-- begin-generated-description -->

This PR introduces a new default agent router, which includes the necessary configurations, dependencies, and test updates.

- The `DEFAULT_AGENT` and `DEFAULT_AGENT_DEFAULT` configurations have been added to the `RouterName` class in `src/backend/config/routers.py`.
- The `default_agent_router` import and inclusion in the `create_app` function in `src/backend/main.py`.
- The `add_default_agent_to_request_state` function import in `src/backend/routers/agent.py`.
- The `default_agent_router` definition, including its prefix and name, has been added to `src/backend/routers/agent.py`.
- The `get_default_agent` function, which retrieves the default agent and returns a generic response message, has been added to `src/backend/routers/agent.py`.
- The `DEFAULT_METRICS_AGENT` constant, representing the default agent's details, has been defined in `src/backend/routers/utils.py`.
- The `GenericResponseMessage` model, which includes a `message` field, has been added to `src/backend/schemas/metrics.py`.
- The `test_get_default_agent_metric` function, which tests the default agent retrieval, has been added to `src/backend/tests/routers/test_agent.py`.
- The necessary types and functions for the default agent retrieval have been added to the TypeScript code in `src/interfaces/coral_web/src/`.

<!-- end-generated-description -->