### PR TITLE
Auth: fix expiry date

### DIFF
--- a/src/backend/config/routers.py
+++ b/src/backend/config/routers.py
@@ -103,16 +103,16 @@ ROUTER_DEPENDENCIES = {
             # Depends(validate_authorization),
         ],
     },
-    # RouterName.DEFAULT_AGENT: {
-    #     "default": [
-    #         Depends(get_session),
-    #     ],
-    #     "auth": [
-    #         Depends(get_session),
-    #         # TODO: Add if the router's have to have authorization
-    #         # Depends(validate_authorization),
-    #     ],
-    # },
+    RouterName.DEFAULT_AGENT: {
+        "default": [
+            Depends(get_session),
+        ],
+        "auth": [
+            Depends(get_session),
+            # TODO: Add if the router's have to have authorization
+            # Depends(validate_authorization),
+        ],
+    },
     RouterName.SNAPSHOT: {
         "default": [
             Depends(get_session),

--- a/src/backend/config/routers.py
+++ b/src/backend/config/routers.py
@@ -103,16 +103,16 @@ ROUTER_DEPENDENCIES = {
             # Depends(validate_authorization),
         ],
     },
-    RouterName.DEFAULT_AGENT: {
-        "default": [
-            Depends(get_session),
-        ],
-        "auth": [
-            Depends(get_session),
-            # TODO: Add if the router's have to have authorization
-            # Depends(validate_authorization),
-        ],
-    },
+    # RouterName.DEFAULT_AGENT: {
+    #     "default": [
+    #         Depends(get_session),
+    #     ],
+    #     "auth": [
+    #         Depends(get_session),
+    #         # TODO: Add if the router's have to have authorization
+    #         # Depends(validate_authorization),
+    #     ],
+    # },
     RouterName.SNAPSHOT: {
         "default": [
             Depends(get_session),

--- a/src/backend/services/auth/jwt.py
+++ b/src/backend/services/auth/jwt.py
@@ -12,7 +12,7 @@ logger = get_logger()
 
 class JWTService:
     ISSUER = "cohere-toolkit"
-    EXPIRY_MONTHS = 3
+    EXPIRY_DAYS = 90
     ALGORITHM = "HS256"
 
     def __init__(self):
@@ -39,7 +39,7 @@ class JWTService:
         payload = {
             "iss": self.ISSUER,
             "iat": now,
-            "exp": now + datetime.timedelta(months=self.EXPIRY_MONTHS),
+            "exp": now + datetime.timedelta(days=self.EXPIRY_DAYS),
             "jti": str(uuid.uuid4()),
             "context": user,
         }

--- a/src/backend/tests/routers/auth/test_authorization_header.py
+++ b/src/backend/tests/routers/auth/test_authorization_header.py
@@ -67,7 +67,7 @@ def test_validate_authorization_invalid_token():
 
 def test_validate_authorization_expired_token():
     user = {"user_id": "test"}
-    with freezegun.freeze_time("2024-01-01 00:00:00"):
+    with freezegun.freeze_time("2023-01-01 00:00:00"):
         token = JWTService().create_and_encode_jwt(user)
 
     request_mock = MagicMock(headers={"Authorization": f"Bearer {token}"})


### PR DESCRIPTION
Thank you for contributing to the Cohere Toolkit!

- [ ] **PR title**: "area: description"
  - Where "area" is whichever of interface, frontend, model, tools, backend, etc. is being modified. Use "docs: ..." for purely docs changes, "infra: ..." for CI changes.
  - Example: "deployment: add Azure model option"


- [ ] **PR message**: ***Delete this entire checklist*** and replace with
    - **Description:** a description of the change
    - **Issue:** the issue # it fixes, if applicable
    - **Dependencies:** any dependencies required for this change


- [ ] **Add tests and docs**: Please include testing and documentation for your changes
- [ ] **Lint and test**: Run `make lint` and `make run-tests`

**AI Description**

<!-- begin-generated-description -->

This pull request makes changes to the backend code, specifically modifying the JWT token expiry time and updating code comments.

## Summary
The `JWTService` class in `jwt.py` has been updated to change the expiry time of JWT tokens from 3 months to 90 days. This is achieved by modifying the `EXPIRY_DAYS` attribute and the `exp` key in the JWT payload. 

Additionally, the code block containing the `RouterName.DEFAULT_AGENT` configuration in `routers.py` has been commented out, and a TODO comment has been added to indicate that authorization may need to be added to the routers. 

Finally, the `test_validate_authorization_expired_token` function in `test_authorization_header.py` has been updated to freeze time one year earlier, likely to simulate token expiration for testing purposes.

## Changes
- Modify the expiry time of JWT tokens from 3 months to 90 days in `jwt.py`.
- Comment out the `RouterName.DEFAULT_AGENT` configuration in `routers.py` and add a TODO comment regarding authorization.
- Update the frozen time in the `test_validate_authorization_expired_token` function in `test_authorization_header.py`.

<!-- end-generated-description -->
