### PR TITLE
feat(toolkit): display dark and light mode

### DIFF
--- a/src/interfaces/assistants_web/.storybook/preview.tsx
+++ b/src/interfaces/assistants_web/.storybook/preview.tsx
@@ -5,27 +5,16 @@ import React from 'react';
 import '../src/styles/main.css';
 
 const preview: Preview = {
-  globalTypes: {
-    theme: {
-      description: 'Global theme for components',
-      toolbar: {
-        // The label to show for this toolbar item
-        title: 'Theme',
-        icon: 'circlehollow',
-        // Array of plain string values or MenuItem shape (see below)
-        items: ['light', 'dark'],
-        // Change title based on selected value
-        dynamicTitle: true,
-      },
-    },
-  },
   decorators: [
-    (Story, context) => (
-      <ThemeProvider forcedTheme={context.globals.theme} attribute="class" defaultTheme="dark">
-        <div className="h-screen w-screen bg-marble-950 p-4 dark:bg-volcanic-100">
+    (Story) => (
+      <div className="grid h-screen w-screen grid-cols-2">
+        <main className="dark bg-volcanic-100 p-3">
           <Story />
-        </div>
-      </ThemeProvider>
+        </main>
+        <main className="bg-marble-950 p-3">
+          <Story />
+        </main>
+      </div>
     ),
   ],
   parameters: {


### PR DESCRIPTION
Display dark and light mode components in storybook

<img width="1728" alt="Screenshot 2024-08-01 at 10 20 16 PM" src="https://github.com/user-attachments/assets/615fe46e-e4ff-4556-bedd-47fd9f662e59">

- [ ] **PR title**: "area: description"
  - Where "area" is whichever of interface, frontend, model, tools, backend, etc. is being modified. Use "docs: ..." for purely docs changes, "infra: ..." for CI changes.
  - Example: "deployment: add Azure model option"


- [ ] **PR message**: ***Delete this entire checklist*** and replace with
    - **Description:** a description of the change
    - **Issue:** the issue # it fixes, if applicable
    - **Dependencies:** any dependencies required for this change


- [ ] **Add tests and docs**: Please include testing and documentation for your changes
- [ ] **Lint and test**: Run `make lint` and `make run-tests`

**AI Description**

<!-- begin-generated-description -->

This pull request updates the rendering of stories in the Storybook for the `assistants_web` interface.

**Changes:**
- Removes the `globalTypes` field from the `preview` object, which includes the `theme` configuration.
- Updates the `decorators` array by modifying the rendering of stories:
- Removes the `context` parameter from the decorator function.
- Uses a grid layout with two columns instead of the `ThemeProvider` component.
- Renders each story in a separate `main` element within the grid.
- The first column has a dark background and displays the story.
- The second column has a light background and also displays the story.

<!-- end-generated-description -->
