### PR TITLE
Check the auth tokens are valid, if not then delete them 

### DIFF
--- a/src/backend/tools/google_drive/auth.py
+++ b/src/backend/tools/google_drive/auth.py
@@ -60,6 +60,14 @@ class GoogleDriveAuth(BaseToolAuthentication, ToolAuthenticationCacheMixin):
         if auth is None:
             return True
 
+        # Check if token is valid
+        try:
+            auth.access_token
+            auth.refresh_token
+        except Exception as e:
+            tool_auth_crud.delete_tool_auth(session, self.TOOL_ID, user_id)
+            return True
+
         if datetime.datetime.now() > auth.expires_at:
             if self.try_refresh_token(session, user_id, auth):
                 # Refreshed token successfully


### PR DESCRIPTION
Some old auth tokens aren't valid, raising an exception - in this case delete them 

**AI Description**

<!-- begin-generated-description -->

The `is_auth_required` function in `auth.py` has been updated to include additional checks for token validity. 

- The code now includes a `try-except` block to catch exceptions when attempting to access the `auth.access_token` and `auth.refresh_token`.
- If an exception occurs, the tool auth is deleted using `tool_auth_crud.delete_tool_auth`, and the function returns `True`.

<!-- end-generated-description -->
