### PR TITLE
fix(toolkit): API host name for RSC

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
       - PGUSER=postgres
       - POSTGRES_PASSWORD=postgres
     ports:
-      - '5433:5432'
+      - "5433:5432"
     networks:
       - proxynet
 
@@ -36,8 +36,8 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
-    ports: 
-      - '6379:6379'
+    ports:
+      - "6379:6379"
     networks:
       - proxynet
     command: redis-server --save 60 1 --loglevel warning --requirepass redis
@@ -78,7 +78,7 @@ services:
       - ./src/backend/alembic:/workspace/src/backend/alembic
       # Mount data folder to sync uploaded files
       - ./src/backend/data:/workspace/src/backend/data
-      # Mount configurations 
+      # Mount configurations
       - ./src/backend/config/secrets.yaml:/workspace/src/backend/config/secrets.yaml
       - ./src/backend/config/configuration.yaml:/workspace/src/backend/config/configuration.yaml
     # network_mode: host
@@ -92,6 +92,7 @@ services:
       dockerfile: Dockerfile
     # Set environment variables directly in the docker-compose file
     environment:
+      API_HOSTNAME: http://backend:8000
       NEXT_PUBLIC_API_HOSTNAME: ${NEXT_PUBLIC_API_HOSTNAME}
       NEXT_PUBLIC_FRONTEND_HOSTNAME: ${NEXT_PUBLIC_FRONTEND_HOSTNAME}
       NEXT_PUBLIC_GOOGLE_DRIVE_CLIENT_ID: ${NEXT_PUBLIC_GOOGLE_DRIVE_CLIENT_ID}

--- a/src/interfaces/assistants_web/.env.development
+++ b/src/interfaces/assistants_web/.env.development
@@ -1,3 +1,6 @@
+# Server
+API_HOSTNAME=http://backend:8000
+
 # Client
 NEXT_PUBLIC_API_HOSTNAME=http://localhost:8000
 NEXT_PUBLIC_FRONTEND_HOSTNAME=http://localhost:4444

--- a/src/interfaces/assistants_web/.env.production
+++ b/src/interfaces/assistants_web/.env.production
@@ -1,3 +1,6 @@
+# Server
+API_HOSTNAME=http://backend:8000
+
 # Client
 NEXT_PUBLIC_API_HOSTNAME=http://localhost:8000
 NEXT_PUBLIC_FRONTEND_HOSTNAME=http://localhost:4444

--- a/src/interfaces/assistants_web/src/app/(main)/layout.tsx
+++ b/src/interfaces/assistants_web/src/app/(main)/layout.tsx
@@ -14,7 +14,7 @@ import { cn } from '@/utils';
 const makeCohereClient = () => {
   const apiFetch: Fetch = async (resource, config) => await fetch(resource, config);
   return new CohereClient({
-    hostname: env.NEXT_PUBLIC_API_HOSTNAME,
+    hostname: env.API_HOSTNAME,
     fetch: apiFetch,
   });
 };

--- a/src/interfaces/assistants_web/src/env.mjs
+++ b/src/interfaces/assistants_web/src/env.mjs
@@ -3,7 +3,9 @@ import { createEnv } from '@t3-oss/env-nextjs';
 import z from 'zod';
 
 export const env = createEnv({
-  server: {},
+  server: {
+    API_HOSTNAME: z.string().default('http://backend:8000'),
+  },
   client: {
     NEXT_PUBLIC_API_HOSTNAME: z.string(),
     NEXT_PUBLIC_FRONTEND_HOSTNAME: z.string().optional().default('http://localhost:4000'),
@@ -16,6 +18,7 @@ export const env = createEnv({
       .default(false),
   },
   runtimeEnv: {
+    API_HOSTNAME: process.env.API_HOSTNAME,
     NEXT_PUBLIC_API_HOSTNAME: process.env.NEXT_PUBLIC_API_HOSTNAME,
     NEXT_PUBLIC_FRONTEND_HOSTNAME: process.env.NEXT_PUBLIC_FRONTEND_HOSTNAME,
     NEXT_PUBLIC_GOOGLE_DRIVE_CLIENT_ID: process.env.NEXT_PUBLIC_GOOGLE_DRIVE_CLIENT_ID,

--- a/src/interfaces/coral_web/.env.development
+++ b/src/interfaces/coral_web/.env.development
@@ -1,3 +1,6 @@
+# Server
+API_HOSTNAME=http://backend:8000
+
 # Client
 NEXT_PUBLIC_API_HOSTNAME=http://localhost:8000
 NEXT_PUBLIC_FRONTEND_HOSTNAME=http://localhost:4000

--- a/src/interfaces/coral_web/.env.production
+++ b/src/interfaces/coral_web/.env.production
@@ -1,3 +1,6 @@
+# Server
+API_HOSTNAME=http://backend:8000
+
 # Client
 NEXT_PUBLIC_API_HOSTNAME=http://localhost:8000
 NEXT_PUBLIC_FRONTEND_HOSTNAME=http://localhost:4000

--- a/src/interfaces/coral_web/src/app/(main)/layout.tsx
+++ b/src/interfaces/coral_web/src/app/(main)/layout.tsx
@@ -11,7 +11,7 @@ import { env } from '@/env.mjs';
 const makeCohereClient = () => {
   const apiFetch: Fetch = async (resource, config) => await fetch(resource, config);
   return new CohereClient({
-    hostname: env.NEXT_PUBLIC_API_HOSTNAME,
+    hostname: env.API_HOSTNAME,
     fetch: apiFetch,
   });
 };

--- a/src/interfaces/coral_web/src/env.mjs
+++ b/src/interfaces/coral_web/src/env.mjs
@@ -3,7 +3,9 @@ import { createEnv } from '@t3-oss/env-nextjs';
 import z from 'zod';
 
 export const env = createEnv({
-  server: {},
+  server: {
+    API_HOSTNAME: z.string().default('http://backend:8000'),
+  },
   client: {
     NEXT_PUBLIC_API_HOSTNAME: z.string(),
     NEXT_PUBLIC_FRONTEND_HOSTNAME: z.string().optional().default('http://localhost:4000'),
@@ -18,6 +20,7 @@ export const env = createEnv({
       .transform((s) => s === 'true'),
   },
   runtimeEnv: {
+    API_HOSTNAME: process.env.API_HOSTNAME,
     NEXT_PUBLIC_API_HOSTNAME: process.env.NEXT_PUBLIC_API_HOSTNAME,
     NEXT_PUBLIC_FRONTEND_HOSTNAME: process.env.NEXT_PUBLIC_FRONTEND_HOSTNAME,
     NEXT_PUBLIC_GOOGLE_DRIVE_CLIENT_ID: process.env.NEXT_PUBLIC_GOOGLE_DRIVE_CLIENT_ID,


### PR DESCRIPTION
React Server Components runs in the server, for our case this means that it runs in the same network that our backend is running, therefore to communicate with the backend we need to specify the internal docker network route to the backend (http://backend/). For the client bundle we still use the exposed port 8000 because requests are performed from an external network from that of docker.
- API_HOSTNAME -> to be used in RSC context
- NEXT_PUBLIC_API_HOSTNAME -> for the client bundle