### PR TITLE
coral-web: fix citation alignment in read only convo

### DIFF
--- a/src/interfaces/coral_web/src/components/ReadOnlyConversation.tsx
+++ b/src/interfaces/coral_web/src/components/ReadOnlyConversation.tsx
@@ -69,7 +69,7 @@ export const ReadOnlyConversation: React.FC<Props> = ({ title, messages }) => {
 
         <div className="flex flex-col gap-y-4 py-6 md:gap-y-6">
           {messages.map((m, i) => (
-            <div key={i} className="flex items-start gap-x-3">
+            <div key={i} className="flex items-start justify-between gap-x-3">
               <MessageRow
                 message={m}
                 isLast={i === messages.length - 1}


### PR DESCRIPTION
| Before | After |
|--------|-------|
| ![Screenshot 2024-07-18 at 17 58 53](https://github.com/user-attachments/assets/f6983b47-4f04-4287-82e6-04126394d86a) | ![Screenshot 2024-07-18 at 18 00 57](https://github.com/user-attachments/assets/51e8859f-f692-4216-9a2b-b032947f8193) |
**AI Description**

<!-- begin-generated-description -->

This pull request updates the `ReadOnlyConversation` component in the `src/interfaces/coral_web/src/components/ReadOnlyConversation.tsx` file. Specifically, the changes are:

- The `justify-between` class has been added to the `div` element within the `messages.map` loop. This class applies a flex justification rule, likely aligning items to the start and end of the flex container.

<!-- end-generated-description -->
