### PR TITLE
fix(toolkit): update login/register

### DIFF
--- a/src/interfaces/assistants_web/src/app/(auth)/register/Register.tsx
+++ b/src/interfaces/assistants_web/src/app/(auth)/register/Register.tsx
@@ -4,7 +4,8 @@ import { useRouter, useSearchParams } from 'next/navigation';
 import { SubmitHandler, useForm } from 'react-hook-form';
 
 import { AuthLink } from '@/components/AuthLink';
-import { Button, Input, Text } from '@/components/Shared';
+import { Button, Input, Spinner, Text } from '@/components/Shared';
+import { useAuthStrategies } from '@/hooks/authStrategies';
 import { useSession } from '@/hooks/session';
 import { getQueryString, simpleEmailValidation } from '@/utils';
 
@@ -22,6 +23,7 @@ type RegisterStatus = 'idle' | 'pending';
 const Register: React.FC = () => {
   const router = useRouter();
   const search = useSearchParams();
+  const { data: authStrategies, isFetching } = useAuthStrategies();
 
   const { registerMutation } = useSession();
 
@@ -43,6 +45,14 @@ const Register: React.FC = () => {
   const redirect = getQueryString(search.get('redirect_uri'));
 
   const errors: string[] = [];
+
+  if (isFetching) {
+    return <Spinner className="h-10 w-10" />;
+  }
+
+  if (!authStrategies.hasBasicAuth) {
+    router.push('/login');
+  }
 
   return (
     <div className="flex flex-col items-center justify-center">

--- a/src/interfaces/assistants_web/src/components/WelcomePage.tsx
+++ b/src/interfaces/assistants_web/src/components/WelcomePage.tsx
@@ -8,6 +8,7 @@ import { NavigationUserMenu } from '@/components/NavigationUserMenu';
 import { Text } from '@/components/Shared';
 import { CellBackground } from '@/components/Welcome/CellBackground';
 import { Navigation } from '@/components/Welcome/Navigation';
+import { useAuthStrategies } from '@/hooks/authStrategies';
 
 type Props = PropsWithChildren<{
   userEmail?: string;
@@ -21,12 +22,15 @@ export const WelcomePage: React.FC<Props> = ({
   videoStep = 0,
   showEmailInHeader,
 }) => {
+  const { data: authStrategies } = useAuthStrategies();
+
   const pathname = usePathname();
-  const navigationAction = pathname.includes('/login')
-    ? 'register'
-    : pathname.includes('/register')
-    ? 'login'
-    : undefined;
+  const navigationAction =
+    authStrategies.hasBasicAuth && pathname.includes('/login')
+      ? 'register'
+      : pathname.includes('/register')
+      ? 'login'
+      : undefined;
   return (
     <div className="relative flex h-full min-h-screen w-full bg-green-950 dark:bg-volcanic-150">
       <CellBackground step={videoStep} />

--- a/src/interfaces/assistants_web/src/hooks/authStrategies.ts
+++ b/src/interfaces/assistants_web/src/hooks/authStrategies.ts
@@ -1,6 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
 
-import { useCohereClient } from '@/cohere-client';
+import { ListAuthStrategy, useCohereClient } from '@/cohere-client';
+import { NoNullProperties } from '@/types/util';
 
 /**
  * @description Hook to get authentication methods supported by the server.
@@ -13,4 +14,27 @@ export const useServerAuthStrategies = (options?: { enabled?: boolean }) => {
     refetchOnWindowFocus: false,
     ...options,
   });
+};
+
+export const useAuthStrategies = () => {
+  const cohereClient = useCohereClient();
+  const queryInfo = useQuery({
+    queryKey: ['authStrategies'],
+    queryFn: () => cohereClient.getAuthStrategies(),
+    refetchOnWindowFocus: false,
+    refetchInterval: false,
+  });
+
+  return {
+    ...queryInfo,
+    data: {
+      hasBasicAuth: queryInfo.data?.some((strategy) => strategy.strategy.toLowerCase() === 'basic'),
+      ssoStrategies: (queryInfo.data?.filter(
+        (strategy) =>
+          strategy.strategy !== 'Basic' &&
+          strategy.client_id !== null &&
+          strategy.authorization_endpoint !== null
+      ) ?? []) as NoNullProperties<ListAuthStrategy>[],
+    },
+  };
 };


### PR DESCRIPTION
- Hides "Sign Up" button if basic auth is not enabled
- Add spinner for loading auth strategies
- Displays message if there aren't any auth strategies enabled
- Redirect from /register page if no basic auth enabled

TODO: 
- [ ] sign up flashes before redirect
- [ ] handle google signup/in
- [ ] loading state for sign up


Thank you for contributing to the Cohere Toolkit!

- [ ] **PR title**: "area: description"
  - Where "area" is whichever of interface, frontend, model, tools, backend, etc. is being modified. Use "docs: ..." for purely docs changes, "infra: ..." for CI changes.
  - Example: "deployment: add Azure model option"


- [ ] **PR message**: ***Delete this entire checklist*** and replace with
    - **Description:** a description of the change
    - **Issue:** the issue # it fixes, if applicable
    - **Dependencies:** any dependencies required for this change


- [ ] **Add tests and docs**: Please include testing and documentation for your changes
- [ ] **Lint and test**: Run `make lint` and `make run-tests`

**AI Description**

<!-- begin-generated-description -->

This PR updates the authentication flow by introducing a new `useAuthStrategies` hook and removing the `useAuthConfig` hook. 

The `useAuthStrategies` hook fetches the authentication methods supported by the server and provides the following data:
- `hasBasicAuth`: A boolean indicating if basic authentication is enabled.
- `ssoStrategies`: A list of authentication strategies that are not basic and have a valid `client_id` and `authorization_endpoint`.

The Login.tsx and Register.tsx components have been updated to use this new hook to determine the login and registration flows. 

The WelcomePage.tsx component now uses the `useAuthStrategies` hook to determine the navigation action based on the presence of basic authentication and the pathname.

- **Deleted imports**:
  - `useMemo`, `useState` and `useAuthConfig` from 'react' and '@/hooks/authConfig' respectively in `Login.tsx`.
  - `Button`, `Input`, `Text` from `'@/components/Shared'` in `Login.tsx` and `Register.tsx`.
  - `CohereUnauthorizedError`, `ListAuthStrategy` from `'@/cohere-client'` in `Login.tsx`.
  - `NoNullProperties` from `'@/types/util'` in `Login.tsx.

- **Added imports**:
  - `Spinner` from `'@/components/Shared'` in `Login.tsx and `Register.tsx`.
  - `useAuthStrategies` from `'@/hooks/authStrategies'` in `Login.tsx, `Register.tsx` and `WelcomePage.tsx`.
  - `ListAuthStrategy`, `useCohereClient` from `'@/cohere-client'` and `NoNullProperties` from `'@/types/util'` in `authStrategies.ts`.

## Login.tsx
- **Deleted variables**:
  - `loginStrategies` and `hasBasicAuth`.
  - `ssoStrategies` and its associated logic.

- **Added variables**:
  - `authStrategies` and `isFetching` from `useAuthStrategies`.

- **Updated logic**:
  - If `isFetching` is true, a `Spinner` is rendered.
  - If `authStrategies` is not defined, a text message is displayed.
  - If `authStrategies.ssoStrategies` is defined, the `ssoStrategies` are mapped and rendered.
  - If `authStrategies.hasBasicAuth` is true, the login form is rendered.

## Register.tsx
- **Added variables**:
  - `authStrategies` and `isFetching` from `useAuthStrategies`.

- **Updated logic**:
  - If `isFetching` is true, a `Spinner` is rendered.
  - If `authStrategies.hasBasicAuth` is false, the user is redirected to the login page.

## WelcomePage.tsx
- **Added variables**:
  - `authStrategies` from `useAuthStrategies`.

- **Updated logic**:
  - The `navigationAction` is now determined by checking if `authStrategies.hasBasicAuth` is true and the pathname includes '/login'.

## authStrategies.ts
- **Added exports**:
  - `useAuthStrategies` hook.

- **Updated logic**:
  - The `useServerAuthStrategies` hook now uses the `useCohereClient` hook to fetch authentication strategies from the server.
  - The `useAuthStrategies` hook returns the query information, along with the `hasBasicAuth` and `ssoStrategies` data derived from the query data.

<!-- end-generated-description -->
