### PR TITLE
fix(toolkit): Generating new convo_id for upload files on brand new conversation

### DIFF
--- a/src/interfaces/coral_web/src/components/Conversation/index.tsx
+++ b/src/interfaces/coral_web/src/components/Conversation/index.tsx
@@ -139,7 +139,7 @@ const Conversation: React.FC<Props> = ({
   }
 
   const handleUploadFile = async (e: React.ChangeEvent<HTMLInputElement>) => {
-    const newFileIds = await uploadFile(e.target.files?.[0], conversationId);
+    const newFileIds = await uploadFile(e.target.files?.[0]);
     if (!newFileIds) return;
     enableDefaultFileLoaderTool();
   };

--- a/src/interfaces/coral_web/src/hooks/files.ts
+++ b/src/interfaces/coral_web/src/hooks/files.ts
@@ -102,9 +102,9 @@ export const useFileActions = () => {
   const { mutateAsync: uploadFile } = useUploadFile();
   const { mutateAsync: deleteFile } = useDeleteUploadedFile();
   const { error } = useNotify();
-  const { setConversation } = useConversationStore();
+  const { setConversation, conversation } = useConversationStore();
 
-  const handleUploadFile = async (file?: File, conversationId?: string) => {
+  const handleUploadFile = async (file?: File) => {
     // cleanup uploadingFiles with errors
     const uploadingFilesWithErrors = uploadingFiles.filter((file) => file.error);
     uploadingFilesWithErrors.forEach((file) => deleteUploadingFile(file.id));
@@ -138,7 +138,10 @@ export const useFileActions = () => {
     }
 
     try {
-      const uploadedFile = await uploadFile({ file: newUploadingFile.file, conversationId });
+      const uploadedFile = await uploadFile({
+        file: newUploadingFile.file,
+        conversationId: conversation.id,
+      });
 
       if (!uploadedFile?.id) {
         throw new FileUploadError('File ID not found');
@@ -149,7 +152,7 @@ export const useFileActions = () => {
       const newFileIds = [...(fileIds ?? []), uploadedFileId];
       setParams({ fileIds: newFileIds });
       addComposerFile(uploadedFile);
-      if (!conversationId) {
+      if (!conversation.id) {
         setConversation({ id: uploadedFile.conversation_id });
       }
 


### PR DESCRIPTION
**AI Description**

<!-- begin-generated-description -->

This pull request updates the `handleUploadFile` function in the `Conversation` component and the `useFileActions` hook to remove the explicit dependency on the `conversationId` parameter. 

### Changes: 
- The `handleUploadFile` function in `index.tsx` no longer includes the `conversationId` parameter when calling the `uploadFile` function. 
- The `useFileActions` hook in `files.ts` now destructures `conversation` from `useConversationStore`. 
- The `handleUploadFile` function in `files.ts` no longer includes the `conversationId` parameter. 
- When calling the `uploadFile` function in `files.ts`, the `conversationId` property is now passed by destructuring `conversation.id` from the `conversation` object. 
- When checking for the existence of a `conversationId`, the code now checks for `conversation.id` instead.

<!-- end-generated-description -->
