### PR TITLE
feat(toolkit): fix buttons animations

### DIFF
--- a/src/interfaces/assistants_web/src/components/Conversation/Composer/ComposerError.tsx
+++ b/src/interfaces/assistants_web/src/components/Conversation/Composer/ComposerError.tsx
@@ -39,7 +39,6 @@ export const ComposerError: React.FC<Props> = ({ className = '' }) => {
           className="underline"
           label="here"
           theme="danger"
-          animate={false}
         />
         .
       </Text>

--- a/src/interfaces/assistants_web/src/components/IconButton.tsx
+++ b/src/interfaces/assistants_web/src/components/IconButton.tsx
@@ -22,7 +22,6 @@ type Props = {
   disabled?: boolean;
   className?: string;
   outline?: boolean;
-  animate?: boolean;
   onClick?: (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;
 };
 
@@ -41,14 +40,12 @@ export const IconButton: React.FC<Props> = ({
   href,
   target,
   outline = false,
-  animate = false,
   onClick,
 }) => {
   const iconButton = (
     <Button
       kind={outline ? 'outline' : 'secondary'}
       disabled={disabled}
-      animate={animate}
       href={href}
       onClick={onClick}
       target={target}

--- a/src/interfaces/assistants_web/src/components/MessageRow.tsx
+++ b/src/interfaces/assistants_web/src/components/MessageRow.tsx
@@ -125,7 +125,6 @@ const MessageRow = forwardRef<HTMLDivElement, Props>(function MessageRowInternal
                 iconOptions={{ className: 'dark:fill-marble-800' }}
                 kind="secondary"
                 aria-label={`${isStepsExpanded ? 'Hide' : 'Show'} steps`}
-                animate={false}
                 onClick={() => setIsStepsExpanded((prevIsExpanded) => !prevIsExpanded)}
               />
             )}

--- a/src/interfaces/assistants_web/src/components/ShareModal.tsx
+++ b/src/interfaces/assistants_web/src/components/ShareModal.tsx
@@ -110,7 +110,6 @@ export const ShareModal: React.FC<ShareModalProps> = ({ conversationId }) => {
             target="_blank"
             icon="arrow-up-right"
             disabled={status === 'update-url-loading'}
-            animate={false}
           />
           {snapshotLinksExists && (
             <Button
@@ -121,7 +120,6 @@ export const ShareModal: React.FC<ShareModalProps> = ({ conversationId }) => {
               iconPosition="end"
               isLoading={status === 'update-url-loading'}
               disabled={status === 'update-url-loading'}
-              animate={false}
             />
           )}
         </div>

--- a/src/interfaces/assistants_web/src/components/Shared/Button/Button.stories.tsx
+++ b/src/interfaces/assistants_web/src/components/Shared/Button/Button.stories.tsx
@@ -103,7 +103,6 @@ export const Selection: Story = {
   args: {
     kind: 'primary',
     icon: 'arrow-right',
-    animate: true,
     theme: 'evolved-green',
     label: 'Button',
     stretch: true,

--- a/src/interfaces/assistants_web/src/components/Shared/CodeSnippet/CodeSnippet.tsx
+++ b/src/interfaces/assistants_web/src/components/Shared/CodeSnippet/CodeSnippet.tsx
@@ -72,7 +72,6 @@ export const CodeSnippet: React.FC<Props> = ({
         ref={copyBtnRef}
         value={codeSnippet}
         size="md"
-        animate={false}
         kind="secondary"
         className="absolute right-3 top-3 rounded-lg bg-mushroom-800 px-2 py-1 group-hover:bg-mushroom-800"
       />

--- a/src/interfaces/assistants_web/src/components/Shared/CopyToClipboardButton/CopyToClipboardButton.tsx
+++ b/src/interfaces/assistants_web/src/components/Shared/CopyToClipboardButton/CopyToClipboardButton.tsx
@@ -11,7 +11,6 @@ type CopyToClipboardButtonProps = {
   label?: React.ReactNode;
   size?: 'sm' | 'md' | 'lg';
   kind?: ButtonKind;
-  animate?: boolean;
   disabled?: boolean;
   className?: string;
   iconAtStart?: boolean;
@@ -71,7 +70,6 @@ export const CopyToClipboardButton = forwardRef<
       label={copied ? 'Copied!' : label}
       icon="copy"
       iconPosition={iconAtStart ? 'start' : 'end'}
-      animate={animate}
       className={className}
       disabled={disabled}
       aria-label={copied ? 'copied' : 'copy'}
@@ -133,7 +131,6 @@ export const CopyToClipboardIconButton: React.FC<CopyToClipboardIconButtonProps>
               'fill-volcanic-300 hover:bg-mushroom-900 hover:fill-mushroom-300 dark:fill-mushroom-800 dark:hover:bg-inherit dark:hover:fill-mushroom-800',
               iconClassName
             )}
-            animate={false}
             onClick={handleCopy}
           />
         }


### PR DESCRIPTION


https://github.com/user-attachments/assets/e9157ff3-6792-4725-8df0-9ea9a2182750


**AI Description**

<!-- begin-generated-description -->

This pull request updates several components by removing the `animate` prop and adding a new logic for the `animate` behavior.

- The `animate` prop is removed from the `Props interface in IconButton.tsx, ComposerError.tsx, MessageRow.tsx, ShareModal.tsx, Button.stories.tsx, CodeSnippet.tsx, and CopyToClipboardButton.tsx.
- In Button.tsx, the `animate` prop is replaced with a new logic that sets `animate` to `true` only when there is an icon and a label or children.
- The `animate` variable in the cellInner function in Button.tsx is moved from the third to the fifth position in the function parameters.
- The animateStyles variable in Button.tsx is removed, and the `animate` class is now conditionally added to the `className` prop of the Icon component.
- The `animate` class is now conditionally added to the `className` prop of the `div` element wrapping the `iconElement` and `labelElement` in Button.tsx.

<!-- end-generated-description -->
