### PR TITLE
fix(toolkit): auth when no strategies are enabled

### DIFF
--- a/src/interfaces/assistants_web/package-lock.json
+++ b/src/interfaces/assistants_web/package-lock.json
@@ -24,7 +24,7 @@
         "autoprefixer": "^10.4.7",
         "axios": "^1.6.7",
         "classnames": "^2.5.1",
-        "cross-fetch": "^3.1.5",
+        "cross-fetch": "^3.1.8",
         "csstype": "^3.0.10",
         "form-data": "^4.0.0",
         "hast-util-to-jsx-runtime": "^2.3.0",

--- a/src/interfaces/assistants_web/package.json
+++ b/src/interfaces/assistants_web/package.json
@@ -40,7 +40,7 @@
     "autoprefixer": "^10.4.7",
     "axios": "^1.6.7",
     "classnames": "^2.5.1",
-    "cross-fetch": "^3.1.5",
+    "cross-fetch": "^3.1.8",
     "csstype": "^3.0.10",
     "form-data": "^4.0.0",
     "hast-util-to-jsx-runtime": "^2.3.0",

--- a/src/interfaces/assistants_web/src/app/(main)/layout.tsx
+++ b/src/interfaces/assistants_web/src/app/(main)/layout.tsx
@@ -1,18 +1,34 @@
+import fetch from 'cross-fetch';
 import { NextPage } from 'next';
 import { cookies } from 'next/headers';
 import { redirect } from 'next/navigation';
 
+import { CohereClient, Fetch } from '@/cohere-client';
 import { AgentLeftPanel } from '@/components/Agents/AgentLeftPanel';
 import { AgentsList } from '@/components/Agents/AgentsList';
 import { MobileHeader } from '@/components/MobileHeader';
 import { COOKIE_KEYS } from '@/constants';
+import { env } from '@/env.mjs';
 import { cn } from '@/utils';
 
-const MainLayout: NextPage<React.PropsWithChildren> = ({ children }) => {
-  const cookieStore = cookies();
-  const authToken = cookieStore.get(COOKIE_KEYS.authToken);
-  if (!authToken) {
-    return redirect('/login');
+const makeCohereClient = () => {
+  const apiFetch: Fetch = async (resource, config) => await fetch(resource, config);
+  return new CohereClient({
+    hostname: env.NEXT_PUBLIC_API_HOSTNAME,
+    fetch: apiFetch,
+  });
+};
+
+const MainLayout: NextPage<React.PropsWithChildren> = async ({ children }) => {
+  const cohereClient = makeCohereClient();
+  const strategies = await cohereClient.getAuthStrategies();
+  if (strategies.length !== 0) {
+    const cookieStore = cookies();
+    const authToken = cookieStore.get(COOKIE_KEYS.authToken);
+
+    if (!authToken) {
+      return redirect('/login');
+    }
   }
 
   return (

--- a/src/interfaces/coral_web/package-lock.json
+++ b/src/interfaces/coral_web/package-lock.json
@@ -24,6 +24,7 @@
         "axios": "^1.6.7",
         "class-variance-authority": "^0.7.0",
         "classnames": "^2.5.1",
+        "cross-fetch": "^4.0.0",
         "csstype": "^3.0.10",
         "form-data": "^4.0.0",
         "hast-util-to-jsx-runtime": "^2.3.0",
@@ -4122,6 +4123,14 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/cross-fetch": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-4.0.0.tgz",
+      "integrity": "sha512-e4a5N8lVvuLgAWgnCrLr2PP0YyDOTHa9H/Rj54dirp61qXnNq46m82bRhNqIA5VccJtWBvPTFRV3TtvHUKPB1g==",
+      "dependencies": {
+        "node-fetch": "^2.6.12"
       }
     },
     "node_modules/cross-spawn": {
@@ -8368,6 +8377,25 @@
         "node": ">=10.5.0"
       }
     },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/node-fetch-native": {
       "version": "1.6.4",
       "resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.6.4.tgz",
@@ -10782,6 +10810,11 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+    },
     "node_modules/trim-lines": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
@@ -11216,6 +11249,20 @@
       "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/which": {

--- a/src/interfaces/coral_web/package.json
+++ b/src/interfaces/coral_web/package.json
@@ -38,6 +38,7 @@
     "axios": "^1.6.7",
     "class-variance-authority": "^0.7.0",
     "classnames": "^2.5.1",
+    "cross-fetch": "^4.0.0",
     "csstype": "^3.0.10",
     "form-data": "^4.0.0",
     "hast-util-to-jsx-runtime": "^2.3.0",

--- a/src/interfaces/coral_web/src/app/(main)/layout.tsx
+++ b/src/interfaces/coral_web/src/app/(main)/layout.tsx
@@ -1,16 +1,33 @@
+import fetch from 'cross-fetch';
 import { NextPage } from 'next';
 import { cookies } from 'next/headers';
 import { redirect } from 'next/navigation';
 
 import { MainLayout } from '@/app/(main)/MainLayout';
+import { CohereClient, Fetch } from '@/cohere-client';
 import { COOKIE_KEYS } from '@/constants';
+import { env } from '@/env.mjs';
+
+const makeCohereClient = () => {
+  const apiFetch: Fetch = async (resource, config) => await fetch(resource, config);
+  return new CohereClient({
+    hostname: env.NEXT_PUBLIC_API_HOSTNAME,
+    fetch: apiFetch,
+  });
+};
 
 const Layout: NextPage<React.PropsWithChildren> = async ({ children }) => {
-  const cookieStore = cookies();
-  const authToken = cookieStore.get(COOKIE_KEYS.authToken);
-  if (!authToken) {
-    return redirect('/login');
+  const cohereClient = makeCohereClient();
+  const strategies = await cohereClient.getAuthStrategies();
+  if (strategies.length !== 0) {
+    const cookieStore = cookies();
+    const authToken = cookieStore.get(COOKIE_KEYS.authToken);
+
+    if (!authToken) {
+      return redirect('/login');
+    }
   }
+
   return <MainLayout>{children}</MainLayout>;
 };
 


### PR DESCRIPTION
When no auth strategies are enabled, skip checking auth.

## Summary
The changes include:
- Adding the `cross-fetch` package and its dependencies to `package.json` and `package-lock.json`.
- Importing the `cross-fetch` package and related modules in `layout.tsx`.
- Modifying the `layout.tsx` file to use the `CohereClient` and `Fetch` functions from the `@/cohere-client` module.
- Introducing a new `makeCohereClient` function to create a `CohereClient` instance with the API hostname and `apiFetch` function.
- Updating the `Layout` component to use the `cohereClient` instance and check for auth strategies before redirecting to the login page.

## Changes
- **package-lock.json**:
  - Added `cross-fetch` and its dependencies (`node-fetch` and `node-fetch`'s dependency `whatwg-url') to the `dependencies` list.
- **package.json**:
  - Added `cross-fetch` to the list of dependencies.
- **layout.tsx**:
  - Imported `fetch` from `'cross-fetch''.
  - Imported `CohereClient` and `Fetch` from `'@/cohere-client''.
  - Imported `env` from `'@/env.mjs''.
  - Added the `makeCohereClient` function to create a `CohereClient` instance.
  - Modified the `Layout` component to use the `cohereClient` instance.
  - Checked for the length of `strategies` before redirecting to the login page.

