### PR TITLE
frontend(web): fix attaching previous streaming message to the new chat

### DIFF
--- a/src/interfaces/assistants_web/src/hooks/chat.ts
+++ b/src/interfaces/assistants_web/src/hooks/chat.ts
@@ -33,6 +33,7 @@ import {
   BotState,
   ChatMessage,
   ErrorMessage,
+  FulfilledMessage,
   MessageType,
   StreamingMessage,
   createAbortedMessage,
@@ -466,7 +467,7 @@ export const useChat = (config?: { onSend?: (msg: string) => void }) => {
                   )
                 : botResponse;
 
-              setStreamingMessage({
+              const finalMessage: FulfilledMessage = {
                 type: MessageType.BOT,
                 state: BotState.FULFILLED,
                 generationId,
@@ -478,7 +479,10 @@ export const useChat = (config?: { onSend?: (msg: string) => void }) => {
                 isRAGOn,
                 originalText: isRAGOn ? responseText : botResponse,
                 toolEvents,
-              });
+              };
+
+              setConversation({ messages: [...newMessages, finalMessage] });
+              setStreamingMessage(null);
 
               if (shouldUpdateConversationTitle(newMessages)) {
                 handleUpdateConversationTitle(conversationId);
@@ -592,10 +596,6 @@ export const useChat = (config?: { onSend?: (msg: string) => void }) => {
     };
     let newMessages: ChatMessage[] = currentMessages;
 
-    if (streamingMessage) {
-      newMessages.push(streamingMessage);
-      setStreamingMessage(null);
-    }
     newMessages = newMessages.concat({
       type: MessageType.USER,
       text: message,

--- a/src/interfaces/coral_web/src/hooks/chat.ts
+++ b/src/interfaces/coral_web/src/hooks/chat.ts
@@ -33,6 +33,7 @@ import {
   BotState,
   ChatMessage,
   ErrorMessage,
+  FulfilledMessage,
   MessageType,
   StreamingMessage,
   createAbortedMessage,
@@ -466,7 +467,7 @@ export const useChat = (config?: { onSend?: (msg: string) => void }) => {
                   )
                 : botResponse;
 
-              setStreamingMessage({
+              const finalMessage: FulfilledMessage = {
                 type: MessageType.BOT,
                 state: BotState.FULFILLED,
                 generationId,
@@ -478,7 +479,10 @@ export const useChat = (config?: { onSend?: (msg: string) => void }) => {
                 isRAGOn,
                 originalText: isRAGOn ? responseText : botResponse,
                 toolEvents,
-              });
+              };
+
+              setConversation({ messages: [...newMessages, finalMessage] });
+              setStreamingMessage(null);
 
               if (shouldUpdateConversationTitle(newMessages)) {
                 handleUpdateConversationTitle(conversationId);
@@ -592,10 +596,6 @@ export const useChat = (config?: { onSend?: (msg: string) => void }) => {
     };
     let newMessages: ChatMessage[] = currentMessages;
 
-    if (streamingMessage) {
-      newMessages.push(streamingMessage);
-      setStreamingMessage(null);
-    }
     newMessages = newMessages.concat({
       type: MessageType.USER,
       text: message,


### PR DESCRIPTION
## Description

It looks like, with the new app router, the clean-up function on `chat.ts`, which removes the `streamingMessage` state, isn't executed after the first iteration.

I removed the condition to check if we had a `streamingMessage` before adding it to the conversation and instead pushed the fulfilled message directly to the conversation.

Closes TLK-885