### PR TITLE
Snapshot: fix share agent convo + remove agent data from response

### DIFF
--- a/src/backend/schemas/snapshot.py
+++ b/src/backend/schemas/snapshot.py
@@ -1,7 +1,7 @@
 import datetime
 from typing import Optional, Union
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from backend.schemas.agent import AgentToolMetadata
 from backend.schemas.message import Message
@@ -22,7 +22,7 @@ class SnapshotData(BaseModel):
     title: str
     description: str
     messages: list[Message]
-    agent: Optional[SnapshotAgent]
+    agent: Optional[SnapshotAgent] = Field(exclude=True)
 
     class Config:
         from_attributes = True

--- a/src/backend/services/snapshot.py
+++ b/src/backend/services/snapshot.py
@@ -4,6 +4,7 @@ from typing import Any
 from fastapi import HTTPException
 
 from backend.chat.collate import to_dict
+from backend.crud import agent as agent_crud
 from backend.crud import conversation as conversation_crud
 from backend.crud import snapshot as snapshot_crud
 from backend.database_models import Snapshot as SnapshotModel
@@ -11,6 +12,7 @@ from backend.database_models import SnapshotAccess as SnapshotAccessModel
 from backend.database_models import SnapshotLink as SnapshotLinkModel
 from backend.database_models.conversation import Conversation as ConversationModel
 from backend.database_models.database import DBSessionDep
+from backend.schemas.agent import AgentToolMetadata
 from backend.schemas.conversation import Conversation
 from backend.schemas.snapshot import SnapshotAgent, SnapshotData
 
@@ -76,13 +78,15 @@ def wrap_create_snapshot(
 ) -> SnapshotModel:
     snapshot_agent = None
     if conversation.agent_id:
-        agent = snapshot_crud.get_agent(session, conversation.agent_id)
+        agent = agent_crud.get_agent_by_id(session, conversation.agent_id)
+        tools_metadata = [to_dict(metadata) for metadata in agent.tools_metadata]
+
         snapshot_agent = SnapshotAgent(
             id=agent.id,
             name=agent.name,
             description=agent.description,
             preamble=agent.preamble,
-            tools_metadata=agent.tools_metadata,
+            tools_metadata=tools_metadata,
         )
 
     snapshot_data = SnapshotData(


### PR DESCRIPTION
Users were getting a 500 when sharing an agent conversation, this PR fixes that. It also removes agent information from the shared conversation response.

**AI Description**

<!-- begin-generated-description -->

Generating pr description

<!-- end-generated-description -->
