### PR TITLE
Luisa/fix migration fk

### DIFF
--- a/src/backend/alembic/versions/f077676dfd5d_.py
+++ b/src/backend/alembic/versions/f077676dfd5d_.py
@@ -27,37 +27,73 @@ def upgrade() -> None:
         type_=sa.String(),
         nullable=True,
     )
-    op.create_foreign_key(
-        None, "agent_tool_metadata", "users", ["user_id"], ["id"], ondelete="CASCADE"
+    op.alter_column(
+        "agents",
+        "user_id",
+        existing_type=sa.TEXT(),
+        type_=sa.String(),
+        nullable=True,
     )
     op.alter_column(
-        "agents", "user_id", existing_type=sa.TEXT(), type_=sa.String(), nullable=True
-    )
-    op.create_foreign_key(
-        None, "agents", "users", ["user_id"], ["id"], ondelete="CASCADE"
+        "tool_auth",
+        "user_id",
+        existing_type=sa.TEXT(),
+        type_=sa.String(),
+        nullable=True,
     )
     op.alter_column("citations", "user_id", existing_type=sa.VARCHAR(), nullable=True)
-    op.create_foreign_key(
-        None, "citations", "users", ["user_id"], ["id"], ondelete="CASCADE"
-    )
     op.alter_column(
         "conversations", "user_id", existing_type=sa.VARCHAR(), nullable=True
-    )
-    op.create_unique_constraint(
-        "conversation_id_user_id", "conversations", ["id", "user_id"]
-    )
-    op.create_index(
-        "conversation_user_id_index", "conversations", ["id", "user_id"], unique=True
-    )
-    op.create_foreign_key(
-        None, "conversations", "users", ["user_id"], ["id"], ondelete="CASCADE"
     )
     op.alter_column("documents", "user_id", existing_type=sa.VARCHAR(), nullable=True)
     op.alter_column(
         "documents", "conversation_id", existing_type=sa.VARCHAR(), nullable=True
     )
+    op.alter_column("files", "user_id", existing_type=sa.VARCHAR(), nullable=True)
+    op.alter_column(
+        "files", "conversation_id", existing_type=sa.VARCHAR(), nullable=True
+    )
+    op.alter_column("messages", "user_id", existing_type=sa.VARCHAR(), nullable=True)
+    op.alter_column(
+        "messages", "conversation_id", existing_type=sa.VARCHAR(), nullable=True
+    )
+    op.alter_column(
+        "snapshot_access", "user_id", existing_type=sa.VARCHAR(), nullable=True
+    )
+    op.alter_column(
+        "snapshot_links", "user_id", existing_type=sa.VARCHAR(), nullable=True
+    )
+    op.alter_column("snapshots", "user_id", existing_type=sa.VARCHAR(), nullable=True)
+
     op.drop_constraint(
         "documents_conversation_id_fkey", "documents", type_="foreignkey"
+    )
+    op.drop_constraint("files_conversation_id_fkey", "files", type_="foreignkey")
+    op.drop_constraint("messages_conversation_id_fkey", "messages", type_="foreignkey")
+    op.drop_constraint(
+        "snapshots_conversation_id_fkey", "snapshots", type_="foreignkey"
+    )
+    op.drop_constraint("conversations_pkey", "conversations", type_="primary")
+
+    op.create_unique_constraint(
+        "conversation_id_user_id", "conversations", ["id", "user_id"]
+    )
+    op.create_primary_key("conversations_pkey", "conversations", ["id", "user_id"])
+    op.create_index(
+        "conversation_user_id_index", "conversations", ["id", "user_id"], unique=True
+    )
+
+    op.create_foreign_key(
+        None, "agent_tool_metadata", "users", ["user_id"], ["id"], ondelete="CASCADE"
+    )
+    op.create_foreign_key(
+        None, "agents", "users", ["user_id"], ["id"], ondelete="CASCADE"
+    )
+    op.create_foreign_key(
+        None, "citations", "users", ["user_id"], ["id"], ondelete="CASCADE"
+    )
+    op.create_foreign_key(
+        None, "conversations", "users", ["user_id"], ["id"], ondelete="CASCADE"
     )
     op.create_foreign_key(
         "document_conversation_id_user_id_fkey",
@@ -67,11 +103,6 @@ def upgrade() -> None:
         ["id", "user_id"],
         ondelete="CASCADE",
     )
-    op.alter_column("files", "user_id", existing_type=sa.VARCHAR(), nullable=True)
-    op.alter_column(
-        "files", "conversation_id", existing_type=sa.VARCHAR(), nullable=True
-    )
-    op.drop_constraint("files_conversation_id_fkey", "files", type_="foreignkey")
     op.create_foreign_key(
         "file_conversation_id_user_id_fkey",
         "files",
@@ -80,11 +111,6 @@ def upgrade() -> None:
         ["id", "user_id"],
         ondelete="CASCADE",
     )
-    op.alter_column("messages", "user_id", existing_type=sa.VARCHAR(), nullable=True)
-    op.alter_column(
-        "messages", "conversation_id", existing_type=sa.VARCHAR(), nullable=True
-    )
-    op.drop_constraint("messages_conversation_id_fkey", "messages", type_="foreignkey")
     op.create_foreign_key(
         "message_conversation_id_user_id_fkey",
         "messages",
@@ -93,21 +119,11 @@ def upgrade() -> None:
         ["id", "user_id"],
         ondelete="CASCADE",
     )
-    op.alter_column(
-        "snapshot_access", "user_id", existing_type=sa.VARCHAR(), nullable=True
-    )
     op.create_foreign_key(
         None, "snapshot_access", "users", ["user_id"], ["id"], ondelete="CASCADE"
     )
-    op.alter_column(
-        "snapshot_links", "user_id", existing_type=sa.VARCHAR(), nullable=True
-    )
     op.create_foreign_key(
         None, "snapshot_links", "users", ["user_id"], ["id"], ondelete="CASCADE"
-    )
-    op.alter_column("snapshots", "user_id", existing_type=sa.VARCHAR(), nullable=True)
-    op.drop_constraint(
-        "snapshots_conversation_id_fkey", "snapshots", type_="foreignkey"
     )
     op.create_foreign_key(
         "snapshot_conversation_id_user_id_fkey",
@@ -117,13 +133,6 @@ def upgrade() -> None:
         ["id", "user_id"],
         ondelete="CASCADE",
     )
-    op.alter_column(
-        "tool_auth",
-        "user_id",
-        existing_type=sa.TEXT(),
-        type_=sa.String(),
-        nullable=True,
-    )
     op.create_foreign_key(
         None, "tool_auth", "users", ["user_id"], ["id"], ondelete="CASCADE"
     )
@@ -132,17 +141,24 @@ def upgrade() -> None:
 
 def downgrade() -> None:
     # ### commands auto generated by Alembic - please adjust! ###
-    op.drop_constraint(None, "tool_auth", type_="foreignkey")
-    op.alter_column(
-        "tool_auth",
-        "user_id",
-        existing_type=sa.String(),
-        type_=sa.TEXT(),
-        nullable=False,
+    op.drop_constraint("tool_auth_user_id_fkey", "tool_auth", type_="foreignkey")
+    op.drop_constraint(
+        "snapshot_links_user_id_fkey", "snapshot_links", type_="foreignkey"
     )
     op.drop_constraint(
-        "snapshot_conversation_id_user_id_fkey", "snapshots", type_="foreignkey"
+        "snapshot_access_user_id_fkey", "snapshot_access", type_="foreignkey"
     )
+    op.drop_constraint(
+        "message_conversation_id_user_id_fkey", "messages", type_="foreignkey"
+    )
+    op.drop_constraint("file_conversation_id_user_id_fkey", "files", type_="foreignkey")
+    op.drop_constraint(
+        "document_conversation_id_user_id_fkey", "documents", type_="foreignkey"
+    )
+    op.drop_constraint("conversation_user_id_index", "conversations", type_="index")
+    op.drop_constraint("conversations_pkey", "conversations", type_="primary")
+    op.drop_constraint("conversation_id_user_id", "conversations", type_="unique")
+    op.create_primary_key("conversations_pkey", "conversations", ["id"])
     op.create_foreign_key(
         "snapshots_conversation_id_fkey",
         "snapshots",
@@ -150,18 +166,6 @@ def downgrade() -> None:
         ["conversation_id"],
         ["id"],
         ondelete="CASCADE",
-    )
-    op.alter_column("snapshots", "user_id", existing_type=sa.VARCHAR(), nullable=False)
-    op.drop_constraint(None, "snapshot_links", type_="foreignkey")
-    op.alter_column(
-        "snapshot_links", "user_id", existing_type=sa.VARCHAR(), nullable=False
-    )
-    op.drop_constraint(None, "snapshot_access", type_="foreignkey")
-    op.alter_column(
-        "snapshot_access", "user_id", existing_type=sa.VARCHAR(), nullable=False
-    )
-    op.drop_constraint(
-        "message_conversation_id_user_id_fkey", "messages", type_="foreignkey"
     )
     op.create_foreign_key(
         "messages_conversation_id_fkey",
@@ -171,11 +175,6 @@ def downgrade() -> None:
         ["id"],
         ondelete="CASCADE",
     )
-    op.alter_column(
-        "messages", "conversation_id", existing_type=sa.VARCHAR(), nullable=False
-    )
-    op.alter_column("messages", "user_id", existing_type=sa.VARCHAR(), nullable=False)
-    op.drop_constraint("file_conversation_id_user_id_fkey", "files", type_="foreignkey")
     op.create_foreign_key(
         "files_conversation_id_fkey",
         "files",
@@ -183,13 +182,6 @@ def downgrade() -> None:
         ["conversation_id"],
         ["id"],
         ondelete="CASCADE",
-    )
-    op.alter_column(
-        "files", "conversation_id", existing_type=sa.VARCHAR(), nullable=False
-    )
-    op.alter_column("files", "user_id", existing_type=sa.VARCHAR(), nullable=False)
-    op.drop_constraint(
-        "document_conversation_id_user_id_fkey", "documents", type_="foreignkey"
     )
     op.create_foreign_key(
         "documents_conversation_id_fkey",
@@ -200,27 +192,101 @@ def downgrade() -> None:
         ondelete="CASCADE",
     )
     op.alter_column(
-        "documents", "conversation_id", existing_type=sa.VARCHAR(), nullable=False
+        "snapshots",
+        "user_id",
+        existing_type=sa.VARCHAR(),
+        type_=sa.String(),
+        nullable=False,
     )
-    op.alter_column("documents", "user_id", existing_type=sa.VARCHAR(), nullable=False)
-    op.drop_constraint(None, "conversations", type_="foreignkey")
-    op.drop_index("conversation_user_id_index", table_name="conversations")
-    op.drop_constraint("conversation_id_user_id", "conversations", type_="unique")
     op.alter_column(
-        "conversations", "user_id", existing_type=sa.VARCHAR(), nullable=False
+        "snapshot_links",
+        "user_id",
+        existing_type=sa.VARCHAR(),
+        type_=sa.String(),
+        nullable=False,
     )
-    op.drop_constraint(None, "citations", type_="foreignkey")
-    op.alter_column("citations", "user_id", existing_type=sa.VARCHAR(), nullable=False)
-    op.drop_constraint(None, "agents", type_="foreignkey")
     op.alter_column(
-        "agents", "user_id", existing_type=sa.String(), type_=sa.TEXT(), nullable=False
+        "snapshot_access",
+        "user_id",
+        existing_type=sa.VARCHAR(),
+        type_=sa.String(),
+        nullable=False,
     )
-    op.drop_constraint(None, "agent_tool_metadata", type_="foreignkey")
+    op.alter_column(
+        "messages",
+        "conversation_id",
+        existing_type=sa.VARCHAR(),
+        type_=sa.String(),
+        nullable=False,
+    )
+    op.alter_column(
+        "messages",
+        "user_id",
+        existing_type=sa.VARCHAR(),
+        type_=sa.String(),
+        nullable=False,
+    )
+    op.alter_column(
+        "files",
+        "conversation_id",
+        existing_type=sa.VARCHAR(),
+        type_=sa.String(),
+        nullable=False,
+    )
+    op.alter_column(
+        "files",
+        "user_id",
+        existing_type=sa.VARCHAR(),
+        type_=sa.String(),
+        nullable=False,
+    )
+    op.alter_column(
+        "documents",
+        "conversation_id",
+        existing_type=sa.VARCHAR(),
+        type_=sa.String(),
+        nullable=False,
+    )
+    op.alter_column(
+        "documents",
+        "user_id",
+        existing_type=sa.VARCHAR(),
+        type_=sa.String(),
+        nullable=False,
+    )
+    op.alter_column(
+        "conversations",
+        "user_id",
+        existing_type=sa.VARCHAR(),
+        type_=sa.String(),
+        nullable=False,
+    )
+    op.alter_column(
+        "citations",
+        "user_id",
+        existing_type=sa.VARCHAR(),
+        type_=sa.String(),
+        nullable=False,
+    )
+    op.alter_column(
+        "tool_auth",
+        "user_id",
+        existing_type=sa.TEXT(),
+        type_=sa.String(),
+        nullable=False,
+    )
+    op.alter_column(
+        "agents",
+        "user_id",
+        existing_type=sa.TEXT(),
+        type_=sa.String(),
+        nullable=False,
+    )
     op.alter_column(
         "agent_tool_metadata",
         "user_id",
-        existing_type=sa.String(),
-        type_=sa.TEXT(),
+        existing_type=sa.TEXT(),
+        type_=sa.String(),
         nullable=False,
     )
     # ### end Alembic commands ###

--- a/src/backend/database_models/conversation.py
+++ b/src/backend/database_models/conversation.py
@@ -13,9 +13,7 @@ class Conversation(Base):
     __tablename__ = "conversations"
 
     id: Mapped[str] = mapped_column(String, default=lambda: str(uuid4()))
-    user_id: Mapped[str] = mapped_column(
-        ForeignKey("users.id", ondelete="CASCADE"), nullable=True
-    )
+    user_id: Mapped[str] = mapped_column(ForeignKey("users.id", ondelete="CASCADE"))
     title: Mapped[str] = mapped_column(String, default="New Conversation")
     description: Mapped[str] = mapped_column(String, nullable=True, default=None)
 

--- a/src/backend/tests/crud/test_agent.py
+++ b/src/backend/tests/crud/test_agent.py
@@ -98,17 +98,6 @@ def test_create_agent_missing_model(session, user):
         _ = agent_crud.create_agent(session, agent_data)
 
 
-def test_create_agent_missing_user_id(session):
-    agent_data = Agent(
-        name="test",
-        model="command-r-plus",
-        deployment=ModelDeploymentName.CoherePlatform,
-    )
-
-    with pytest.raises(IntegrityError):
-        _ = agent_crud.create_agent(session, agent_data)
-
-
 def test_create_agent_duplicate_name_version(session, user):
     _ = get_factory("Agent", session).create(
         id="1", user_id=user.id, name="test_agent", version=1

--- a/src/backend/tests/crud/test_agent_tool_metadata.py
+++ b/src/backend/tests/crud/test_agent_tool_metadata.py
@@ -81,22 +81,6 @@ def test_create_agent_missing_tool_name(session, user):
         )
 
 
-def test_create_agent_missing_user_id(session, user):
-    agent = get_factory("Agent", session).create(
-        id="1", name="test_agent", tools=[ToolName.Google_Drive], user_id=user.id
-    )
-
-    agent_tool_metadata_data = AgentToolMetadata(
-        agent_id=agent.id,
-        tool_name=ToolName.Google_Drive,
-        artifacts=[mock_artifact_1],
-    )
-    with pytest.raises(IntegrityError):
-        _ = agent_tool_metadata_crud.create_agent_tool_metadata(
-            session, agent_tool_metadata_data
-        )
-
-
 def test_update_agent_tool_metadata(session, user):
     agent = get_factory("Agent", session).create(user_id=user.id)
     original_agent_tool_metadata = get_factory("AgentToolMetadata", session).create(


### PR DESCRIPTION
Thank you for contributing to the Cohere Toolkit!

- [ ] **PR title**: "area: description"
  - Where "area" is whichever of interface, frontend, model, tools, backend, etc. is being modified. Use "docs: ..." for purely docs changes, "infra: ..." for CI changes.
  - Example: "deployment: add Azure model option"


- [ ] **PR message**: ***Delete this entire checklist*** and replace with
    - **Description:** a description of the change
    - **Issue:** the issue # it fixes, if applicable
    - **Dependencies:** any dependencies required for this change


- [ ] **Add tests and docs**: Please include testing and documentation for your changes
- [ ] **Lint and test**: Run `make lint` and `make run-tests`

**AI Description**

<!-- begin-generated-description -->

This PR makes changes to the database models and tests related to foreign key constraints, column alterations, and user IDs. 

## Summary
- The `upgrade` function in `src/backend/alembic/versions/f077676dfd5d_.py` has been updated to include additional foreign key constraints and column alterations. 
- The `Conversation` model in `src/backend/database_models/conversation.py` has been modified to remove the `nullable=True` attribute from the `user_id` field. 
- The `test_create_agent_missing_user_id` test function has been removed from `src/backend/tests/crud/test_agent.py` and `src/backend/tests/crud/test_agent_tool_metadata.py`.

## Details
- The `upgrade` function now includes foreign key constraints for the "agent_tool_metadata" and "agents" tables, ensuring that the "user_id" field in these tables is properly linked to the "users" table.
- The `upgrade` function also includes additional column alterations for various tables, including "tool_auth", "documents", "files", "messages", and "snapshots". These alterations involve changing the data type of the "user_id" field to `sa.String` and/or making it nullable.
- The `Conversation` model now has a non-nullable "user_id" field, indicating that a user ID is always required for a conversation. 
- The `test_create_agent_missing_user_id` test function, which previously tested the creation of an agent without a user ID, has been removed from both test files. This suggests that the requirement for a user ID during agent creation has been removed or modified.

<!-- end-generated-description -->
