### PR TITLE
Restore chat flow

### DIFF
--- a/src/backend/crud/agent.py
+++ b/src/backend/crud/agent.py
@@ -126,7 +126,7 @@ def get_agents(
     Returns:
       list[Agent]: List of agents.
     """
-    query = db.query(Agent).filter(Agent.id != "default")
+    query = db.query(Agent)
 
     if organization_id is not None:
         query = query.filter(Agent.organization_id == organization_id)

--- a/src/backend/crud/agent.py
+++ b/src/backend/crud/agent.py
@@ -126,7 +126,7 @@ def get_agents(
     Returns:
       list[Agent]: List of agents.
     """
-    query = db.query(Agent)
+    query = db.query(Agent).filter(Agent.id != "default")
 
     if organization_id is not None:
         query = query.filter(Agent.organization_id == organization_id)

--- a/src/backend/database_models/seeders/deplyments_models_seed.py
+++ b/src/backend/database_models/seeders/deplyments_models_seed.py
@@ -112,42 +112,12 @@ def deployments_models_seed(op):
     """
     session = Session(op.get_bind())
 
-    default_user = session.query(User).filter_by(id="user-id").first()
     default_organization = Organization(
         name="Default Organization",
         id="default",
     )
     session.add(default_organization)
     session.commit()
-    default_organization.users.append(default_user)
-    session.commit()
-
-    default_agent = Agent(
-        id="default",
-        version=1,
-        name="Command R+",
-        description="Default agent",
-        preamble="",
-        temperature=0.3,
-        tools=[
-            "web_search",
-            "search_file",
-            "read_document",
-            "toolkit_python_interpreter",
-            "toolkit_calculator",
-            "wikipedia",
-            "google_drive",
-            "arxiv",
-            "example_connector",
-            "pub_med",
-            "file_reader_llamaindex",
-            "wolfram_alpha",
-            "clinical_trials",
-        ],
-        user_id=default_user.id,
-        organization_id=default_organization.id,
-    )
-    session.add(default_agent)
     session.commit()
 
     # Seed deployments and models
@@ -174,24 +144,6 @@ def deployments_models_seed(op):
             )
             session.add(new_model)
             session.commit()
-            if model_mapping_name["is_default"]:
-                model_to_agent_id = new_model.id
-                is_default_for_agent = True
-
-        agent_deployment_association = AgentDeploymentModel(
-            deployment_id=new_deployment.id,
-            agent_id=default_agent.id,
-            model_id=model_to_agent_id,
-            deployment_config={
-                env_var: os.environ.get(env_var, "")
-                for env_var in model_deployments[deployment].env_vars
-            },
-            is_default_deployment=new_deployment.name
-            == ModelDeploymentName.CoherePlatform,
-            is_default_model=is_default_for_agent,
-        )
-        session.add(agent_deployment_association)
-        session.commit()
 
 
 def delete_default_models(op):

--- a/src/backend/database_models/seeders/deplyments_models_seed.py
+++ b/src/backend/database_models/seeders/deplyments_models_seed.py
@@ -1,5 +1,5 @@
-import os
 import json
+import os
 from uuid import uuid4
 
 from dotenv import load_dotenv
@@ -7,11 +7,7 @@ from sqlalchemy import text
 from sqlalchemy.orm import Session
 
 from backend.config.deployments import ALL_MODEL_DEPLOYMENTS, ModelDeploymentName
-from backend.database_models import (
-    Deployment,
-    Model,
-    Organization,
-)
+from backend.database_models import Deployment, Model, Organization
 from community.config.deployments import (
     AVAILABLE_MODEL_DEPLOYMENTS as COMMUNITY_DEPLOYMENTS_SETUP,
 )
@@ -133,11 +129,15 @@ def deployments_models_seed(op):
             id=deployment_id,
             name=deployment,
             description="",
-            default_deployment_config=json.dumps({
-                env_var: os.environ.get(env_var, "")
-                for env_var in model_deployments[deployment].env_vars
-            }),
-            deployment_class_name=model_deployments[deployment].deployment_class.__name__,
+            default_deployment_config=json.dumps(
+                {
+                    env_var: os.environ.get(env_var, "")
+                    for env_var in model_deployments[deployment].env_vars
+                }
+            ),
+            deployment_class_name=model_deployments[
+                deployment
+            ].deployment_class.__name__,
             is_community=deployment in COMMUNITY_DEPLOYMENTS_SETUP,
         )
         op.execute(sql_command)

--- a/src/backend/database_models/seeders/deplyments_models_seed.py
+++ b/src/backend/database_models/seeders/deplyments_models_seed.py
@@ -105,12 +105,22 @@ def deployments_models_seed(op):
     """
     session = Session(op.get_bind())
 
-    default_organization = Organization(
-        name="Default Organization",
+    # Seed default organization
+    sql_command = text(
+        """
+        INSERT INTO organizations (
+            id, name, created_at, updated_at
+        )
+        VALUES (
+            :id, :name, now(), now() 
+        )
+        ON CONFLICT (id) DO NOTHING;
+    """
+    ).bindparams(
         id="default",
+        name="Default Organization",
     )
-    session.add(default_organization)
-    session.commit()
+    op.execute(sql_command)
 
     # Seed deployments and models
     for deployment in MODELS_NAME_MAPPING.keys():

--- a/src/backend/services/chat.py
+++ b/src/backend/services/chat.py
@@ -80,19 +80,6 @@ def process_chat(
     user_id = ctx.get_user_id()
     ctx.with_deployment_config()
     agent_id = ctx.get_agent_id()
-    deployment_name = request.headers.get("Deployment-Name", "")
-    deployment_config = {}
-    # Deployment config is the settings for the model deployment per request
-    # It is a string of key value pairs separated by semicolons
-    # For example: "azure_key1=value1;azure_key2=value2"
-    # TODO Eugene: Confirm it with Scott - header deployment config has priority over the deployment config in the DB,
-    # but agent deployment config has priority over both if it is set
-    if request.headers.get("Deployment-Config", "") != "":
-        ctx.with_deployment_config()
-    else:
-        deployment = deployment_crud.get_deployment_by_name(session, deployment_name)
-        if deployment is not None and deployment.is_available:
-            ctx.with_deployment_config(deployment.default_deployment_config)
 
     if agent_id is not None:
         agent = agent_crud.get_agent_by_id(session, agent_id)
@@ -103,24 +90,6 @@ def process_chat(
             raise HTTPException(
                 status_code=404, detail=f"Agent with ID {agent_id} not found."
             )
-        # TODO Eugene: Confirm it with Scott
-        # Check if the agent is associated with the deployment
-        if agent.deployment and agent.deployment != deployment_name:
-            # if agent's default deployment is not the same as the request's deployment
-            # we try to find that deployment in the agent's associated deployments and use it
-            deployment_config = agent_crud.get_association_by_deployment_name(
-                session, agent, deployment_name
-            ).deployment_config
-            if deployment_config is None:
-                raise HTTPException(
-                    status_code=400,
-                    detail=f"Agent {agent_id} has deployment {agent.deployment.name} but request is for deployment {deployment_name}.",
-                )
-        else:
-            deployment_config = agent_crud.get_association_by_deployment_name(
-                session, agent, deployment_name
-            ).deployment_config
-            ctx.with_deployment_config(deployment_config)
 
         if chat_request.tools:
             for tool in chat_request.tools:
@@ -133,14 +102,6 @@ def process_chat(
         # Set the agent settings in the chat request
         chat_request.preamble = agent.preamble
         chat_request.tools = [Tool(name=tool) for tool in agent.tools]
-        # NOTE TEMPORARY: we do not set the model for now and just use the default model
-        # chat_request.model = None
-        model = (
-            agent.default_model_association.model
-            if agent.default_model_association
-            else None
-        )
-        chat_request.model = model.cohere_name if model else None
 
     should_store = chat_request.chat_history is None and not is_custom_tool_call(
         chat_request

--- a/src/backend/tests/routers/test_agent.py
+++ b/src/backend/tests/routers/test_agent.py
@@ -365,7 +365,7 @@ def test_list_agents_with_pagination(
     )
     assert response.status_code == 200
     response_agents = response.json()
-    assert len(response_agents) == 2
+    assert len(response_agents) == 1
 
 
 @pytest.mark.asyncio

--- a/src/backend/tests/routers/test_chat.py
+++ b/src/backend/tests/routers/test_chat.py
@@ -89,8 +89,18 @@ def test_streaming_new_chat(
 # TODO: add test case for when stream raises an error
 @pytest.mark.skipif(not is_cohere_env_set, reason="Cohere API key not set")
 def test_streaming_new_chat_metrics_with_agent(
-    session_client_chat: TestClient, session_chat: Session, default_agent_copy: Agent
+    session_client_chat: TestClient, session_chat: Session, user: User
 ):
+    agent = get_factory("Agent", session_chat).create(user=user)
+    deployment = get_factory("Deployment", session_chat).create()
+    model = get_factory("Model", session_chat).create(deployment=deployment)
+    agent_association = get_factory("AgentDeploymentModel", session_chat).create(
+        agent=agent,
+        deployment=deployment,
+        model=model,
+        is_default_deployment=True,
+        is_default_model=True,
+    )
     with patch(
         "backend.services.metrics.report_metrics",
         return_value=None,
@@ -98,14 +108,14 @@ def test_streaming_new_chat_metrics_with_agent(
         response = session_client_chat.post(
             "/v1/chat-stream",
             headers={
-                "User-Id": default_agent_copy.user.id,
-                "Deployment-Name": default_agent_copy.deployment,
+                "User-Id": agent.user.id,
+                "Deployment-Name": agent.deployment,
             },
-            params={"agent_id": default_agent_copy.id},
+            params={"agent_id": agent.id},
             json={
                 "message": "Hello",
                 "max_tokens": 10,
-                "agent_id": default_agent_copy.id,
+                "agent_id": agent.id,
             },
         )
         # finish all the event stream
@@ -113,10 +123,10 @@ def test_streaming_new_chat_metrics_with_agent(
         for line in response.iter_lines():
             continue
         m_args: MetricsData = mock_metrics.await_args.args[0].signal
-        assert m_args.user_id == default_agent_copy.user.id
+        assert m_args.user_id == agent.user.id
         assert m_args.message_type == MetricsMessageType.CHAT_API_SUCCESS
-        assert m_args.assistant_id == default_agent_copy.id
-        assert m_args.assistant.name == default_agent_copy.name
+        assert m_args.assistant_id == agent.id
+        assert m_args.assistant.name == agent.name
         assert m_args.model is not None
         assert m_args.input_nb_tokens > 0
         assert m_args.output_nb_tokens > 0
@@ -124,37 +134,56 @@ def test_streaming_new_chat_metrics_with_agent(
 
 @pytest.mark.skipif(not is_cohere_env_set, reason="Cohere API key not set")
 def test_streaming_new_chat_with_agent(
-    session_client_chat: TestClient, session_chat: Session, default_agent_copy: Agent
+    session_client_chat: TestClient, session_chat: Session, user: User
 ):
+    agent = get_factory("Agent", session_chat).create(user=user)
+    deployment = get_factory("Deployment", session_chat).create()
+    model = get_factory("Model", session_chat).create(deployment=deployment)
+    agent_association = get_factory("AgentDeploymentModel", session_chat).create(
+        agent=agent,
+        deployment=deployment,
+        model=model,
+        is_default_deployment=True,
+        is_default_model=True,
+    )
     response = session_client_chat.post(
         "/v1/chat-stream",
         headers={
-            "User-Id": default_agent_copy.user.id,
-            "Deployment-Name": default_agent_copy.deployment,
+            "User-Id": agent.user.id,
+            "Deployment-Name": agent.deployment,
         },
-        params={"agent_id": default_agent_copy.id},
+        params={"agent_id": agent.id},
         json={"message": "Hello", "max_tokens": 10},
     )
     assert response.status_code == 200
     validate_chat_streaming_response(
-        response, default_agent_copy.user, session_chat, session_client_chat, 2
+        response, agent.user, session_chat, session_client_chat, 2
     )
 
 
 @pytest.mark.skipif(not is_cohere_env_set, reason="Cohere API key not set")
 def test_streaming_new_chat_with_agent_existing_conversation(
-    session_client_chat: TestClient, session_chat: Session, default_agent_copy: Agent
+    session_client_chat: TestClient, session_chat: Session, user: User
 ):
-
-    default_agent_copy.preamble = "you are a smart assistant"
-    session_chat.refresh(default_agent_copy)
+    agent = get_factory("Agent", session_chat).create(user=user)
+    deployment = get_factory("Deployment", session_chat).create()
+    model = get_factory("Model", session_chat).create(deployment=deployment)
+    agent_association = get_factory("AgentDeploymentModel", session_chat).create(
+        agent=agent,
+        deployment=deployment,
+        model=model,
+        is_default_deployment=True,
+        is_default_model=True,
+    )
+    agent.preamble = "you are a smart assistant"
+    session_chat.refresh(agent)
 
     conversation = get_factory("Conversation", session_chat).create(
-        user_id=default_agent_copy.user.id, agent_id=default_agent_copy.id
+        user_id=agent.user.id, agent_id=agent.id
     )
     _ = get_factory("Message", session_chat).create(
         conversation_id=conversation.id,
-        user_id=default_agent_copy.user.id,
+        user_id=agent.user.id,
         agent="USER",
         text="Hello",
         position=1,
@@ -163,7 +192,7 @@ def test_streaming_new_chat_with_agent_existing_conversation(
 
     _ = get_factory("Message", session_chat).create(
         conversation_id=conversation.id,
-        user_id=default_agent_copy.user.id,
+        user_id=agent.user.id,
         agent="CHATBOT",
         text="Hi",
         position=2,
@@ -175,16 +204,16 @@ def test_streaming_new_chat_with_agent_existing_conversation(
     response = session_client_chat.post(
         "/v1/chat-stream",
         headers={
-            "User-Id": default_agent_copy.user.id,
-            "Deployment-Name": default_agent_copy.deployment,
+            "User-Id": agent.user.id,
+            "Deployment-Name": agent.deployment,
         },
-        params={"agent_id": default_agent_copy.id},
+        params={"agent_id": agent.id},
         json={"message": "Hello", "max_tokens": 10, "conversation_id": conversation.id},
     )
 
     assert response.status_code == 200
     validate_chat_streaming_response(
-        response, default_agent_copy.user, session_chat, session_client_chat, 4
+        response, agent.user, session_chat, session_client_chat, 4
     )
 
 
@@ -235,25 +264,35 @@ def test_streaming_chat_with_existing_conversation_from_other_agent(
 
 @pytest.mark.skipif(not is_cohere_env_set, reason="Cohere API key not set")
 def test_streaming_chat_with_tools_not_in_agent_tools(
-    session_client_chat: TestClient, session_chat: Session, default_agent_copy: Agent
+    session_client_chat: TestClient, session_chat: Session, user: User
 ):
+    agent = get_factory("Agent", session_chat).create(user=user)
+    deployment = get_factory("Deployment", session_chat).create()
+    model = get_factory("Model", session_chat).create(deployment=deployment)
+    agent_association = get_factory("AgentDeploymentModel", session_chat).create(
+        agent=agent,
+        deployment=deployment,
+        model=model,
+        is_default_deployment=True,
+        is_default_model=True,
+    )
     response = session_client_chat.post(
         "/v1/chat-stream",
         headers={
-            "User-Id": default_agent_copy.user.id,
-            "Deployment-Name": default_agent_copy.deployment,
+            "User-Id": agent.user.id,
+            "Deployment-Name": agent.deployment,
         },
         json={
             "message": "Hello",
             "max_tokens": 10,
             "tools": [{"name": "web_search"}],
-            "agent_id": default_agent_copy.id,
+            "agent_id": agent.id,
         },
     )
 
     assert response.status_code == 400
     assert response.json() == {
-        "detail": f"Tool web_search not found in agent {default_agent_copy.id}"
+        "detail": f"Tool web_search not found in agent {agent.id}"
     }
 
 


### PR DESCRIPTION
- Restore chat flow

**AI Description**

<!-- begin-generated-description -->

This PR makes changes to the backend of the application, including database models, chat processing, and testing. 

## Summary
- Updates the `src/backend/database_models/seeders/deplyments_models_seed.py` file to use SQL commands for inserting data into the `deployments` and `models` tables, replacing the previous method of using the `Session` object. 
- Removes some code related to `default_user` and `default_organization` in the `deployments_models_seed` function. 
- Removes the `default_agent` code block and associated code from the same function. 
- Introduces the `uuid4` function from the `uuid` module to generate unique IDs for the `deployment_id` and `model_id`. 
- Updates the `src/backend/services/chat.py` file by removing some code related to deployment configuration and agent association. 
- Removes a block of code that sets a temporary note about not setting the model and instead uses the default model. 
- Updates the `src/backend/tests/routers/test_agent.py` file by changing the expected number of response agents from 2 to 1 in the `test_list_agents_with_pagination` test. 
- Updates the `src/backend/tests/routers/test_chat.py` file by adding new test cases and modifying existing ones to include the creation of `User`, `Agent`, `Deployment`, `Model`, and `AgentDeploymentModel` objects. 

## Details:
- **src/backend/database_models/seeders/deplyments_models_seed.py**:
  - The `uuid` module is imported to generate unique IDs.
  - The `sqlalchemy.text` module is imported for executing SQL commands.
  - The `Deployment`, `Model`, and `Organization` classes are imported from `backend.database_models`.
  - The `Agent`, `AgentDeploymentModel`, `User`, and `ModelDeploymentName` classes are no longer imported.
  - The `deployments_models_seed` function now uses SQL commands to insert data into the `deployments` and `models` tables, with unique IDs generated using `uuid4`.
  - The code related to `default_user` and `default_organization` has been removed, along with the associated `default_organization.users.append(default_user)` line.
  - The code block for `default_agent` and associated code have been removed.

- **src/backend/services/chat.py**:
  - Removes code related to checking and setting deployment configuration and agent association.
  - Deletes a block of code that sets a temporary note about not setting the model and instead uses the default model.

- **src/backend/tests/routers/test_agent.py**:
  - Updates the expected number of response agents from 2 to 1 in the `test_list_agents_with_pagination` test.

- **src/backend/tests/routers/test_chat.py**:
  - Adds or modifies test cases to include the creation of `User`, `Agent`, `Deployment`, `Model`, and `AgentDeploymentModel` objects.
  - Updates the `test_streaming_new_chat_metrics_with_agent` test case to use the `get_factory` function to create the necessary objects.
  - Similar updates are made to the `test_streaming_new_chat_with_agent` and `test_streaming_new_chat_with_agent_existing_conversation` test cases.
  - The `test_streaming_chat_with_tools_not_in_agent_tools` test case is modified to use the `get_factory` function to create the required objects.

<!-- end-generated-description -->
