### PR TITLE
[2/N] Logs: replace response ID by trace ID

### DIFF
--- a/src/backend/services/chat.py
+++ b/src/backend/services/chat.py
@@ -493,7 +493,7 @@ async def generate_chat_response(
         event = json.loads(event)
         if event["event"] == StreamEvent.STREAM_END:
             data = event["data"]
-            response_id = response_message.id if response_message else None
+            response_id = ctx.get_trace_id()
             generation_id = response_message.generation_id if response_message else None
 
             non_streamed_chat_response = NonStreamedChatResponse(
@@ -543,7 +543,7 @@ async def generate_chat_stream(
 
     stream_end_data = {
         "conversation_id": conversation_id,
-        "response_id": response_message.id if response_message else None,
+        "response_id": ctx.get_trace_id(),
         "text": "",
         "citations": [],
         "documents": [],


### PR DESCRIPTION
Thank you for contributing to the Cohere Toolkit!

- [ ] **PR title**: "area: description"
  - Where "area" is whichever of interface, frontend, model, tools, backend, etc. is being modified. Use "docs: ..." for purely docs changes, "infra: ..." for CI changes.
  - Example: "deployment: add Azure model option"


- [ ] **PR message**: ***Delete this entire checklist*** and replace with
    - **Description:** a description of the change
    - **Issue:** the issue # it fixes, if applicable
    - **Dependencies:** any dependencies required for this change


- [ ] **Add tests and docs**: Please include testing and documentation for your changes
- [ ] **Lint and test**: Run `make lint` and `make run-tests`

**AI Description**

<!-- begin-generated-description -->

The pull request updates the `response_id` assignment in the `generate_chat_response` and `generate_chat_stream` functions within `src/backend/services/chat.py`.

## Summary
The changes in this pull request modify how the `response_id` is assigned in the `generate_chat_response` and `generate_chat_stream` functions. Instead of setting `response_id` to `response_message.id` if `response_message` is truthy, it now uses the value returned by `ctx.get_trace_id()`.

## Code Changes
- `src/backend/services/chat.py`
  - `generate_chat_response` function
    - Modified the assignment of `response_id` to use `ctx.get_trace_id()` instead of `response_message.id`.
  - `generate_chat_stream` function
    - Updated the value of "`response_id" in the `stream_end_data` dictionary to use `ctx.get_trace_id()` instead of `response_message.id`.

<!-- end-generated-description -->
