### PR TITLE
frontend(web): allow to download tool generated files

### DIFF
--- a/src/interfaces/coral_web/src/components/MessageContent.tsx
+++ b/src/interfaces/coral_web/src/components/MessageContent.tsx
@@ -9,6 +9,7 @@ import { MarkdownImage } from '@/components/MarkdownImage';
 import { MessageFile } from '@/components/MessageFile';
 import { Icon } from '@/components/Shared';
 import { Markdown, Text } from '@/components/Shared';
+import { useCitationsStore } from '@/stores';
 import {
   type ChatMessage,
   MessageType,
@@ -17,7 +18,7 @@ import {
   isFulfilledOrTypingMessage,
   isLoadingMessage,
 } from '@/types/message';
-import { cn } from '@/utils';
+import { base64ToBlobUrl, cn, guessFileType } from '@/utils';
 
 type Props = {
   isLast: boolean;
@@ -34,6 +35,9 @@ export const MessageContent: React.FC<Props> = ({ isLast, message, onRetry }) =>
   const isUserError = isUser && message.error;
   const isAborted = isAbortedMessage(message);
   const isTypingOrFulfilledMessage = isFulfilledOrTypingMessage(message);
+  // const {
+  //   citations: { outputFiles },
+  // } = useCitationsStore();
 
   let content: React.ReactNode = null;
 
@@ -116,6 +120,16 @@ export const MessageContent: React.FC<Props> = ({ isLast, message, onRetry }) =>
             table: DataTable as any,
           }}
           renderLaTex={!hasCitations}
+          // TODO(tomeu): model should send downloable files as links.
+          // urlTransform={(url) => {
+          //   const file = Object.keys(outputFiles).find((key) => outputFiles[key].name === url);
+          //   if (!file) {
+          //     return url;
+          //   }
+          //   const fileType = guessFileType(outputFiles[file].name);
+          //   const blobUrl = base64ToBlobUrl(outputFiles[file].data, fileType);
+          //   return blobUrl;
+          // }}
         />
         {isAborted && (
           <MessageInfo>

--- a/src/interfaces/coral_web/src/utils/citations.ts
+++ b/src/interfaces/coral_web/src/utils/citations.ts
@@ -45,9 +45,9 @@ export const replaceTextWithCitations = (
     const fixedText = fixMarkdownImagesInText(citationText);
 
     // Encode the citationText in case there are any weird characters or unclosed brackets that will
-    // interfere with parsing the markdown. However, let markdown images through so they may be properly
+    // interfere with parsing the markdown. However, let markdown images and links through so they may be properly
     // rendered.
-    const isMarkdownImage = fixedText.match(/!\[.*\]\(.*\)/);
+    const isMarkdownImage = fixedText.match(/!?\[.*\]\(.*\)/);
     const encodedCitationText = isMarkdownImage ? fixedText : encodeURIComponent(fixedText);
     const citationId = `:cite[${encodedCitationText}]{generationId="${generationId}" start="${start}" end="${end}"}`;
 

--- a/src/interfaces/coral_web/src/utils/file.ts
+++ b/src/interfaces/coral_web/src/utils/file.ts
@@ -44,3 +44,38 @@ export const getFileUploadTimeEstimateInMs = (fileSizeInBytes: number) => {
  */
 export const isDefaultFileLoaderTool = (t: ManagedTool) =>
   t.category === FILE_TOOL_CATEGORY && t.is_visible;
+
+/**
+ * @description Converts a base64 string to a blob URL.
+ * @param base64String
+ * @param fileType
+ * @returns blob URL
+ */
+export const base64ToBlobUrl = (base64String: string, fileType: string) => {
+  const binaryString = atob(base64String);
+  const arrayBuffer = new ArrayBuffer(binaryString.length);
+  const arrayView = new Uint8Array(arrayBuffer);
+  for (let i = 0; i < binaryString.length; i++) {
+    arrayView[i] = binaryString.charCodeAt(i);
+  }
+  const blob = new Blob([arrayBuffer], { type: fileType });
+  return URL.createObjectURL(blob);
+};
+
+/**
+ * @description Guesses the file type based on the file name.
+ * @param fileName
+ * @returns file type
+ * @default text/plain
+ */
+export const guessFileType = (fileName: string) => {
+  const extension = fileName.split('.').pop();
+  switch (extension) {
+    case 'csv':
+      return 'text/csv';
+    case 'json':
+      return 'application/json';
+    default:
+      return 'text/plain';
+  }
+};


### PR DESCRIPTION
## Description

Model is sending generated files always as markdown images (e.g.: `![some data](data.json)`) and it should be `[text](data.json)`, until is fixed, we should take of images and render them based on the filename extension.

- feat: allow to download tool-generated files

## TODOs
- [ ] add the same fix to `assistants_web`

Closes TLK-789