### PR TITLE
infra: Added Redis

### DIFF
--- a/charts/cohere-toolkit/Chart.lock
+++ b/charts/cohere-toolkit/Chart.lock
@@ -2,5 +2,8 @@ dependencies:
 - name: postgresql
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 15.5.4
-digest: sha256:141aac773e977b07030baafa6e55e7c677e23fc913a63b16144d513b23ed67b5
-generated: "2024-06-07T12:06:57.91646+01:00"
+- name: redis
+  repository: oci://registry-1.docker.io/bitnamicharts
+  version: 19.6.4
+digest: sha256:8044d54c7a2e3f2818aa367a8d8216cc131f216256a94375c640c9600c7297f3
+generated: "2024-08-07T12:05:43.181805-04:00"

--- a/charts/cohere-toolkit/Chart.yaml
+++ b/charts/cohere-toolkit/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/cohere-toolkit/Chart.yaml
+++ b/charts/cohere-toolkit/Chart.yaml
@@ -28,3 +28,8 @@ dependencies:
     repository: oci://registry-1.docker.io/bitnamicharts
     version: 15.5.4
     condition: postgresql.enabled
+  - name: redis
+    repository: oci://registry-1.docker.io/bitnamicharts
+    version: 19.6.4
+    condition: redis.enabled
+    

--- a/charts/cohere-toolkit/templates/_helpers.tpl
+++ b/charts/cohere-toolkit/templates/_helpers.tpl
@@ -28,3 +28,8 @@ Database connection string
 {{- printf "postgresql+psycopg2://%s:%s@%s:%.0f/%s" $db.username $db.password $db.host $db.port $db.name }}
 {{- end}}
 {{- end}}
+
+{{- define "cohere-toolkit.redis-url" -}}
+{{- $redis := .Values.global.redis }}
+{{- printf "redis://:%s@%s:%.0f" $redis.password $redis.host $redis.port -}}
+{{- end -}}

--- a/charts/cohere-toolkit/templates/backend.yaml
+++ b/charts/cohere-toolkit/templates/backend.yaml
@@ -36,6 +36,7 @@ spec:
       name: toolkit-backend
       labels:
         app.kubernetes.io/name: toolkit-backend
+        {{ printf "%s-client" .Values.global.redis.host }}: "true"
         {{- include "cohere-toolkit.labels" . | nindent 8 }}
       {{- with $values.podAnnotations }}
       annotations:
@@ -161,6 +162,7 @@ metadata:
     {{- include "cohere-toolkit.labels" . | nindent 4 }}
 stringData:
   DATABASE_URL: "{{ template "cohere-toolkit.database-url" $ }}"
+  REDIS_URL: "{{ template "cohere-toolkit.redis-url" $ }}"
   {{- if .Values.global.cohere.api_key }}
   COHERE_API_KEY: "{{ .Values.global.cohere.api_key }}"
   {{- end }}

--- a/charts/cohere-toolkit/values.yaml
+++ b/charts/cohere-toolkit/values.yaml
@@ -7,6 +7,11 @@ redis:
   auth:
     enabled: true
     password: &redis_password "redis"
+  commonConfiguration: |
+    save 60 1
+    loglevel warning
+  networkPolicy:
+    allowExternal: false
 
 postgresql:
   enabled: true
@@ -28,6 +33,10 @@ global:
     username: "postgres"
     password: *database_password
     connection_string: "" # overrides host, port, username, and password
+  redis:
+    host: *redis_name
+    port: 6379
+    password: *redis_password
 
 backend:
   replicaCounts: 1

--- a/charts/cohere-toolkit/values.yaml
+++ b/charts/cohere-toolkit/values.yaml
@@ -1,6 +1,13 @@
 # Default values for cohere-toolkit.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
+redis:
+  enabled: true
+  fullnameOverride: &redis_name "toolkit-redis"
+  auth:
+    enabled: true
+    password: &redis_password "redis"
+
 postgresql:
   enabled: true
   fullnameOverride: &database_name "toolkit-db"


### PR DESCRIPTION
This PR adds a Redis helm chart dependency and sets the `REDIS_URL` and network access for `toolkit-backend`.

**AI Description**

<!-- begin-generated-description -->

This pull request adds a Redis dependency to the Cohere Toolkit. 

- The `dependencies` section in `Chart.lock` and `Chart.yaml` now includes a Redis entry with the repository, version, digest, and generation time.
- The `cohere-toolkit.redis-url` template in `_helpers.tpl` is defined to format the Redis connection string.
- The `backend.yaml` now includes a reference to the Redis host in the `spec` section and adds the `REDIS_URL` to the `stringData` section, using the `cohere-toolkit.redis-url` template.
- The `values.yaml` file has been updated to include Redis-related configurations, such as enabling Redis, setting a full name override, enabling authentication, and specifying a password. It also includes common configurations, network policies, and Redis-specific details like host, port, and password.

<!-- end-generated-description -->
