### PR TITLE
fix(toolkit): clear file errors on message send

### DIFF
--- a/src/interfaces/coral_web/src/hooks/chat.ts
+++ b/src/interfaces/coral_web/src/hooks/chat.ts
@@ -94,6 +94,7 @@ export const useChat = (config?: { onSend?: (msg: string) => void }) => {
   const {
     files: { composerFiles },
     clearComposerFiles,
+    clearUploadingErrors,
   } = useFilesStore();
   const queryClient = useQueryClient();
 
@@ -235,6 +236,7 @@ export const useChat = (config?: { onSend?: (msg: string) => void }) => {
 
     try {
       clearComposerFiles();
+      clearUploadingErrors();
 
       await streamConverse({
         request,

--- a/src/interfaces/coral_web/src/stores/index.ts
+++ b/src/interfaces/coral_web/src/stores/index.ts
@@ -64,6 +64,7 @@ export const useFilesStore = () => {
       addComposerFile: state.addComposerFile,
       deleteComposerFile: state.deleteComposerFile,
       clearComposerFiles: state.clearComposerFiles,
+      clearUploadingErrors: state.clearUploadingErrors,
       updateUploadingFileError: state.updateUploadingFileError,
     }),
     shallow

--- a/src/interfaces/coral_web/src/stores/slices/filesSlice.ts
+++ b/src/interfaces/coral_web/src/stores/slices/filesSlice.ts
@@ -31,6 +31,7 @@ type Actions = {
   updateUploadingFileError: (file: UploadingFile, error: string) => void;
   deleteUploadingFile: (id: string) => void;
   deleteComposerFile: (id: string) => void;
+  clearUploadingErrors: () => void;
   clearComposerFiles: () => void;
 };
 
@@ -103,6 +104,19 @@ export const createFilesSlice: StateCreator<StoreState, [], [], FilesStore> = (s
         composerFiles: state.files.composerFiles.filter((f) => f.id !== id),
       },
     }));
+  },
+  clearUploadingErrors() {
+    set((state) => {
+      const newUploadingFiles = state.files.uploadingFiles.filter(
+        (f) => typeof f.error === 'undefined'
+      );
+      return {
+        files: {
+          ...state.files,
+          uploadingFiles: newUploadingFiles,
+        },
+      };
+    });
   },
   clearComposerFiles() {
     set((state) => ({


### PR DESCRIPTION


**AI Description**

<!-- begin-generated-description -->

This pull request introduces a new `clearUploadingErrors` function to the `filesSlice` and updates the `useFilesStore` and `useChat` hooks to use this new function.

- `clearUploadingErrors` is added to the `useFilesStore` hook in `index.ts`.
- `clearUploadingErrors` is called in the `useChat` hook in `chat.ts`.
- `clearUploadingErrors` is defined in `filesSlice.ts` to filter out uploading files with errors.

<!-- end-generated-description -->
