### PR TITLE
File Service: fix empty generator

### DIFF
--- a/src/backend/services/file.py
+++ b/src/backend/services/file.py
@@ -131,10 +131,13 @@ class FileService:
         agent_tool_metadata = agent.tools_metadata
         if agent_tool_metadata is not None and len(agent_tool_metadata) > 0:
             artifacts = next(
-                tool_metadata.artifacts
-                for tool_metadata in agent_tool_metadata
-                if tool_metadata.tool_name == ToolName.Read_File
-                or tool_metadata.tool_name == ToolName.Search_File
+                (
+                    tool_metadata.artifacts
+                    for tool_metadata in agent_tool_metadata
+                    if tool_metadata.tool_name == ToolName.Read_File
+                    or tool_metadata.tool_name == ToolName.Search_File
+                ),
+                [],  # Default value if the generator is empty
             )
 
             # TODO scott: enumerate type names (?), different types for local vs. compass?


### PR DESCRIPTION
Thank you for contributing to the Cohere Toolkit!

- [ ] **PR title**: "area: description"
  - Where "area" is whichever of interface, frontend, model, tools, backend, etc. is being modified. Use "docs: ..." for purely docs changes, "infra: ..." for CI changes.
  - Example: "deployment: add Azure model option"


- [ ] **PR message**: ***Delete this entire checklist*** and replace with
    - **Description:** a description of the change
    - **Issue:** the issue # it fixes, if applicable
    - **Dependencies:** any dependencies required for this change


- [ ] **Add tests and docs**: Please include testing and documentation for your changes
- [ ] **Lint and test**: Run `make lint` and `make run-tests`

**AI Description**

<!-- begin-generated-description -->

The `get_files_by_agent_id` function in `src/backend/services/file.py` has been updated to include a default value for the generator being empty. This is achieved by adding an empty list `[]`.

---

- The function `get_files_by_agent_id` has been modified:
  - An empty tuple `(`, `),` is added to the line containing `tool_metadata.artifacts`.
  - An empty list ` [],` is added as the default value if the generator is empty.

<!-- end-generated-description -->
