### PR TITLE
feat(helm): liveness and readiness probes

### DIFF
--- a/charts/cohere-toolkit/templates/backend.yaml
+++ b/charts/cohere-toolkit/templates/backend.yaml
@@ -71,7 +71,14 @@ spec:
             - secretRef:
                 name: toolkit-backend
                 optional: false
-          {{- /* TODO: Add livenessProbe and readinessProbe */}}
+          {{- with $values.livenessProbe }}
+          livenessProbe:
+              {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with $values.readinessProbe }}
+          readinessProbe:
+              {{- toYaml . | nindent 12 }}
+          {{- end }}
           {{- with $values.sidecars }}
           {{- toYaml . | nindent 12 }}
           {{- end }}

--- a/charts/cohere-toolkit/templates/frontend.yaml
+++ b/charts/cohere-toolkit/templates/frontend.yaml
@@ -71,7 +71,14 @@ spec:
             - secretRef:
                 name: toolkit-frontend
                 optional: false
-          {{- /* TODO: Add livenessProbe and readinessProbe */}}
+          {{- with $values.livenessProbe }}
+          livenessProbe:
+              {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with $values.readinessProbe }}
+          readinessProbe:
+              {{- toYaml . | nindent 12 }}
+          {{- end }}
           {{- with $values.sidecars }}
           {{- toYaml . | nindent 12 }}
           {{- end }}

--- a/charts/cohere-toolkit/templates/terrarium.yaml
+++ b/charts/cohere-toolkit/templates/terrarium.yaml
@@ -67,7 +67,14 @@ spec:
             - containerPort: 8080
               protocol: TCP
               name: http
-          {{- /* TODO: Add livenessProbe and readinessProbe */}}
+          {{- with $values.livenessProbe }}
+          livenessProbe:
+              {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with $values.readinessProbe }}
+          readinessProbe:
+              {{- toYaml . | nindent 12 }}
+          {{- end }}
           {{- with $values.sidecars }}
           {{- toYaml . | nindent 12 }}
           {{- end }}

--- a/charts/cohere-toolkit/values.yaml
+++ b/charts/cohere-toolkit/values.yaml
@@ -73,6 +73,16 @@ backend:
     targetCPUUtilizationPercentage: 80
     # targetMemoryUtilizationPercentage: 80
 
+  livenessProbe:
+    httpGet:
+      path: "/health"
+      port: http
+
+  readinessProbe:
+    httpGet:
+      path: "/health"
+      port: http
+
   nodeSelector: {}
 
   tolerations: []
@@ -135,6 +145,16 @@ frontend:
     maxReplicas: 100
     targetCPUUtilizationPercentage: 80
     targetMemoryUtilizationPercentage: 80
+
+  livenessProbe:
+    httpGet:
+      path: "/"
+      port: http
+
+  readinessProbe:
+    httpGet:
+      path: "/"
+      port: http
 
   nodeSelector: {}
 
@@ -200,6 +220,16 @@ terrarium:
     maxReplicas: 100
     targetCPUUtilizationPercentage: 80
     targetMemoryUtilizationPercentage: 80
+
+  livenessProbe:
+    httpGet:
+      path: "/health"
+      port: http
+
+  readinessProbe:
+    httpGet:
+      path: "/health"
+      port: http
 
   nodeSelector: { }
 


### PR DESCRIPTION
Closes EINF-1016

**AI Description**

<!-- begin-generated-description -->

This pull request adds `livenessProbe` and `readinessProbe` to the `backend.yaml`, `frontend.yaml`, and `terrarium.yaml` files.

- The `livenessProbe` is configured to perform an HTTP GET request to the `/health` endpoint for `backend.yaml` and to the root endpoint (`/`) for `frontend.yaml` and `terrarium.yaml`.
- The `readinessProbe` is set up similarly, making an HTTP GET request to the respective endpoints.
- Both probes use the `http` port.

<!-- end-generated-description -->
