### PR TITLE
feat(toolkit): do not override google drive files on new selection

### DIFF
--- a/src/interfaces/coral_web/src/components/Agents/CreateAgent.tsx
+++ b/src/interfaces/coral_web/src/components/Agents/CreateAgent.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useLocalStorageValue } from '@react-hookz/web';
+import { uniqBy } from 'lodash';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import React, { useContext, useEffect, useState } from 'react';
 
@@ -54,26 +55,35 @@ export const CreateAgent: React.FC = () => {
 
   const openFilePicker = useOpenGoogleDrivePicker((data) => {
     if (data.docs) {
-      setFields((prev) => ({
-        ...prev,
-        tools_metadata: [
-          ...(prev.tools_metadata?.filter((tool) => tool.tool_name !== TOOL_GOOGLE_DRIVE_ID) ?? []),
-          ...[
-            {
-              tool_name: TOOL_GOOGLE_DRIVE_ID,
-              artifacts: data.docs.map(
-                (doc: any) =>
-                  ({
-                    id: doc.id,
-                    name: doc.name,
-                    type: doc.type,
-                    url: doc.url,
-                  } as GoogleDriveToolArtifact)
-              ),
-            },
+      setFields((prev) => {
+        const updatedArtifacts = [
+          ...(prev.tools_metadata?.find((tool) => tool.tool_name === TOOL_GOOGLE_DRIVE_ID)
+            ?.artifacts ?? []),
+          ...data.docs.map(
+            (doc) =>
+              ({
+                id: doc.id,
+                name: doc.name,
+                type: doc.type,
+                url: doc.url,
+              } as GoogleDriveToolArtifact)
+          ),
+        ];
+
+        return {
+          ...prev,
+          tools_metadata: [
+            ...(prev.tools_metadata?.filter((tool) => tool.tool_name !== TOOL_GOOGLE_DRIVE_ID) ??
+              []),
+            ...[
+              {
+                tool_name: TOOL_GOOGLE_DRIVE_ID,
+                artifacts: uniqBy(updatedArtifacts, 'id'),
+              },
+            ],
           ],
-        ],
-      }));
+        };
+      });
     }
   });
 

--- a/src/interfaces/coral_web/src/components/Agents/UpdateAgent.tsx
+++ b/src/interfaces/coral_web/src/components/Agents/UpdateAgent.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useLocalStorageValue } from '@react-hookz/web';
+import { uniqBy } from 'lodash';
 import React, { useEffect, useState } from 'react';
 
 import { AgentForm, UpdateAgentFormFields } from '@/components/Agents/AgentForm';
@@ -62,7 +63,7 @@ export const UpdateAgent: React.FC<Props> = ({ agentId }) => {
               {
                 tool_name: TOOL_GOOGLE_DRIVE_ID,
                 artifacts: data.docs.map(
-                  (doc: any) =>
+                  (doc) =>
                     ({
                       id: doc.id,
                       name: doc.name,
@@ -74,11 +75,12 @@ export const UpdateAgent: React.FC<Props> = ({ agentId }) => {
             ],
           };
         }
-        // If the tool is already enabled, update the artifacts
-        const updateGoogleDriveTool = {
-          ...currentGoogleDriveTool,
-          artifacts: data.docs.map(
-            (doc: any) =>
+
+        const updatedArtifacts = [
+          ...(prev.tools_metadata?.find((tool) => tool.tool_name === TOOL_GOOGLE_DRIVE_ID)
+            ?.artifacts ?? []),
+          ...data.docs.map(
+            (doc) =>
               ({
                 id: doc.id,
                 name: doc.name,
@@ -86,6 +88,12 @@ export const UpdateAgent: React.FC<Props> = ({ agentId }) => {
                 url: doc.url,
               } as GoogleDriveToolArtifact)
           ),
+        ];
+
+        // If the tool is already enabled, update the artifacts
+        const updateGoogleDriveTool = {
+          ...currentGoogleDriveTool,
+          artifacts: uniqBy(updatedArtifacts, 'id'),
         };
 
         return {


### PR DESCRIPTION
**AI Description**

<!-- begin-generated-description -->

This pull request updates the `CreateAgent` and `UpdateAgent` components in the `src/interfaces/coral_web/src/components/Agents` directory. 

**Summary**
- The PR introduces changes to the way artifacts are handled when the tool name is `TOOL_GOOGLE_DRIVE_ID`. 
- It ensures that duplicate artifacts are removed by using the `uniqBy` function from Lodash. 
- The `tools_metadata` array is updated to include only unique artifacts for `TOOL_GOOGLE_DRIVE_ID`, while keeping other tool artifacts unchanged. 

**Code Changes**
- The `uniqBy` function from Lodash is imported in both `CreateAgent.tsx` and `UpdateAgent.tsx`.
- In `CreateAgent.tsx`, when handling data from Google Drive, the code now constructs an `updatedArtifacts` array, which includes existing artifacts for `TOOL_GOOGLE_DRIVE_ID` and new artifacts from the `data.docs` array. 
- The `tools_metadata` array is then updated with a new object containing `TOOL_GOOGLE_DRIVE_ID` and the unique `updatedArtifacts`. 
- Similar changes are made in `UpdateAgent.tsx`, where the `updatedArtifacts` array is constructed and used to update the `artifacts` property of the `updateGoogleDriveTool` object.

<!-- end-generated-description -->
