### PR TITLE
refactor: rename files and bug fixes

### DIFF
--- a/src/interfaces/assistants_web/src/app/(main)/layout.tsx
+++ b/src/interfaces/assistants_web/src/app/(main)/layout.tsx
@@ -3,8 +3,7 @@ import { NextPage } from 'next';
 import { cookies } from 'next/headers';
 import { redirect } from 'next/navigation';
 
-import { AgentLeftPanel } from '@/components/Agents/AgentLeftPanel';
-import { AgentsList } from '@/components/Agents/AgentsList';
+import { LeftPanel } from '@/components/Agents/LeftPanel';
 import { HotKeys } from '@/components/Shared/HotKeys';
 import { COOKIE_KEYS, DEFAULT_AGENT_TOOLS } from '@/constants';
 import { getCohereServerClient } from '@/server/cohereServerClient';
@@ -44,18 +43,14 @@ const MainLayout: NextPage<React.PropsWithChildren> = async ({ children }) => {
     <HydrationBoundary state={dehydrate(queryClient)}>
       <div className="flex h-screen w-full flex-1 flex-col gap-3 bg-mushroom-900 p-3 dark:bg-volcanic-60">
         <div className="relative flex h-full flex-grow flex-col flex-nowrap gap-3 overflow-hidden lg:flex-row">
-          <AgentLeftPanel className="hidden md:flex">
-            <AgentsList />
-          </AgentLeftPanel>
+          <LeftPanel className="hidden md:flex" />
           <section className="relative flex h-full min-w-0 flex-grow flex-col overflow-hidden">
             <HotKeys />
             {children}
           </section>
         </div>
       </div>
-      <AgentLeftPanel className="rounded-bl-none rounded-tl-none md:hidden">
-        <AgentsList />
-      </AgentLeftPanel>
+      <LeftPanel className="rounded-bl-none rounded-tl-none md:hidden" />
     </HydrationBoundary>
   );
 };

--- a/src/interfaces/assistants_web/src/components/Agents/DiscoverAgentCard.tsx
+++ b/src/interfaces/assistants_web/src/components/Agents/DiscoverAgentCard.tsx
@@ -18,7 +18,7 @@ export const DiscoverAgentCard: React.FC<Props> = ({ id, name, description, isBa
   const { bg, contrastText } = useBrandedColors(id);
 
   return (
-    <article className="flex overflow-x-hidden rounded-lg border border-volcanic-800 bg-volcanic-950 p-4 dark:border-volcanic-300 dark:bg-volcanic-150">
+    <article className="flex overflow-x-hidden rounded-lg border border-volcanic-800 bg-volcanic-950 p-4 transition-colors dark:border-volcanic-300 dark:bg-volcanic-150 dark:hover:bg-volcanic-200">
       <div className="flex h-full flex-grow flex-col items-start gap-y-2 overflow-x-hidden">
         <div className="flex w-full items-center gap-x-2">
           <div

--- a/src/interfaces/assistants_web/src/components/Agents/DiscoverAgents.tsx
+++ b/src/interfaces/assistants_web/src/components/Agents/DiscoverAgents.tsx
@@ -2,7 +2,7 @@
 
 import { PropsWithChildren, useDeferredValue, useState } from 'react';
 
-import { Agent, Conversation, ConversationWithoutMessages } from '@/cohere-client';
+import { Agent, ConversationWithoutMessages } from '@/cohere-client';
 import { DiscoverAgentCard } from '@/components/Agents/DiscoverAgentCard';
 import { Button, Icon, Input, Tabs, Text, Tooltip } from '@/components/Shared';
 import { useListAgents } from '@/hooks/agents';
@@ -18,6 +18,24 @@ const tabs = [
     <Icon name="profile" kind="outline" />
     <Text>Private</Text>
   </div>,
+];
+
+const BASE_AGENTS: Array<Agent & { isBaseAgent: boolean }> = [
+  {
+    id: '',
+    name: 'Command R+',
+    description: 'Review, understand and ask questions about internal financial documents.',
+    user_id: 'xxxx',
+    created_at: '2021-09-01T00:00:00Z',
+    updated_at: '2021-09-01T00:00:00Z',
+    preamble: '',
+    version: 1,
+    temperature: 0.3,
+    tools: [],
+    model: '',
+    deployment: '',
+    isBaseAgent: true,
+  },
 ];
 
 export const DiscoverAgents = () => {
@@ -90,7 +108,7 @@ const GroupAgents: React.FC<{ agents: Agent[]; title: string; subTitle: string }
       </header>
       <div className="grid grid-cols-1 gap-x-4 gap-y-5 md:grid-cols-3 xl:grid-cols-4">
         {visibleAgents.map((agent) => (
-          <DiscoverAgentCard key={agent.id} {...agent} isBaseAgent={agent.id === 'default'} />
+          <DiscoverAgentCard key={agent.id} {...agent} />
         ))}
       </div>
       {hasShowMore && (
@@ -120,6 +138,11 @@ const CompanyAgents: React.FC<{
   const handleOnChange = (e: React.ChangeEvent<HTMLInputElement>) => setQuery(e.target.value);
   const deferredQuery = useDeferredValue(query);
 
+  // TODO(tomeu): verify with design
+  if (!agents.length) {
+    return null;
+  }
+
   const filteredAgents = agents
     .filter((agent) => agent.name.toLowerCase().includes(deferredQuery.toLowerCase()))
     .sort((a, b) => b.name.toLowerCase().localeCompare(a.name.toLowerCase()));
@@ -146,7 +169,9 @@ const CompanyAgents: React.FC<{
     .map((id) => filteredAgents.find((a) => a.id === id))
     .filter((agent) => !!agent);
 
-  const featuredAgents = filteredAgents.filter((agent) => agent.id === 'default');
+  const featuredAgents = BASE_AGENTS.filter((agent) =>
+    agent.name.toLowerCase().includes(deferredQuery.toLowerCase())
+  );
 
   return (
     <Wrapper>

--- a/src/interfaces/assistants_web/src/components/Agents/LeftPanel.tsx
+++ b/src/interfaces/assistants_web/src/components/Agents/LeftPanel.tsx
@@ -4,6 +4,7 @@ import { Transition } from '@headlessui/react';
 import Link from 'next/link';
 import React from 'react';
 
+import { ConversationList } from '@/components/ConversationList/ConversationList';
 import { Button, ButtonTheme, Icon, IconName, Logo, Text, Tooltip } from '@/components/Shared';
 import { Shortcut } from '@/components/Shortcut';
 import { env } from '@/env.mjs';
@@ -17,10 +18,7 @@ import { cn } from '@/utils';
  * It contains the logo and a button to expand or collapse the panel.
  * It also renders the children components that are passed to it.
  */
-export const AgentLeftPanel: React.FC<React.PropsWithChildren<{ className?: string }>> = ({
-  className = '',
-  children,
-}) => {
+export const LeftPanel: React.FC<{ className?: string }> = ({ className = '' }) => {
   const { isAgentsLeftPanelOpen } = useSettingsStore();
   const isDesktop = useIsDesktop();
   const isMobile = !isDesktop;
@@ -29,7 +27,7 @@ export const AgentLeftPanel: React.FC<React.PropsWithChildren<{ className?: stri
   return (
     <Transition
       show={isAgentsLeftPanelOpen || isDesktop}
-      as="div"
+      as="aside"
       className={cn(
         'absolute bottom-0 left-0 top-0 z-30 lg:static',
         'h-full bg-marble-980 md:bg-transparent dark:bg-volcanic-60',
@@ -105,7 +103,7 @@ export const AgentLeftPanel: React.FC<React.PropsWithChildren<{ className?: stri
           />
         </div>
 
-        {children}
+        <ConversationList />
 
         <footer className={cn('flex flex-col gap-4', { 'items-center': !isAgentsLeftPanelOpen })}>
           <AgentsSidePanelButton

--- a/src/interfaces/assistants_web/src/components/ConversationList/ConversationList.tsx
+++ b/src/interfaces/assistants_web/src/components/ConversationList/ConversationList.tsx
@@ -22,7 +22,7 @@ const sortByDate = (a: Conversation, b: Conversation) => {
  * @description This component renders a list of agents.
  * It shows the most recent agents and the base agents.
  */
-export const AgentsList: React.FC = () => {
+export const ConversationList: React.FC = () => {
   const { data: conversations } = useConversations({});
   const { search, setSearch, searchResults } = useSearchConversations(conversations);
   const { data: agents = [] } = useListAgents();
@@ -72,7 +72,11 @@ export const AgentsList: React.FC = () => {
           )}
         </section>
       </div>
-      <div className="flex-grow space-y-4 overflow-y-auto">
+      <div
+        className={cn('flex-grow', {
+          'space-y-4 overflow-y-auto': conversations.length > 0,
+        })}
+      >
         <Text
           styleAs="label"
           className={cn('truncate dark:text-mushroom-800', {

--- a/src/interfaces/assistants_web/src/components/Shared/Button/Button.tsx
+++ b/src/interfaces/assistants_web/src/components/Shared/Button/Button.tsx
@@ -89,7 +89,7 @@ const getButtonStyles = (kind: ButtonKind, theme: ButtonTheme, disabled: boolean
   }
 
   return cn({
-    'fill-coral-700 bg-coral-700 group-hover:bg-coral-600 dark:bg-evolved-green-700 dark:group-hover:bg-evolved-green-500':
+    'fill-coral-700 bg-coral-700 dark:text-volcanic-150 group-hover:bg-coral-600 dark:bg-evolved-green-700 dark:group-hover:bg-evolved-green-500':
       theme === 'default',
     'bg-evolved-green-700 group-hover:bg-evolved-green-500': theme === 'evolved-green',
     'bg-blue-500 group-hover:bg-blue-400': theme === 'blue',
@@ -169,7 +169,7 @@ export const Button: React.FC<ButtonProps> = ({
 }) => {
   const labelStyles = getLabelStyles(kind, theme, disabled);
   const buttonStyles = getButtonStyles(kind, theme, disabled);
-  const animate = !!icon && (!!label || !!children); // we only want to animate if there is an icon and a label
+  const animate = (!!icon || !!iconOptions?.customIcon) && (!!label || !!children); // we only want to animate if there is an icon and a label
 
   const animateClasses = cn({
     'duration-400 transform transition-transform ease-in-out group-hover:-translate-x-1.5': animate,
@@ -216,6 +216,7 @@ export const Button: React.FC<ButtonProps> = ({
             className={cn({
               [animateClasses]: iconPosition === 'start',
               'px-2': kind === 'outline',
+              'w-full': stretch && kind === 'secondary',
             })}
           >
             {labelElement}

--- a/src/interfaces/assistants_web/src/components/Shared/CopyToClipboardButton/CopyToClipboardButton.tsx
+++ b/src/interfaces/assistants_web/src/components/Shared/CopyToClipboardButton/CopyToClipboardButton.tsx
@@ -126,7 +126,7 @@ export const CopyToClipboardIconButton: React.FC<CopyToClipboardIconButtonProps>
           iconKind={isCopied ? 'default' : 'outline'}
           className="grid place-items-center rounded hover:bg-mushroom-900 dark:hover:bg-volcanic-200"
           iconClassName={cn(
-            'text-volcanic-300 group-hover/icon-button:fill-mushroom-300',
+            'text-volcanic-300 fill-volcanic-300 group-hover/icon-button:fill-mushroom-300',
             'dark:fill-marble-800 dark:group-hover/icon-button:fill-marble-800',
             iconClassName
           )}


### PR DESCRIPTION
## Description

- fix: button `stretch` prop when is used as `secondary` vs `primary` kind
- fix: fill color Copy to clipboard button
- fix: button animation with a custom icon
- fix: default text color for the default theme
- fix: add default agent to /discover page
- style: not show any agent group when there is no agents
- refactor: rename `AgentSidePanel` to `LeftPanel`
- refactor: rename `AgentList` to `ListConversation`
- style: hide scrollbar when there is no conversations
- style: animate on hover `DiscoverAgentCard`