### PR TITLE
Add default fallback value - when there is no cohere api key 

### DIFF
--- a/src/backend/config/deployments.py
+++ b/src/backend/config/deployments.py
@@ -101,6 +101,7 @@ def get_available_deployments() -> dict[ModelDeploymentName, Deployment]:
 
 def get_default_deployment(**kwargs) -> BaseDeployment:
     # Fallback to the first available deployment
+    fallback = None
     for deployment in AVAILABLE_MODEL_DEPLOYMENTS.values():
         if deployment.is_available:
             fallback = deployment.deployment_class(**kwargs)


### PR DESCRIPTION
Thank you for contributing to the Cohere Toolkit!

- [ ] **PR title**: "area: description"
  - Where "area" is whichever of interface, frontend, model, tools, backend, etc. is being modified. Use "docs: ..." for purely docs changes, "infra: ..." for CI changes.
  - Example: "deployment: add Azure model option"


- [ ] **PR message**: ***Delete this entire checklist*** and replace with
    - **Description:** a description of the change
    - **Issue:** the issue # it fixes, if applicable
    - **Dependencies:** any dependencies required for this change


- [ ] **Add tests and docs**: Please include testing and documentation for your changes
- [ ] **Lint and test**: Run `make lint` and `make run-tests`

**AI Description**

<!-- begin-generated-description -->

This pull request introduces a new `fallback` variable in the `get_default_deployment` function within `src/backend/config/deployments.py`. 

**Code Changes:**
- The `fallback = None` line is added to initialize the `fallback` variable.
- The `fallback` variable is then updated within the loop that iterates over `AVAILABLE_MODEL_DEPLOYMENTS.values()`.
- If a deployment is available (`deployment.is_available` is true), the `fallback` is set to `deployment.deployment_class(**kwargs)`.

This change appears to provide a default or fallback option for when a specific deployment is not available.

<!-- end-generated-description -->
