### PR TITLE
backend: Change the JWT expiry time to 3 months

### DIFF
--- a/src/backend/services/auth/jwt.py
+++ b/src/backend/services/auth/jwt.py
@@ -12,7 +12,7 @@ logger = get_logger()
 
 class JWTService:
     ISSUER = "cohere-toolkit"
-    EXPIRY_HOURS = 12
+    EXPIRY_MONTHS = 3
     ALGORITHM = "HS256"
 
     def __init__(self):
@@ -39,7 +39,7 @@ class JWTService:
         payload = {
             "iss": self.ISSUER,
             "iat": now,
-            "exp": now + datetime.timedelta(hours=self.EXPIRY_HOURS),
+            "exp": now + datetime.timedelta(months=self.EXPIRY_MONTHS),
             "jti": str(uuid.uuid4()),
             "context": user,
         }


### PR DESCRIPTION
Logging in every 12 hours appears to be too short of a default, so we're bumping it up to 3 months.

**AI Description**

<!-- begin-generated-description -->

<!--
  New: command-r-plus will maintain a pr description for you!
  Simply delete this section to opt out.
  Content inside this section will be overwritten by command as the PR is updated.
-->

<!-- end-generated-description -->
