### PR TITLE
backend: Add migration patch to bring existing users up to DB agnostic changes

### DIFF
--- a/src/backend/alembic/versions/208f735ed937_.py
+++ b/src/backend/alembic/versions/208f735ed937_.py
@@ -1,0 +1,257 @@
+"""empty message
+
+Revision ID: 208f735ed937
+Revises: dc0d3f19222f
+Create Date: 2024-07-24 18:40:59.287003
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import ARRAY, JSONB
+from sqlalchemy.engine.reflection import Inspector
+
+# revision identifiers, used by Alembic.
+revision: str = "208f735ed937"
+down_revision: Union[str, None] = "ed17f144f4bf"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+AGENT_TABLE = "agents"
+AGENT_ARRAY_COLUMN = "tools"
+
+AGENT_TOOL_METADATA_TABLE = "agent_tool_metadata"
+AGENT_TOOL_METADATA_ARRAY_COLUMN = "artifacts"
+
+CITATION_TABLE = "citations"
+CITATION_DOCUMENTS_TABLE = "citation_documents"
+
+
+def is_postgresql():
+    conn = op.get_bind()
+    return conn.dialect.name == "postgresql"
+
+
+def get_inspector():
+    conn = op.get_bind()
+    inspector = Inspector.from_engine(conn)
+
+    return inspector
+
+
+def column_exists_and_is_postgresql_array(table_name, column_name):
+    inspector = get_inspector()
+
+    columns = inspector.get_columns(table_name)
+
+    for column in columns:
+        if column["name"] == column_name:
+            if isinstance(column["type"], ARRAY):
+                return True
+            break
+
+    return False
+
+
+def column_exists_and_is_json(table_name, column_name):
+    inspector = get_inspector()
+
+    columns = inspector.get_columns(table_name)
+
+    for column in columns:
+        if column["name"] == column_name:
+            if isinstance(column["type"], sa.JSON):
+                return True
+            break
+
+    return False
+
+
+def column_exists(table_name, column_name):
+    inspector = get_inspector()
+
+    columns = inspector.get_columns(table_name)
+
+    for column in columns:
+        if column["name"] == column_name:
+            return True
+
+    return False
+
+
+def alter_array_column_to_json(table_name, column_name):
+    op.execute(
+        f"""
+        ALTER TABLE {table_name}
+        ALTER COLUMN {column_name}
+        SET DATA TYPE JSON
+        USING array_to_json({column_name})
+    """
+    )
+
+
+def alter_to_text_array(table_name, column_name):
+    temp_column_name = f"temp_{column_name}"
+
+    # 1. Add a new temporary column of type Text[]
+    op.add_column(table_name, sa.Column(temp_column_name, ARRAY(sa.Text)))
+
+    # 2. Update the new temporary column with converted data
+    op.execute(
+        f"""
+        UPDATE {table_name}
+        SET {temp_column_name} = (
+            SELECT array_agg(value::TEXT)
+            FROM json_array_elements_text({column_name}) AS value
+        )
+    """
+    )
+
+    # 3. Drop the original column
+    op.drop_column(table_name, column_name)
+
+    # 4. Add the final column with the TEXT[] type
+    op.add_column(table_name, sa.Column(column_name, ARRAY(sa.Text)))
+
+    # 5. Copy data from the temporary column to the final column
+    op.execute(
+        f"""
+        UPDATE {table_name}
+        SET {column_name} = {temp_column_name}
+    """
+    )
+
+    # 6. Drop the temporary column
+    op.drop_column(table_name, temp_column_name)
+
+
+def alter_to_jsonb_array(table_name, column_name):
+    temp_column_name = f"temp_{column_name}"
+
+    # 1. Add a new temporary column of type JSONB[]
+    op.add_column(
+        table_name, sa.Column(temp_column_name, ARRAY((JSONB(astext_type=sa.Text()))))
+    )
+
+    # 2. Update the new temporary column with converted data
+    op.execute(
+        f"""
+        UPDATE {table_name}
+        SET {temp_column_name} = (
+            SELECT array_agg(value::JSONB)
+            FROM json_array_elements({column_name}::json) AS value
+        )
+    """
+    )
+
+    # 3. Drop the original column
+    op.drop_column(table_name, column_name)
+
+    # 4. Add the final column with the JSONB[] type
+    op.add_column(
+        table_name, sa.Column(column_name, ARRAY((JSONB(astext_type=sa.Text()))))
+    )
+
+    # 5. Copy data from the temporary column to the final column
+    op.execute(
+        f"""
+        UPDATE {table_name}
+        SET {column_name} = {temp_column_name}
+    """
+    )
+
+    # 6. Drop the temporary column
+    op.drop_column(table_name, temp_column_name)
+
+
+def upgrade() -> None:
+    # Only run this migration for Postgres databases
+    if is_postgresql():
+        # Handle Agent table
+        if column_exists_and_is_postgresql_array(AGENT_TABLE, AGENT_ARRAY_COLUMN):
+            alter_array_column_to_json(AGENT_TABLE, AGENT_ARRAY_COLUMN)
+
+        # Handle AgentToolMetadata table
+        if column_exists_and_is_postgresql_array(
+            AGENT_TOOL_METADATA_TABLE, AGENT_TOOL_METADATA_ARRAY_COLUMN
+        ):
+            alter_array_column_to_json(
+                AGENT_TOOL_METADATA_TABLE, AGENT_TOOL_METADATA_ARRAY_COLUMN
+            )
+
+        # Handle Citation table
+        if not column_exists(CITATION_DOCUMENTS_TABLE, "id"):
+            op.add_column(
+                CITATION_DOCUMENTS_TABLE, sa.Column("id", sa.String(), nullable=False)
+            )
+        if not column_exists(CITATION_DOCUMENTS_TABLE, "created_at"):
+            op.add_column(
+                CITATION_DOCUMENTS_TABLE,
+                sa.Column("created_at", sa.DateTime(), nullable=True),
+            )
+        if not column_exists(CITATION_DOCUMENTS_TABLE, "updated_at"):
+            op.add_column(
+                CITATION_DOCUMENTS_TABLE,
+                sa.Column("updated_at", sa.DateTime(), nullable=True),
+            )
+        if column_exists_and_is_postgresql_array(CITATION_TABLE, "document_ids"):
+            op.alter_column(
+                CITATION_DOCUMENTS_TABLE,
+                "left_id",
+                existing_type=sa.String(),
+                nullable=False,
+            )
+            op.alter_column(
+                CITATION_DOCUMENTS_TABLE,
+                "right_id",
+                existing_type=sa.String(),
+                nullable=False,
+            )
+            op.drop_column(CITATION_TABLE, "document_ids")
+
+
+def downgrade() -> None:
+    if is_postgresql():
+        # Handle Agent table
+        if column_exists_and_is_json(AGENT_TABLE, AGENT_ARRAY_COLUMN):
+            alter_to_text_array(AGENT_TABLE, AGENT_ARRAY_COLUMN)
+
+        # Handle AgentToolMetadata table
+        if column_exists_and_is_json(
+            AGENT_TOOL_METADATA_TABLE, AGENT_TOOL_METADATA_ARRAY_COLUMN
+        ):
+            alter_to_jsonb_array(
+                AGENT_TOOL_METADATA_TABLE, AGENT_TOOL_METADATA_ARRAY_COLUMN
+            )
+
+        # Handle Citation table
+        if column_exists(CITATION_DOCUMENTS_TABLE, "id"):
+            op.drop_column(CITATION_DOCUMENTS_TABLE, "id")
+        if not column_exists(CITATION_DOCUMENTS_TABLE, "created_at"):
+            op.drop_column(CITATION_DOCUMENTS_TABLE, "created_at")
+        if not column_exists(CITATION_DOCUMENTS_TABLE, "updated_at"):
+            op.drop_column(CITATION_DOCUMENTS_TABLE, "updated_at")
+        if not column_exists(CITATION_TABLE, "document_ids"):
+            op.add_column(
+                "citations",
+                sa.Column(
+                    "document_ids",
+                    ARRAY(sa.VARCHAR()),
+                    autoincrement=False,
+                    nullable=False,
+                ),
+            )
+            op.alter_column(
+                CITATION_DOCUMENTS_TABLE,
+                "left_id",
+                existing_type=sa.String(),
+                nullable=True,
+            )
+            op.alter_column(
+                CITATION_DOCUMENTS_TABLE,
+                "right_id",
+                existing_type=sa.String(),
+                nullable=True,
+            )

--- a/src/backend/database_models/user.py
+++ b/src/backend/database_models/user.py
@@ -17,11 +17,16 @@ class UserOrganizationAssociation(Base):
     )
 
 
+
 class User(Base):
     __tablename__ = "users"
 
     fullname: Mapped[str] = mapped_column()
     email: Mapped[Optional[str]] = mapped_column()
     hashed_password: Mapped[Optional[bytes]] = mapped_column()
+
+    # testing
+    test_text: Mapped[list[str]] = mapped_column(ARRAY(Text), default=[], nullable=False)
+    test_jsonb: Mapped[list[str]] = mapped_column(ARRAY(JSONB), nullable=True)
 
     __table_args__ = (UniqueConstraint("email", name="unique_user_email"),)

--- a/src/backend/database_models/user.py
+++ b/src/backend/database_models/user.py
@@ -1,7 +1,6 @@
-from typing import List, Optional
+from typing import Optional
 
-from sqlalchemy import ForeignKey, Text, UniqueConstraint
-from sqlalchemy.dialects.postgresql import ARRAY, JSONB
+from sqlalchemy import ForeignKey, UniqueConstraint
 from sqlalchemy.orm import Mapped, mapped_column
 
 from backend.database_models.base import Base

--- a/src/backend/database_models/user.py
+++ b/src/backend/database_models/user.py
@@ -1,7 +1,8 @@
 from typing import List, Optional
 
-from sqlalchemy import Column, ForeignKey, Table, UniqueConstraint
-from sqlalchemy.orm import Mapped, mapped_column, relationship
+from sqlalchemy import ForeignKey, Text, UniqueConstraint
+from sqlalchemy.dialects.postgresql import ARRAY, JSONB
+from sqlalchemy.orm import Mapped, mapped_column
 
 from backend.database_models.base import Base
 
@@ -17,16 +18,11 @@ class UserOrganizationAssociation(Base):
     )
 
 
-
 class User(Base):
     __tablename__ = "users"
 
     fullname: Mapped[str] = mapped_column()
     email: Mapped[Optional[str]] = mapped_column()
     hashed_password: Mapped[Optional[bytes]] = mapped_column()
-
-    # testing
-    test_text: Mapped[list[str]] = mapped_column(ARRAY(Text), default=[], nullable=False)
-    test_jsonb: Mapped[list[str]] = mapped_column(ARRAY(JSONB), nullable=True)
 
     __table_args__ = (UniqueConstraint("email", name="unique_user_email"),)


### PR DESCRIPTION
**AI Description**

<!-- begin-generated-description -->

This PR introduces changes to the database schema and migration scripts. 

## `src/backend/alembic/versions/208f735ed937_.py`
The new file `208f735ed937_.py` is added to handle database migrations. It includes functions to check the database type, inspect the database, and alter columns. The functions are used to update the `agents`, `agent_tool_metadata`, and `citations` tables. 

### `agents` and `agent_tool_metadata` tables: 
- Alter the `tools` column in the `agents` table from a PostgreSQL array to JSON. 
- Alter the `artifacts` column in the `agent_tool_metadata` table from a PostgreSQL array to JSON. 

### `citations` and `citation_documents` tables: 
- Add `id`, `created_at`, and `updated_at` columns to the `citation_documents` table. 
- Alter the `left_id` and `right_id` columns in the `citation_documents` table to be non-nullable. 
- Remove the `document_ids` column from the `citations` table. 

## `src/backend/database_models/user.py`
The `List` and `Column` imports from the `sqlalchemy` package are removed, leaving only the `ForeignKey`, `UniqueConstraint`, `Mapped`, and `mapped_column` imports.

<!-- end-generated-description -->
