### PR TITLE
fix(toolkit): centralize chat navigation

### DIFF
--- a/src/interfaces/assistants_web/src/components/Agents/AgentsSidePanel.tsx
+++ b/src/interfaces/assistants_web/src/components/Agents/AgentsSidePanel.tsx
@@ -1,8 +1,6 @@
 'use client';
 
 import { Transition } from '@headlessui/react';
-import Link from 'next/link';
-import { useRouter } from 'next/navigation';
 import React, { ReactElement } from 'react';
 
 import { IconButton } from '@/components/IconButton';
@@ -10,13 +8,8 @@ import { Button, Icon, Logo, Text } from '@/components/Shared';
 import { Shortcut } from '@/components/Shortcut';
 import { env } from '@/env.mjs';
 import { useIsDesktop } from '@/hooks/breakpoint';
-import {
-  useAgentsStore,
-  useCitationsStore,
-  useConversationStore,
-  useParamsStore,
-  useSettingsStore,
-} from '@/stores';
+import { useNavigateToNewChat } from '@/hooks/chatRoutes';
+import { useAgentsStore, useSettingsStore } from '@/stores';
 import { cn } from '@/utils';
 
 /**
@@ -28,26 +21,13 @@ export const AgentsSidePanel: React.FC<React.PropsWithChildren<{ className?: str
   className = '',
   children,
 }) => {
-  const router = useRouter();
   const {
     agents: { isAgentsSidePanelOpen },
   } = useAgentsStore();
   const isDesktop = useIsDesktop();
   const isMobile = !isDesktop;
 
-  const { setEditAgentPanelOpen } = useAgentsStore();
-  const { resetConversation } = useConversationStore();
-  const { resetCitations } = useCitationsStore();
-  const { resetFileParams } = useParamsStore();
-
-  const handleNewChat = () => {
-    const url = '/';
-    setEditAgentPanelOpen(false);
-    resetConversation();
-    resetCitations();
-    resetFileParams();
-    router.push(url);
-  };
+  const navigateToNewChat = useNavigateToNewChat();
 
   return (
     <Transition
@@ -88,12 +68,12 @@ export const AgentsSidePanel: React.FC<React.PropsWithChildren<{ className?: str
             'justify-between gap-x-3': isMobile && isAgentsSidePanelOpen,
           })}
         >
-          <Link href="/">
+          <button onClick={() => navigateToNewChat()}>
             <Logo
               hasCustomLogo={env.NEXT_PUBLIC_HAS_CUSTOM_LOGO}
               includeBrandName={isAgentsSidePanelOpen}
             />
-          </Link>
+          </button>
 
           <ToggleAgentsSidePanelButton className="flex md:hidden" />
         </div>
@@ -110,7 +90,7 @@ export const AgentsSidePanel: React.FC<React.PropsWithChildren<{ className?: str
                 <Shortcut sequence={['⌘', '↑', 'N']} className="hidden group-hover:flex" />
               </div>
             }
-            onClick={handleNewChat}
+            onClick={() => navigateToNewChat()}
             tooltip="New chat"
             icon={<Icon name="add" kind="outline" className="dark:text-evolved-green-700" />}
           />

--- a/src/interfaces/assistants_web/src/components/Conversation/Header.tsx
+++ b/src/interfaces/assistants_web/src/components/Conversation/Header.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Transition } from '@headlessui/react';
-import { usePathname, useRouter } from 'next/navigation';
+import { usePathname } from 'next/navigation';
 import { useContext } from 'react';
 
 import { IconButton } from '@/components/IconButton';
@@ -12,24 +12,18 @@ import { WelcomeGuideTooltip } from '@/components/WelcomeGuideTooltip';
 import { ModalContext } from '@/context/ModalContext';
 import { useAgent } from '@/hooks/agents';
 import { useIsDesktop } from '@/hooks/breakpoint';
+import { useNavigateToNewChat } from '@/hooks/chatRoutes';
 import { WelcomeGuideStep, useWelcomeGuideState } from '@/hooks/ftux';
 import { useSession } from '@/hooks/session';
-import {
-  useAgentsStore,
-  useCitationsStore,
-  useConversationStore,
-  useParamsStore,
-  useSettingsStore,
-} from '@/stores';
+import { useAgentsStore, useConversationStore, useSettingsStore } from '@/stores';
 import { cn } from '@/utils';
 
 const useHeaderMenu = ({ agentId }: { agentId?: string }) => {
   const { open } = useContext(ModalContext);
   const {
     conversation: { id: conversationId },
-    resetConversation,
   } = useConversationStore();
-  const { resetCitations } = useCitationsStore();
+
   const { userId } = useSession();
   const { data: agent } = useAgent({ agentId });
   const isAgentCreator = userId === agent?.user_id;
@@ -42,18 +36,14 @@ const useHeaderMenu = ({ agentId }: { agentId?: string }) => {
     agents: { isEditAgentPanelOpen },
     setEditAgentPanelOpen,
   } = useAgentsStore();
-  const { resetFileParams } = useParamsStore();
-  const router = useRouter();
+
   const pathname = usePathname();
   const { welcomeGuideState, progressWelcomeGuideStep, finishWelcomeGuide } =
     useWelcomeGuideState();
 
+  const navigateToNewChat = useNavigateToNewChat();
   const handleNewChat = () => {
-    const url = agentId ? `/a/${agentId}` : pathname.includes('/a') ? '/a' : '/';
-    router.push(url, undefined);
-    resetConversation();
-    resetCitations();
-    resetFileParams();
+    navigateToNewChat(agentId);
   };
 
   const handleOpenShareModal = () => {

--- a/src/interfaces/assistants_web/src/hooks/chatRoutes.ts
+++ b/src/interfaces/assistants_web/src/hooks/chatRoutes.ts
@@ -1,7 +1,27 @@
-import { useParams } from 'next/navigation';
+import { useParams, useRouter } from 'next/navigation';
 import { useMemo } from 'react';
 
+import { useAgentsStore, useCitationsStore, useConversationStore, useParamsStore } from '@/stores';
 import { getQueryString } from '@/utils';
+
+export const useNavigateToNewChat = () => {
+  const router = useRouter();
+  const { setEditAgentPanelOpen } = useAgentsStore();
+  const { resetConversation } = useConversationStore();
+  const { resetCitations } = useCitationsStore();
+  const { resetFileParams } = useParamsStore();
+
+  const handleNavigate = (agentId?: string) => {
+    const url = agentId ? `/a/${agentId}` : '/';
+    setEditAgentPanelOpen(false);
+    resetConversation();
+    resetCitations();
+    resetFileParams();
+    router.push(url);
+  };
+
+  return handleNavigate;
+};
 
 export const useChatRoutes = () => {
   const params = useParams();

--- a/src/interfaces/assistants_web/src/hooks/conversation.tsx
+++ b/src/interfaces/assistants_web/src/hooks/conversation.tsx
@@ -1,5 +1,4 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { usePathname, useRouter } from 'next/navigation';
 
 import {
   ApiError,
@@ -13,8 +12,9 @@ import {
 import { DeleteConversations } from '@/components/Modals/DeleteConversations';
 import { EditConversationTitle } from '@/components/Modals/EditConversationTitle';
 import { useContextStore } from '@/context';
+import { useChatRoutes, useNavigateToNewChat } from '@/hooks/chatRoutes';
 import { useNotify } from '@/hooks/toast';
-import { useCitationsStore, useConversationStore, useParamsStore } from '@/stores';
+import { useConversationStore } from '@/stores';
 import { isAbortError } from '@/utils';
 
 export const useConversations = (params: { offset?: number; limit?: number; agentId?: string }) => {
@@ -101,16 +101,13 @@ export const useDeleteConversation = () => {
 };
 
 export const useConversationActions = () => {
-  const router = useRouter();
-  const pathname = usePathname();
+  const { agentId } = useChatRoutes();
   const { open, close } = useContextStore();
   const {
-    resetConversation,
     conversation: { id: conversationId },
   } = useConversationStore();
-  const { resetCitations } = useCitationsStore();
-  const { resetFileParams } = useParamsStore();
   const notify = useNotify();
+  const navigateToNewChat = useNavigateToNewChat();
   const { mutateAsync: deleteConversation, isPending } = useDeleteConversation();
 
   const handleDeleteConversation = async ({
@@ -125,11 +122,7 @@ export const useConversationActions = () => {
       onComplete?.();
 
       if (id === conversationId) {
-        resetConversation();
-        resetCitations();
-        resetFileParams();
-        const newUrl = pathname.replace(`/c/${id}`, '');
-        router.push(newUrl, undefined); // go to new chat
+        navigateToNewChat(agentId);
       }
     };
 

--- a/src/interfaces/coral_web/src/components/Agents/AgentsSidePanel.tsx
+++ b/src/interfaces/coral_web/src/components/Agents/AgentsSidePanel.tsx
@@ -1,12 +1,12 @@
 'use client';
 
 import { Transition } from '@headlessui/react';
-import Link from 'next/link';
 
 import { IconButton } from '@/components/IconButton';
 import { Button, Icon, IconProps, Logo, Tooltip } from '@/components/Shared';
 import { env } from '@/env.mjs';
 import { useIsDesktop } from '@/hooks/breakpoint';
+import { useNavigateToNewChat } from '@/hooks/chatRoutes';
 import { useAgentsStore, useSettingsStore } from '@/stores';
 import { cn } from '@/utils';
 
@@ -32,6 +32,8 @@ export const AgentsSidePanel: React.FC<React.PropsWithChildren<{ className?: str
     setSettings({ isConfigDrawerOpen: false });
     setAgentsSidePanelOpen(!isAgentsSidePanelOpen);
   };
+
+  const navigateToNewChat = useNavigateToNewChat();
 
   const navigationItems: {
     label: string;
@@ -88,11 +90,11 @@ export const AgentsSidePanel: React.FC<React.PropsWithChildren<{ className?: str
             enterFrom="-translate-x-full"
             enterTo="translate-x-0"
           >
-            <Link href="/" shallow>
+            <button onClick={() => navigateToNewChat()}>
               <div className="mr-3 flex items-baseline">
                 <Logo hasCustomLogo={env.NEXT_PUBLIC_HAS_CUSTOM_LOGO === 'true'} />
               </div>
-            </Link>
+            </button>
           </Transition>
 
           <IconButton

--- a/src/interfaces/coral_web/src/components/Conversation/Header.tsx
+++ b/src/interfaces/coral_web/src/components/Conversation/Header.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Transition } from '@headlessui/react';
-import { usePathname, useRouter } from 'next/navigation';
+import { usePathname } from 'next/navigation';
 import { useContext } from 'react';
 
 import { IconButton } from '@/components/IconButton';
@@ -12,24 +12,18 @@ import { WelcomeGuideTooltip } from '@/components/WelcomeGuideTooltip';
 import { ModalContext } from '@/context/ModalContext';
 import { useAgent } from '@/hooks/agents';
 import { useIsDesktop } from '@/hooks/breakpoint';
+import { useNavigateToNewChat } from '@/hooks/chatRoutes';
 import { WelcomeGuideStep, useWelcomeGuideState } from '@/hooks/ftux';
 import { useSession } from '@/hooks/session';
-import {
-  useAgentsStore,
-  useCitationsStore,
-  useConversationStore,
-  useParamsStore,
-  useSettingsStore,
-} from '@/stores';
+import { useAgentsStore, useConversationStore, useSettingsStore } from '@/stores';
 import { cn } from '@/utils';
 
 const useHeaderMenu = ({ agentId }: { agentId?: string }) => {
   const { open } = useContext(ModalContext);
   const {
     conversation: { id: conversationId },
-    resetConversation,
   } = useConversationStore();
-  const { resetCitations } = useCitationsStore();
+
   const { userId } = useSession();
   const { data: agent } = useAgent({ agentId });
   const isAgentCreator = userId === agent?.user_id;
@@ -42,18 +36,14 @@ const useHeaderMenu = ({ agentId }: { agentId?: string }) => {
     agents: { isEditAgentPanelOpen },
     setEditAgentPanelOpen,
   } = useAgentsStore();
-  const { resetFileParams } = useParamsStore();
-  const router = useRouter();
+
   const pathname = usePathname();
   const { welcomeGuideState, progressWelcomeGuideStep, finishWelcomeGuide } =
     useWelcomeGuideState();
 
+  const navigateToNewChat = useNavigateToNewChat();
   const handleNewChat = () => {
-    const url = agentId ? `/a/${agentId}` : pathname.includes('/a') ? '/a' : '/';
-    router.push(url, undefined);
-    resetConversation();
-    resetCitations();
-    resetFileParams();
+    navigateToNewChat(agentId);
   };
 
   const handleOpenShareModal = () => {

--- a/src/interfaces/coral_web/src/hooks/chatRoutes.ts
+++ b/src/interfaces/coral_web/src/hooks/chatRoutes.ts
@@ -1,7 +1,27 @@
-import { useParams } from 'next/navigation';
+import { useParams, useRouter } from 'next/navigation';
 import { useMemo } from 'react';
 
+import { useAgentsStore, useCitationsStore, useConversationStore, useParamsStore } from '@/stores';
 import { getQueryString } from '@/utils';
+
+export const useNavigateToNewChat = () => {
+  const router = useRouter();
+  const { setEditAgentPanelOpen } = useAgentsStore();
+  const { resetConversation } = useConversationStore();
+  const { resetCitations } = useCitationsStore();
+  const { resetFileParams } = useParamsStore();
+
+  const handleNavigate = (agentId?: string) => {
+    const url = agentId ? `/a/${agentId}` : '/';
+    setEditAgentPanelOpen(false);
+    resetConversation();
+    resetCitations();
+    resetFileParams();
+    router.push(url);
+  };
+
+  return handleNavigate;
+};
 
 export const useChatRoutes = () => {
   const params = useParams();

--- a/src/interfaces/coral_web/src/hooks/conversation.tsx
+++ b/src/interfaces/coral_web/src/hooks/conversation.tsx
@@ -1,5 +1,4 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { usePathname, useRouter } from 'next/navigation';
 
 import {
   ApiError,
@@ -13,8 +12,9 @@ import {
 import { DeleteConversations } from '@/components/Modals/DeleteConversations';
 import { EditConversationTitle } from '@/components/Modals/EditConversationTitle';
 import { useContextStore } from '@/context';
+import { useChatRoutes, useNavigateToNewChat } from '@/hooks/chatRoutes';
 import { useNotify } from '@/hooks/toast';
-import { useCitationsStore, useConversationStore, useParamsStore } from '@/stores';
+import { useConversationStore } from '@/stores';
 import { isAbortError } from '@/utils';
 
 export const useConversations = (params: { offset?: number; limit?: number; agentId?: string }) => {
@@ -29,7 +29,7 @@ export const useConversations = (params: { offset?: number; limit?: number; agen
         return conversations;
       }
 
-      return conversations.filter((c) => c.agent_id === null);
+      return conversations;
     },
     retry: 0,
     refetchOnWindowFocus: false,
@@ -101,16 +101,13 @@ export const useDeleteConversation = () => {
 };
 
 export const useConversationActions = () => {
-  const router = useRouter();
-  const pathname = usePathname();
+  const { agentId } = useChatRoutes();
   const { open, close } = useContextStore();
   const {
-    resetConversation,
     conversation: { id: conversationId },
   } = useConversationStore();
-  const { resetCitations } = useCitationsStore();
-  const { resetFileParams } = useParamsStore();
   const notify = useNotify();
+  const navigateToNewChat = useNavigateToNewChat();
   const { mutateAsync: deleteConversation, isPending } = useDeleteConversation();
 
   const handleDeleteConversation = async ({
@@ -125,11 +122,7 @@ export const useConversationActions = () => {
       onComplete?.();
 
       if (id === conversationId) {
-        resetConversation();
-        resetCitations();
-        resetFileParams();
-        const newUrl = pathname.replace(`/c/${id}`, '');
-        router.push(newUrl, undefined); // go to new chat
+        navigateToNewChat(agentId);
       }
     };
 


### PR DESCRIPTION
**AI Description**

<!-- begin-generated-description -->

This PR introduces a new `useNavigateToNewChat` hook and updates the AgentsSidePanel and Header components to use this hook for handling new chat functionality.

- The `useNavigateToNewChat` hook is defined in `chatRoutes.ts`. It utilizes the useRouter, useAgentsStore, useConversationStore, useCitationsStore, and useParamsStore hooks to handle navigation to a new chat.
- In `AgentsSidePanel.tsx`, the useRouter, useAgentsStore, useCitationsStore, useConversationStore, and useParamsStore hooks are replaced with useNavigateToNewChat. The handleNewChat function is removed, and the button's onClick event now calls the navigateToNewChat function.
- In `Header.tsx`, the useRouter, useAgentsStore, useCitationsStore, useConversationStore, and useParamsStore hooks are replaced with useNavigateToNewChat. The handleNewChat function now calls the navigateToNewChat function with the agentId.
- Similar changes are made in the coral_web directory, updating the AgentsSidePanel.tsx and Header.tsx files to use the new useNavigateToNewChat hook.

<!-- end-generated-description -->
