### PR TITLE
fix(dark-mode): fix bugs and improvements to UX

### DIFF
--- a/src/interfaces/assistants_web/src/components/Agents/AgentRightPanel.tsx
+++ b/src/interfaces/assistants_web/src/components/Agents/AgentRightPanel.tsx
@@ -21,7 +21,6 @@ type Props = {};
 const AgentRightPanel: React.FC<Props> = () => {
   const [isDeletingFile, setIsDeletingFile] = useState(false);
   const [selectedIndex, setSelectedIndex] = useState(0);
-  // TODO: (khalil) configure this to use Google drive files
   const {
     agents: { disabledAssistantKnowledge },
     setUseAssistantKnowledge,

--- a/src/interfaces/assistants_web/src/components/Agents/AgentRightPanel.tsx
+++ b/src/interfaces/assistants_web/src/components/Agents/AgentRightPanel.tsx
@@ -1,17 +1,18 @@
 'use client';
 
 import { Transition } from '@headlessui/react';
+import { uniqBy } from 'lodash';
 import { useMemo, useState } from 'react';
 
 import { CitationsTab } from '@/components/Agents/CitationsTab';
 import { IconButton } from '@/components/IconButton';
 import { Banner, Button, Icon, Switch, Tabs, Text, Tooltip } from '@/components/Shared';
-import { TOOL_GOOGLE_DRIVE_ID } from '@/constants';
+import { TOOL_GOOGLE_DRIVE_ID, TOOL_READ_DOCUMENT_ID, TOOL_SEARCH_FILE_ID } from '@/constants';
 import { useAgent } from '@/hooks/agents';
 import { useBrandedColors } from '@/hooks/brandedColors';
 import { useChatRoutes } from '@/hooks/chatRoutes';
 import { useFileActions, useListFiles } from '@/hooks/files';
-import { useParamsStore } from '@/stores';
+import { useAgentsStore, useParamsStore } from '@/stores';
 import { DataSourceArtifact } from '@/types/tools';
 import { pluralize } from '@/utils';
 
@@ -21,7 +22,10 @@ const AgentRightPanel: React.FC<Props> = () => {
   const [isDeletingFile, setIsDeletingFile] = useState(false);
   const [selectedIndex, setSelectedIndex] = useState(0);
   // TODO: (khalil) configure this to use Google drive files
-  const [useAssistantKnowledge, setUseAssistantKnowledge] = useState(true);
+  const {
+    agents: { disabledAssistantKnowledge },
+    setUseAssistantKnowledge,
+  } = useAgentsStore();
   const { agentId, conversationId } = useChatRoutes();
   const { data: agent, isLoading: isAgentLoading } = useAgent({ agentId });
   const { theme } = useBrandedColors(agentId);
@@ -34,20 +38,29 @@ const AgentRightPanel: React.FC<Props> = () => {
   const { data: files, isLoading: isFilesLoading } = useListFiles(conversationId);
   const { deleteFile } = useFileActions();
 
-  const agentGoogleDriveArtifcats = useMemo(() => {
-    if (!agent)
+  const agentToolMetadataArtifacts = useMemo(() => {
+    if (!agent) {
       return {
         files: [],
         folders: [],
       };
+    }
 
-    const artifacts =
-      (agent.tools_metadata?.find(
-        (tool_metadata) => tool_metadata.tool_name === TOOL_GOOGLE_DRIVE_ID
-      )?.artifacts as DataSourceArtifact[]) ?? [];
+    const fileArtifacts = uniqBy(
+      (
+        agent.tools_metadata?.filter((tool_metadata) =>
+          [TOOL_GOOGLE_DRIVE_ID, TOOL_READ_DOCUMENT_ID, TOOL_SEARCH_FILE_ID].includes(
+            tool_metadata.tool_name
+          )
+        ) ?? []
+      )
+        .map((tool_metadata) => tool_metadata.artifacts as DataSourceArtifact[])
+        .flat(),
+      'id'
+    );
 
-    const files = artifacts.filter((artifact) => artifact.type === 'file');
-    const folders = artifacts.filter((artifact) => artifact.type === 'folder');
+    const files = fileArtifacts.filter((artifact) => artifact.type === 'file');
+    const folders = fileArtifacts.filter((artifact) => artifact.type === 'folder');
     return {
       files,
       folders,
@@ -55,8 +68,8 @@ const AgentRightPanel: React.FC<Props> = () => {
   }, [agent]);
 
   const agentKnowledgeFiles = [
-    ...agentGoogleDriveArtifcats.files,
-    ...agentGoogleDriveArtifcats.folders,
+    ...agentToolMetadataArtifacts.files,
+    ...agentToolMetadataArtifacts.folders,
   ];
 
   const handleDeleteFile = async (fileId: string) => {
@@ -109,12 +122,12 @@ const AgentRightPanel: React.FC<Props> = () => {
               </span>
               <Switch
                 theme={theme}
-                checked={useAssistantKnowledge}
-                onChange={setUseAssistantKnowledge}
+                checked={!disabledAssistantKnowledge.includes(agentId)}
+                onChange={(checked) => setUseAssistantKnowledge(checked, agentId)}
               />
             </div>
             <Transition
-              show={useAssistantKnowledge}
+              show={!disabledAssistantKnowledge.includes(agentId) ?? false}
               enter="duration-300 ease-in-out transition-all"
               enterFrom="opacity-0 scale-90"
               enterTo="opacity-100 scale-100"
@@ -126,7 +139,14 @@ const AgentRightPanel: React.FC<Props> = () => {
               {agentKnowledgeFiles.length === 0 ? (
                 <Banner className="flex flex-col">
                   Add a data source to expand the assistant’s knowledge.
-                  <Button theme={theme} className="mt-4" label="Add Data Source" icon="add" />
+                  <Button
+                    theme={theme}
+                    className="mt-4 w-full"
+                    label="Add Data Source"
+                    stretch
+                    icon="add"
+                    href={`/edit/${agentId}?datasources=1`}
+                  />
                 </Banner>
               ) : (
                 <div className="flex flex-col gap-y-3">
@@ -135,15 +155,15 @@ const AgentRightPanel: React.FC<Props> = () => {
                     {/*  This renders the number of folders and files in the agent's Google Drive.
                     For example, if the agent has 2 folders and 3 files, it will render:
                     - "2 folders and 3 files" */}
-                    {agentGoogleDriveArtifcats.folders.length > 0 &&
-                      `${agentGoogleDriveArtifcats.folders.length} ${pluralize(
+                    {agentToolMetadataArtifacts.folders.length > 0 &&
+                      `${agentToolMetadataArtifacts.folders.length} ${pluralize(
                         'folder',
-                        agentGoogleDriveArtifcats.folders.length
-                      )} ${agentGoogleDriveArtifcats.files.length > 0 ? 'and' : ''}`}
-                    {agentGoogleDriveArtifcats.files.length > 0 &&
-                      `${agentGoogleDriveArtifcats.files.length} ${pluralize(
+                        agentToolMetadataArtifacts.folders.length
+                      )} ${agentToolMetadataArtifacts.files.length > 0 ? 'and ' : ''}`}
+                    {agentToolMetadataArtifacts.files.length > 0 &&
+                      `${agentToolMetadataArtifacts.files.length} ${pluralize(
                         'file',
-                        agentGoogleDriveArtifcats.files.length
+                        agentToolMetadataArtifacts.files.length
                       )}`}
                   </Text>
                   {agentKnowledgeFiles.map((file) => (

--- a/src/interfaces/assistants_web/src/components/Agents/AgentSettings/AgentSettingsForm.tsx
+++ b/src/interfaces/assistants_web/src/components/Agents/AgentSettings/AgentSettingsForm.tsx
@@ -64,11 +64,11 @@ export const AgentSettingsForm: React.FC<Props> = ({
       ?.artifacts as DataSourceArtifact[]
   );
 
-  const nameError = !fields.name.trim()
-    ? 'Assistant name is required'
-    : isAgentNameUnique(fields.name.trim(), agentId)
+  const nameError = isAgentNameUnique(fields.name.trim(), agentId)
     ? 'Assistant name must be unique'
     : undefined;
+
+  const canCreate = !nameError;
 
   const setToolsMetadata = () => {
     const tools_metadata = [
@@ -145,11 +145,7 @@ export const AgentSettingsForm: React.FC<Props> = ({
         isExpanded={currentStep === 'define'}
         setIsExpanded={(expanded) => setCurrentStep(expanded ? 'define' : undefined)}
       >
-        <DefineAssistantStep
-          fields={fields}
-          setFields={setFields}
-          nameError={!!fields.name ? nameError : undefined}
-        />
+        <DefineAssistantStep fields={fields} setFields={setFields} nameError={nameError} />
         <StepButtons
           handleNext={() => setCurrentStep('dataSources')}
           hide={source !== 'create'}
@@ -218,7 +214,7 @@ export const AgentSettingsForm: React.FC<Props> = ({
           handleNext={onSubmit}
           handleBack={() => setCurrentStep('tools')}
           nextLabel="Create"
-          disabled={!!nameError}
+          disabled={!canCreate}
           isSubmit
           hide={source !== 'create'}
         />

--- a/src/interfaces/assistants_web/src/components/Agents/AgentSettings/AgentSettingsForm.tsx
+++ b/src/interfaces/assistants_web/src/components/Agents/AgentSettings/AgentSettingsForm.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { uniqBy } from 'lodash';
+import { useSearchParams } from 'next/navigation';
 import { useEffect, useState } from 'react';
 
 import { CreateAgent, UpdateAgent } from '@/cohere-client';
@@ -46,10 +47,12 @@ export const AgentSettingsForm: React.FC<Props> = ({
 }) => {
   const { data: listToolsData, status: listToolsStatus } = useListTools();
   const isAgentNameUnique = useIsAgentNameUnique();
+  const params = useSearchParams();
+  const defaultStep = params.has('datasources');
 
   const [currentStep, setCurrentStep] = useState<
     'define' | 'dataSources' | 'tools' | 'visibility' | undefined
-  >('define');
+  >(() => (defaultStep ? 'dataSources' : 'define'));
 
   const [googleFiles, setGoogleFiles] = useState<DataSourceArtifact[]>(
     fields.tools_metadata?.find((metadata) => metadata.tool_name === TOOL_GOOGLE_DRIVE_ID)
@@ -142,7 +145,11 @@ export const AgentSettingsForm: React.FC<Props> = ({
         isExpanded={currentStep === 'define'}
         setIsExpanded={(expanded) => setCurrentStep(expanded ? 'define' : undefined)}
       >
-        <DefineAssistantStep fields={fields} setFields={setFields} nameError={nameError} />
+        <DefineAssistantStep
+          fields={fields}
+          setFields={setFields}
+          nameError={!!fields.name ? nameError : undefined}
+        />
         <StepButtons
           handleNext={() => setCurrentStep('dataSources')}
           hide={source !== 'create'}

--- a/src/interfaces/assistants_web/src/components/Agents/AgentSettings/DefineStep.tsx
+++ b/src/interfaces/assistants_web/src/components/Agents/AgentSettings/DefineStep.tsx
@@ -17,7 +17,7 @@ export const DefineAssistantStep: React.FC<Props> = ({ fields, nameError, setFie
         placeholder="e.g., HR Benefits Bot"
         value={fields.name}
         onChange={(e) => setFields({ ...fields, name: e.target.value })}
-        errorText={!fields.name.trim() ? 'Assistant name is required' : nameError}
+        errorText={nameError}
       />
       <Textarea
         label="Description"

--- a/src/interfaces/assistants_web/src/components/Agents/CreateAgent.tsx
+++ b/src/interfaces/assistants_web/src/components/Agents/CreateAgent.tsx
@@ -107,12 +107,14 @@ export const CreateAgent: React.FC = () => {
         </div>
         <Text styleAs="h4">Create assistant</Text>
       </header>
-      <AgentSettingsForm
-        fields={fields}
-        setFields={setFields}
-        onSubmit={handleOpenSubmitModal}
-        savePendingAssistant={() => setPendingAssistant(fields)}
-      />
+      <div className="overflow-y-auto">
+        <AgentSettingsForm
+          fields={fields}
+          setFields={setFields}
+          onSubmit={handleOpenSubmitModal}
+          savePendingAssistant={() => setPendingAssistant(fields)}
+        />
+      </div>
     </div>
   );
 };

--- a/src/interfaces/assistants_web/src/components/Agents/UpdateAgent.tsx
+++ b/src/interfaces/assistants_web/src/components/Agents/UpdateAgent.tsx
@@ -104,36 +104,40 @@ export const UpdateAgent: React.FC<Props> = ({ agentId }) => {
         </div>
         <Text styleAs="h4">Edit {agent.name}</Text>
       </header>
-      <AgentSettingsForm
-        source="update"
-        fields={fields}
-        setFields={setFields}
-        onSubmit={handleSubmit}
-        savePendingAssistant={() => setPendingAssistant(fields)}
-        agentId={agentId}
-      />
-      <div className="space-y-5 px-8 pb-8">
-        <div className="flex w-full max-w-screen-md items-center justify-between ">
-          <Button label="Cancel" kind="secondary" href="/discover" />
+      <div className="flex flex-col overflow-y-auto">
+        <AgentSettingsForm
+          source="update"
+          fields={fields}
+          setFields={setFields}
+          onSubmit={handleSubmit}
+          savePendingAssistant={() => setPendingAssistant(fields)}
+          agentId={agentId}
+        />
+        <div className="space-y-5 p-8">
+          <div className="flex w-full max-w-screen-md items-center justify-between ">
+            <Button label="Cancel" kind="secondary" href="/discover" />
+            <Button
+              label="Update"
+              theme="evolved-green"
+              kind="cell"
+              icon={'checkmark'}
+              iconOptions={{ customIcon: isSubmitting ? <Spinner /> : undefined }}
+              disabled={
+                isSubmitting ||
+                !fields.name.trim() ||
+                isAgentNameUnique(fields.name.trim(), agent.id)
+              }
+              onClick={handleSubmit}
+            />
+          </div>
           <Button
-            label="Update"
-            theme="evolved-green"
-            kind="cell"
-            icon={'checkmark'}
-            iconOptions={{ customIcon: isSubmitting ? <Spinner /> : undefined }}
-            disabled={
-              isSubmitting || !fields.name.trim() || isAgentNameUnique(fields.name.trim(), agent.id)
-            }
-            onClick={handleSubmit}
+            label="Delete assistant"
+            icon="trash"
+            theme="danger"
+            kind="secondary"
+            onClick={handleOpenDeleteModal}
           />
         </div>
-        <Button
-          label="Delete assistant"
-          icon="trash"
-          theme="danger"
-          kind="secondary"
-          onClick={handleOpenDeleteModal}
-        />
       </div>
     </div>
   );

--- a/src/interfaces/assistants_web/src/components/CollapsibleSection.tsx
+++ b/src/interfaces/assistants_web/src/components/CollapsibleSection.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { ReactNode } from 'react';
+import { ReactNode, useEffect, useRef } from 'react';
 
 import { Icon, Text } from '@/components/Shared';
 import { cn } from '@/utils';
@@ -21,8 +21,20 @@ export const CollapsibleSection: React.FC<Props> = ({
   isExpanded = false,
   setIsExpanded,
 }) => {
+  const ref = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    if (isExpanded) {
+      ref.current?.scrollIntoView({
+        behavior: 'smooth',
+        block: 'center',
+        inline: 'nearest',
+      });
+    }
+  }, [isExpanded]);
+
   return (
     <div
+      ref={ref}
       className={cn(
         'flex w-full max-w-screen-md flex-col rounded-md',
         'space-y-5 border p-6',

--- a/src/interfaces/assistants_web/src/hooks/chat.ts
+++ b/src/interfaces/assistants_web/src/hooks/chat.ts
@@ -28,7 +28,13 @@ import {
 import { useChatRoutes } from '@/hooks/chatRoutes';
 import { useUpdateConversationTitle } from '@/hooks/generateTitle';
 import { StreamingChatParams, useStreamChat } from '@/hooks/streamChat';
-import { useCitationsStore, useConversationStore, useFilesStore, useParamsStore } from '@/stores';
+import {
+  useAgentsStore,
+  useCitationsStore,
+  useConversationStore,
+  useFilesStore,
+  useParamsStore,
+} from '@/stores';
 import { OutputFiles } from '@/stores/slices/citationsSlice';
 import { useStreamingStore } from '@/stores/streaming';
 import {
@@ -97,6 +103,9 @@ export const useChat = (config?: { onSend?: (msg: string) => void }) => {
     clearComposerFiles,
     clearUploadingErrors,
   } = useFilesStore();
+  const {
+    agents: { disabledAssistantKnowledge },
+  } = useAgentsStore();
   const queryClient = useQueryClient();
 
   const currentConversationId = id || composerFiles[0]?.conversation_id;

--- a/src/interfaces/assistants_web/src/stores/index.ts
+++ b/src/interfaces/assistants_web/src/stores/index.ts
@@ -87,6 +87,7 @@ export const useAgentsStore = () => {
   return useStore(
     (state) => ({
       agents: state.agents,
+      setUseAssistantKnowledge: state.setUseAssistantKnowledge,
       setAgentsLeftSidePanelOpen: state.setAgentsLeftSidePanelOpen,
       setAgentsRightSidePanelOpen: state.setAgentsRightSidePanelOpen,
     }),

--- a/src/interfaces/assistants_web/src/stores/slices/agentsSlice.ts
+++ b/src/interfaces/assistants_web/src/stores/slices/agentsSlice.ts
@@ -3,15 +3,18 @@ import { StateCreator } from 'zustand';
 import { StoreState } from '@/stores';
 
 const INITIAL_STATE = {
+  disabledAssistantKnowledge: [],
   isAgentsLeftPanelOpen: true,
   isAgentsRightPanelOpen: false,
 };
 
 type State = {
+  disabledAssistantKnowledge: string[];
   isAgentsLeftPanelOpen: boolean;
   isAgentsRightPanelOpen: boolean;
 };
 type Actions = {
+  setUseAssistantKnowledge: (useKnowledge: boolean, agentId: string) => void;
   setAgentsLeftSidePanelOpen: (isOpen: boolean) => void;
   setAgentsRightSidePanelOpen: (isOpen: boolean) => void;
 };
@@ -21,6 +24,16 @@ export type AgentsStore = {
 } & Actions;
 
 export const createAgentsSlice: StateCreator<StoreState, [], [], AgentsStore> = (set) => ({
+  setUseAssistantKnowledge(useKnowledge, agentId) {
+    set((state) => ({
+      agents: {
+        ...state.agents,
+        disabledAssistantKnowledge: useKnowledge
+          ? state.agents.disabledAssistantKnowledge.filter((id) => id !== agentId)
+          : [...state.agents.disabledAssistantKnowledge, agentId],
+      },
+    }));
+  },
   setAgentsLeftSidePanelOpen(isOpen) {
     set((state) => ({
       agents: {


### PR DESCRIPTION
https://github.com/user-attachments/assets/cf4f1339-8815-416e-a872-d05babff6f9e

- Scroll overflow for create/update assistant
- Do not show error message when name is not typed for assistant
- Do not override files on file picker select
- Auto scroll to assistant step on "Next" or "Back"


**AI Description**

<!-- begin-generated-description -->

This pull request makes changes to the assistant settings and UI components. 

## Summary
The changes include:
- Adding the ability to disable assistant knowledge for specific agents.
- Updating the agent settings form to include data sources by default when creating a new agent.
- Enhancing the collapsible section component to smoothly scroll to the expanded content.
- Refactoring the assistant settings form to include a new "Update" button and rearranging the "Delete Assistant" button.

## Details
- **AgentRightPanel.tsx**: 
  - Introduces the `useAgentsStore` hook to manage the `disabledAssistantKnowledge` state for specific agents.
  - Updates the `useMemo` logic to retrieve tool metadata for Google Drive, Read Document, and Search File tools.
  - Adjusts the rendering of agent knowledge files and folders based on the new tool metadata structure.
- **AgentSettingsForm.tsx**: 
  - Adds the `useSearchParams` hook to determine the default step based on the presence of data sources in the URL parameters.
  - Updates the initial state of the `currentStep` to either "dataSources" or "define" based on the default step.
- **CreateAgent.tsx** and **UpdateAgent.tsx**: 
  - Wraps the `AgentSettingsForm` component in a container with a `className` of "overflow-y-auto" to enable vertical scrolling.
- **CollapsibleSection.tsx**: 
  - Imports the `useEffect` and `useRef` hooks from React.
  - Initializes a `ref` variable using `useRef` to reference the collapsible section element.
  - In the `useEffect` hook, when the `isExpanded` state is true, the `ref.current` element is scrolled into view smoothly using the `scrollIntoView` method.
- **chat.ts** and **stores/index.ts**: 
  - Updates the imports to include the `useAgentsStore` hook, which provides access to the `disabledAssistantKnowledge` state.
- **agentsSlice.ts**: 
  - Introduces a new `disabledAssistantKnowledge` array in the initial state.
  - Adds a new `setUseAssistantKnowledge` action to enable or disable assistant knowledge for specific agents.
  - Implements the `setUseAssistantKnowledge` action to update the `disabledAssistantKnowledge` array based on the provided `useKnowledge` flag and `agentId`.

<!-- end-generated-description -->
