### PR TITLE
metrics: send the correct time from event

### DIFF
--- a/src/backend/model_deployments/cohere_platform.py
+++ b/src/backend/model_deployments/cohere_platform.py
@@ -15,7 +15,6 @@ from backend.chat.enums import StreamEvent
 from backend.model_deployments.base import BaseDeployment
 from backend.model_deployments.utils import get_model_config_var
 from backend.schemas.cohere_chat import CohereChatRequest
-from backend.schemas.metrics import MetricsData
 from backend.services.logger import get_logger, send_log_message
 
 COHERE_API_KEY_ENV_VAR = "COHERE_API_KEY"

--- a/src/backend/schemas/metrics.py
+++ b/src/backend/schemas/metrics.py
@@ -40,7 +40,7 @@ class MetricsDataBase(BaseModel):
     user_id: str
     trace_id: str
     message_type: MetricsMessageType
-    timestamp: float = time.time()
+    timestamp: float
     secret: str = ""
 
 

--- a/src/backend/services/metrics.py
+++ b/src/backend/services/metrics.py
@@ -83,11 +83,13 @@ class MetricsMiddleware(BaseHTTPMiddleware):
         user = self.get_user(request)
         object_ids = self.get_object_ids(request)
         event_id = str(uuid.uuid4())
+        now_unix_seconds = time.time()
 
         try:
             data = MetricsData(
                 id=event_id,
                 user_id=user_id,
+                timestamp=now_unix_seconds,
                 user=user,
                 message_type=message_type,
                 trace_id=request.state.trace_id,


### PR DESCRIPTION
<!-- begin-generated-description -->

The pull request updates the `timestamp` field in the `MetricsDataBase` class and the `get_event_data` function to use the current Unix timestamp in seconds. 

## Summary
- The `timestamp` field in the `MetricsDataBase` class now has a default value of the current Unix timestamp in seconds.
- The `get_event_data` function now includes a `now_unix_seconds` variable, which stores the current Unix timestamp in seconds and is used as the `timestamp` value in the `MetricsData` object.

<!-- end-generated-description -->