### PR TITLE
fix(toolkit): update OpenAPI schema

### DIFF
--- a/src/interfaces/assistants_web/src/app/(main)/(chat)/Chat.tsx
+++ b/src/interfaces/assistants_web/src/app/(main)/(chat)/Chat.tsx
@@ -36,9 +36,11 @@ const Chat: React.FC<{ agentId?: string; conversationId?: string }> = ({
   useEffect(() => {
     resetFileParams();
 
-    const agentTools = (agent?.tools
-      .map((name) => (tools ?? [])?.find((t) => t.name === name))
-      .filter((t) => t !== undefined) ?? []) as ManagedTool[];
+    const agentTools =
+      agent?.tools &&
+      ((agent.tools
+        .map((name) => (tools ?? [])?.find((t) => t.name === name))
+        .filter((t) => t !== undefined) ?? []) as ManagedTool[]);
 
     const fileIds = conversation?.files.map((file) => file.id);
 

--- a/src/interfaces/assistants_web/src/cohere-client/client.ts
+++ b/src/interfaces/assistants_web/src/cohere-client/client.ts
@@ -8,13 +8,13 @@ import {
   CohereClientGenerated,
   CohereNetworkError,
   CohereUnauthorizedError,
-  CreateAgent,
-  CreateSnapshot,
+  CreateAgentRequest,
+  CreateSnapshotRequest,
   CreateUser,
   ExperimentalFeatures,
   Fetch,
-  UpdateAgent,
-  UpdateConversation,
+  UpdateAgentRequest,
+  UpdateConversationRequest,
   UpdateDeploymentEnv,
 } from '@/cohere-client';
 
@@ -165,7 +165,7 @@ export class CohereClient {
     });
   }
 
-  public editConversation(requestBody: UpdateConversation, conversationId: string) {
+  public editConversation(requestBody: UpdateConversationRequest, conversationId: string) {
     return this.cohereService.default.updateConversationV1ConversationsConversationIdPut({
       conversationId: conversationId,
       requestBody,
@@ -277,7 +277,7 @@ export class CohereClient {
     return this.cohereService.default.getDefaultAgentV1DefaultAgentGet();
   }
 
-  public createAgent(requestBody: CreateAgent) {
+  public createAgent(requestBody: CreateAgentRequest) {
     return this.cohereService.default.createAgentV1AgentsPost({ requestBody });
   }
 
@@ -285,7 +285,7 @@ export class CohereClient {
     return this.cohereService.default.listAgentsV1AgentsGet({ offset, limit });
   }
 
-  public updateAgent(requestBody: UpdateAgent, agentId: string) {
+  public updateAgent(requestBody: UpdateAgentRequest, agentId: string) {
     return this.cohereService.default.updateAgentV1AgentsAgentIdPut({
       agentId: agentId,
       requestBody,
@@ -306,7 +306,7 @@ export class CohereClient {
     return this.cohereService.default.listSnapshotsV1SnapshotsGet();
   }
 
-  public createSnapshot(requestBody: CreateSnapshot) {
+  public createSnapshot(requestBody: CreateSnapshotRequest) {
     return this.cohereService.default.createSnapshotV1SnapshotsPost({ requestBody });
   }
 

--- a/src/interfaces/assistants_web/src/cohere-client/generated/schemas.gen.ts
+++ b/src/interfaces/assistants_web/src/cohere-client/generated/schemas.gen.ts
@@ -66,17 +66,10 @@ export const $Agent = {
       title: 'Temperature',
     },
     tools: {
-      items: {
-        type: 'string',
-      },
-      type: 'array',
-      title: 'Tools',
-    },
-    tools_metadata: {
       anyOf: [
         {
           items: {
-            $ref: '#/components/schemas/AgentToolMetadataPublic',
+            type: 'string',
           },
           type: 'array',
         },
@@ -84,15 +77,43 @@ export const $Agent = {
           type: 'null',
         },
       ],
+      title: 'Tools',
+    },
+    tools_metadata: {
+      items: {
+        $ref: '#/components/schemas/AgentToolMetadataPublic',
+      },
+      type: 'array',
       title: 'Tools Metadata',
     },
-    model: {
-      type: 'string',
-      title: 'Model',
+    deployments: {
+      items: {
+        $ref: '#/components/schemas/DeploymentWithModels',
+      },
+      type: 'array',
+      title: 'Deployments',
     },
     deployment: {
-      type: 'string',
+      anyOf: [
+        {
+          type: 'string',
+        },
+        {
+          type: 'null',
+        },
+      ],
       title: 'Deployment',
+    },
+    model: {
+      anyOf: [
+        {
+          type: 'string',
+        },
+        {
+          type: 'null',
+        },
+      ],
+      title: 'Model',
     },
   },
   type: 'object',
@@ -107,18 +128,16 @@ export const $Agent = {
     'preamble',
     'temperature',
     'tools',
-    'model',
+    'tools_metadata',
+    'deployments',
     'deployment',
+    'model',
   ],
   title: 'Agent',
 } as const;
 
 export const $AgentPublic = {
   properties: {
-    user_id: {
-      type: 'string',
-      title: 'User Id',
-    },
     id: {
       type: 'string',
       title: 'Id',
@@ -168,10 +187,17 @@ export const $AgentPublic = {
       title: 'Temperature',
     },
     tools: {
-      items: {
-        type: 'string',
-      },
-      type: 'array',
+      anyOf: [
+        {
+          items: {
+            type: 'string',
+          },
+          type: 'array',
+        },
+        {
+          type: 'null',
+        },
+      ],
       title: 'Tools',
     },
     tools_metadata: {
@@ -188,18 +214,38 @@ export const $AgentPublic = {
       ],
       title: 'Tools Metadata',
     },
-    model: {
-      type: 'string',
-      title: 'Model',
+    deployments: {
+      items: {
+        $ref: '#/components/schemas/DeploymentWithModels',
+      },
+      type: 'array',
+      title: 'Deployments',
     },
     deployment: {
-      type: 'string',
+      anyOf: [
+        {
+          type: 'string',
+        },
+        {
+          type: 'null',
+        },
+      ],
       title: 'Deployment',
+    },
+    model: {
+      anyOf: [
+        {
+          type: 'string',
+        },
+        {
+          type: 'null',
+        },
+      ],
+      title: 'Model',
     },
   },
   type: 'object',
   required: [
-    'user_id',
     'id',
     'created_at',
     'updated_at',
@@ -209,19 +255,30 @@ export const $AgentPublic = {
     'preamble',
     'temperature',
     'tools',
-    'model',
+    'deployments',
     'deployment',
+    'model',
   ],
   title: 'AgentPublic',
 } as const;
 
 export const $AgentToolMetadata = {
   properties: {
-    user_id: {
+    id: {
       type: 'string',
-      title: 'User Id',
+      title: 'Id',
     },
-    organization_id: {
+    created_at: {
+      type: 'string',
+      format: 'date-time',
+      title: 'Created At',
+    },
+    updated_at: {
+      type: 'string',
+      format: 'date-time',
+      title: 'Updated At',
+    },
+    user_id: {
       anyOf: [
         {
           type: 'string',
@@ -230,11 +287,11 @@ export const $AgentToolMetadata = {
           type: 'null',
         },
       ],
-      title: 'Organization Id',
+      title: 'User Id',
     },
-    id: {
+    agent_id: {
       type: 'string',
-      title: 'Id',
+      title: 'Agent Id',
     },
     tool_name: {
       type: 'string',
@@ -249,26 +306,29 @@ export const $AgentToolMetadata = {
     },
   },
   type: 'object',
-  required: ['user_id', 'id', 'tool_name', 'artifacts'],
+  required: ['id', 'created_at', 'updated_at', 'user_id', 'agent_id', 'tool_name', 'artifacts'],
   title: 'AgentToolMetadata',
 } as const;
 
 export const $AgentToolMetadataPublic = {
   properties: {
-    organization_id: {
-      anyOf: [
-        {
-          type: 'string',
-        },
-        {
-          type: 'null',
-        },
-      ],
-      title: 'Organization Id',
-    },
     id: {
       type: 'string',
       title: 'Id',
+    },
+    created_at: {
+      type: 'string',
+      format: 'date-time',
+      title: 'Created At',
+    },
+    updated_at: {
+      type: 'string',
+      format: 'date-time',
+      title: 'Updated At',
+    },
+    agent_id: {
+      type: 'string',
+      title: 'Agent Id',
     },
     tool_name: {
       type: 'string',
@@ -283,7 +343,7 @@ export const $AgentToolMetadataPublic = {
     },
   },
   type: 'object',
-  required: ['id', 'tool_name', 'artifacts'],
+  required: ['id', 'created_at', 'updated_at', 'agent_id', 'tool_name', 'artifacts'],
   title: 'AgentToolMetadataPublic',
 } as const;
 
@@ -822,23 +882,8 @@ export const $CohereChatRequest = {
 See: https://github.com/cohere-ai/cohere-python/blob/main/src/cohere/base_client.py#L1629`,
 } as const;
 
-export const $Conversation = {
+export const $ConversationPublic = {
   properties: {
-    user_id: {
-      type: 'string',
-      title: 'User Id',
-    },
-    organization_id: {
-      anyOf: [
-        {
-          type: 'string',
-        },
-        {
-          type: 'null',
-        },
-      ],
-      title: 'Organization Id',
-    },
     id: {
       type: 'string',
       title: 'Id',
@@ -901,7 +946,6 @@ export const $Conversation = {
   },
   type: 'object',
   required: [
-    'user_id',
     'id',
     'created_at',
     'updated_at',
@@ -912,26 +956,11 @@ export const $Conversation = {
     'agent_id',
     'total_file_size',
   ],
-  title: 'Conversation',
+  title: 'ConversationPublic',
 } as const;
 
 export const $ConversationWithoutMessages = {
   properties: {
-    user_id: {
-      type: 'string',
-      title: 'User Id',
-    },
-    organization_id: {
-      anyOf: [
-        {
-          type: 'string',
-        },
-        {
-          type: 'null',
-        },
-      ],
-      title: 'Organization Id',
-    },
     id: {
       type: 'string',
       title: 'Id',
@@ -987,7 +1016,6 @@ export const $ConversationWithoutMessages = {
   },
   type: 'object',
   required: [
-    'user_id',
     'id',
     'created_at',
     'updated_at',
@@ -1000,7 +1028,7 @@ export const $ConversationWithoutMessages = {
   title: 'ConversationWithoutMessages',
 } as const;
 
-export const $CreateAgent = {
+export const $CreateAgentRequest = {
   properties: {
     name: {
       type: 'string',
@@ -1050,14 +1078,6 @@ export const $CreateAgent = {
       ],
       title: 'Temperature',
     },
-    model: {
-      type: 'string',
-      title: 'Model',
-    },
-    deployment: {
-      type: 'string',
-      title: 'Deployment',
-    },
     tools: {
       anyOf: [
         {
@@ -1076,7 +1096,7 @@ export const $CreateAgent = {
       anyOf: [
         {
           items: {
-            $ref: '#/components/schemas/CreateAgentToolMetadata',
+            $ref: '#/components/schemas/CreateAgentToolMetadataRequest',
           },
           type: 'array',
         },
@@ -1086,13 +1106,58 @@ export const $CreateAgent = {
       ],
       title: 'Tools Metadata',
     },
+    deployment_config: {
+      anyOf: [
+        {
+          additionalProperties: {
+            type: 'string',
+          },
+          type: 'object',
+        },
+        {
+          type: 'null',
+        },
+      ],
+      title: 'Deployment Config',
+    },
+    is_default_deployment: {
+      anyOf: [
+        {
+          type: 'boolean',
+        },
+        {
+          type: 'null',
+        },
+      ],
+      title: 'Is Default Deployment',
+      default: false,
+    },
+    model: {
+      type: 'string',
+      title: 'Model',
+    },
+    deployment: {
+      type: 'string',
+      title: 'Deployment',
+    },
+    organization_id: {
+      anyOf: [
+        {
+          type: 'string',
+        },
+        {
+          type: 'null',
+        },
+      ],
+      title: 'Organization Id',
+    },
   },
   type: 'object',
   required: ['name', 'model', 'deployment'],
-  title: 'CreateAgent',
+  title: 'CreateAgentRequest',
 } as const;
 
-export const $CreateAgentToolMetadata = {
+export const $CreateAgentToolMetadataRequest = {
   properties: {
     id: {
       anyOf: [
@@ -1119,10 +1184,22 @@ export const $CreateAgentToolMetadata = {
   },
   type: 'object',
   required: ['tool_name', 'artifacts'],
-  title: 'CreateAgentToolMetadata',
+  title: 'CreateAgentToolMetadataRequest',
 } as const;
 
-export const $CreateSnapshot = {
+export const $CreateOrganization = {
+  properties: {
+    name: {
+      type: 'string',
+      title: 'Name',
+    },
+  },
+  type: 'object',
+  required: ['name'],
+  title: 'CreateOrganization',
+} as const;
+
+export const $CreateSnapshotRequest = {
   properties: {
     conversation_id: {
       type: 'string',
@@ -1131,7 +1208,7 @@ export const $CreateSnapshot = {
   },
   type: 'object',
   required: ['conversation_id'],
-  title: 'CreateSnapshot',
+  title: 'CreateSnapshotRequest',
 } as const;
 
 export const $CreateSnapshotResponse = {
@@ -1139,10 +1216,6 @@ export const $CreateSnapshotResponse = {
     snapshot_id: {
       type: 'string',
       title: 'Snapshot Id',
-    },
-    user_id: {
-      type: 'string',
-      title: 'User Id',
     },
     link_id: {
       type: 'string',
@@ -1157,7 +1230,7 @@ export const $CreateSnapshotResponse = {
     },
   },
   type: 'object',
-  required: ['snapshot_id', 'user_id', 'link_id', 'messages'],
+  required: ['snapshot_id', 'link_id', 'messages'],
   title: 'CreateSnapshotResponse',
 } as const;
 
@@ -1219,16 +1292,46 @@ export const $DeleteAgentToolMetadata = {
   title: 'DeleteAgentToolMetadata',
 } as const;
 
-export const $DeleteConversation = {
+export const $DeleteConversationResponse = {
   properties: {},
   type: 'object',
-  title: 'DeleteConversation',
+  title: 'DeleteConversationResponse',
 } as const;
 
-export const $DeleteFile = {
+export const $DeleteDeployment = {
   properties: {},
   type: 'object',
-  title: 'DeleteFile',
+  title: 'DeleteDeployment',
+} as const;
+
+export const $DeleteFileResponse = {
+  properties: {},
+  type: 'object',
+  title: 'DeleteFileResponse',
+} as const;
+
+export const $DeleteModel = {
+  properties: {},
+  type: 'object',
+  title: 'DeleteModel',
+} as const;
+
+export const $DeleteOrganization = {
+  properties: {},
+  type: 'object',
+  title: 'DeleteOrganization',
+} as const;
+
+export const $DeleteSnapshotLinkResponse = {
+  properties: {},
+  type: 'object',
+  title: 'DeleteSnapshotLinkResponse',
+} as const;
+
+export const $DeleteSnapshotResponse = {
+  properties: {},
+  type: 'object',
+  title: 'DeleteSnapshotResponse',
 } as const;
 
 export const $DeleteUser = {
@@ -1239,6 +1342,17 @@ export const $DeleteUser = {
 
 export const $Deployment = {
   properties: {
+    id: {
+      anyOf: [
+        {
+          type: 'string',
+        },
+        {
+          type: 'null',
+        },
+      ],
+      title: 'Id',
+    },
     name: {
       type: 'string',
       title: 'Name',
@@ -1253,18 +1367,236 @@ export const $Deployment = {
     is_available: {
       type: 'boolean',
       title: 'Is Available',
+      default: false,
     },
     env_vars: {
-      items: {
-        type: 'string',
-      },
-      type: 'array',
+      anyOf: [
+        {
+          items: {
+            type: 'string',
+          },
+          type: 'array',
+        },
+        {
+          type: 'null',
+        },
+      ],
       title: 'Env Vars',
+    },
+    description: {
+      anyOf: [
+        {
+          type: 'string',
+        },
+        {
+          type: 'null',
+        },
+      ],
+      title: 'Description',
+    },
+    is_community: {
+      anyOf: [
+        {
+          type: 'boolean',
+        },
+        {
+          type: 'null',
+        },
+      ],
+      title: 'Is Community',
+      default: false,
     },
   },
   type: 'object',
-  required: ['name', 'models', 'is_available', 'env_vars'],
+  required: ['name', 'models', 'env_vars'],
   title: 'Deployment',
+} as const;
+
+export const $DeploymentCreate = {
+  properties: {
+    id: {
+      anyOf: [
+        {
+          type: 'string',
+        },
+        {
+          type: 'null',
+        },
+      ],
+      title: 'Id',
+    },
+    name: {
+      type: 'string',
+      title: 'Name',
+    },
+    description: {
+      anyOf: [
+        {
+          type: 'string',
+        },
+        {
+          type: 'null',
+        },
+      ],
+      title: 'Description',
+    },
+    deployment_class_name: {
+      type: 'string',
+      title: 'Deployment Class Name',
+    },
+    is_community: {
+      type: 'boolean',
+      title: 'Is Community',
+      default: false,
+    },
+    default_deployment_config: {
+      additionalProperties: {
+        type: 'string',
+      },
+      type: 'object',
+      title: 'Default Deployment Config',
+    },
+  },
+  type: 'object',
+  required: ['name', 'deployment_class_name', 'default_deployment_config'],
+  title: 'DeploymentCreate',
+} as const;
+
+export const $DeploymentUpdate = {
+  properties: {
+    name: {
+      anyOf: [
+        {
+          type: 'string',
+        },
+        {
+          type: 'null',
+        },
+      ],
+      title: 'Name',
+    },
+    description: {
+      anyOf: [
+        {
+          type: 'string',
+        },
+        {
+          type: 'null',
+        },
+      ],
+      title: 'Description',
+    },
+    deployment_class_name: {
+      anyOf: [
+        {
+          type: 'string',
+        },
+        {
+          type: 'null',
+        },
+      ],
+      title: 'Deployment Class Name',
+    },
+    is_community: {
+      anyOf: [
+        {
+          type: 'boolean',
+        },
+        {
+          type: 'null',
+        },
+      ],
+      title: 'Is Community',
+    },
+    default_deployment_config: {
+      anyOf: [
+        {
+          additionalProperties: {
+            type: 'string',
+          },
+          type: 'object',
+        },
+        {
+          type: 'null',
+        },
+      ],
+      title: 'Default Deployment Config',
+    },
+  },
+  type: 'object',
+  title: 'DeploymentUpdate',
+} as const;
+
+export const $DeploymentWithModels = {
+  properties: {
+    id: {
+      anyOf: [
+        {
+          type: 'string',
+        },
+        {
+          type: 'null',
+        },
+      ],
+      title: 'Id',
+    },
+    name: {
+      type: 'string',
+      title: 'Name',
+    },
+    description: {
+      anyOf: [
+        {
+          type: 'string',
+        },
+        {
+          type: 'null',
+        },
+      ],
+      title: 'Description',
+    },
+    is_available: {
+      type: 'boolean',
+      title: 'Is Available',
+      default: false,
+    },
+    is_community: {
+      anyOf: [
+        {
+          type: 'boolean',
+        },
+        {
+          type: 'null',
+        },
+      ],
+      title: 'Is Community',
+      default: false,
+    },
+    env_vars: {
+      anyOf: [
+        {
+          items: {
+            type: 'string',
+          },
+          type: 'array',
+        },
+        {
+          type: 'null',
+        },
+      ],
+      title: 'Env Vars',
+    },
+    models: {
+      items: {
+        $ref: '#/components/schemas/ModelSimple',
+      },
+      type: 'array',
+      title: 'Models',
+    },
+  },
+  type: 'object',
+  required: ['name', 'env_vars', 'models'],
+  title: 'DeploymentWithModels',
 } as const;
 
 export const $Document = {
@@ -1379,7 +1711,47 @@ export const $File = {
   title: 'File',
 } as const;
 
-export const $GenerateTitle = {
+export const $FilePublic = {
+  properties: {
+    id: {
+      type: 'string',
+      title: 'Id',
+    },
+    created_at: {
+      type: 'string',
+      format: 'date-time',
+      title: 'Created At',
+    },
+    updated_at: {
+      type: 'string',
+      format: 'date-time',
+      title: 'Updated At',
+    },
+    conversation_id: {
+      type: 'string',
+      title: 'Conversation Id',
+    },
+    file_name: {
+      type: 'string',
+      title: 'File Name',
+    },
+    file_path: {
+      type: 'string',
+      title: 'File Path',
+    },
+    file_size: {
+      type: 'integer',
+      minimum: 0,
+      title: 'File Size',
+      default: 0,
+    },
+  },
+  type: 'object',
+  required: ['id', 'created_at', 'updated_at', 'conversation_id', 'file_name', 'file_path'],
+  title: 'FilePublic',
+} as const;
+
+export const $GenerateTitleResponse = {
   properties: {
     title: {
       type: 'string',
@@ -1388,7 +1760,7 @@ export const $GenerateTitle = {
   },
   type: 'object',
   required: ['title'],
-  title: 'GenerateTitle',
+  title: 'GenerateTitleResponse',
 } as const;
 
 export const $GenericResponseMessage = {
@@ -1580,10 +1952,6 @@ export const $ListFile = {
       format: 'date-time',
       title: 'Updated At',
     },
-    user_id: {
-      type: 'string',
-      title: 'User Id',
-    },
     conversation_id: {
       type: 'string',
       title: 'Conversation Id',
@@ -1604,15 +1972,7 @@ export const $ListFile = {
     },
   },
   type: 'object',
-  required: [
-    'id',
-    'created_at',
-    'updated_at',
-    'user_id',
-    'conversation_id',
-    'file_name',
-    'file_path',
-  ],
+  required: ['id', 'created_at', 'updated_at', 'conversation_id', 'file_name', 'file_path'],
   title: 'ListFile',
 } as const;
 
@@ -1867,6 +2227,175 @@ export const $MessageAgent = {
   title: 'MessageAgent',
 } as const;
 
+export const $Model = {
+  properties: {
+    id: {
+      type: 'string',
+      title: 'Id',
+    },
+    name: {
+      type: 'string',
+      title: 'Name',
+    },
+    deployment_id: {
+      type: 'string',
+      title: 'Deployment Id',
+    },
+    cohere_name: {
+      anyOf: [
+        {
+          type: 'string',
+        },
+        {
+          type: 'null',
+        },
+      ],
+      title: 'Cohere Name',
+    },
+    description: {
+      anyOf: [
+        {
+          type: 'string',
+        },
+        {
+          type: 'null',
+        },
+      ],
+      title: 'Description',
+    },
+  },
+  type: 'object',
+  required: ['id', 'name', 'deployment_id', 'cohere_name', 'description'],
+  title: 'Model',
+} as const;
+
+export const $ModelCreate = {
+  properties: {
+    name: {
+      type: 'string',
+      title: 'Name',
+    },
+    cohere_name: {
+      anyOf: [
+        {
+          type: 'string',
+        },
+        {
+          type: 'null',
+        },
+      ],
+      title: 'Cohere Name',
+    },
+    description: {
+      anyOf: [
+        {
+          type: 'string',
+        },
+        {
+          type: 'null',
+        },
+      ],
+      title: 'Description',
+    },
+    deployment_id: {
+      type: 'string',
+      title: 'Deployment Id',
+    },
+  },
+  type: 'object',
+  required: ['name', 'cohere_name', 'description', 'deployment_id'],
+  title: 'ModelCreate',
+} as const;
+
+export const $ModelSimple = {
+  properties: {
+    id: {
+      type: 'string',
+      title: 'Id',
+    },
+    name: {
+      type: 'string',
+      title: 'Name',
+    },
+    cohere_name: {
+      anyOf: [
+        {
+          type: 'string',
+        },
+        {
+          type: 'null',
+        },
+      ],
+      title: 'Cohere Name',
+    },
+    description: {
+      anyOf: [
+        {
+          type: 'string',
+        },
+        {
+          type: 'null',
+        },
+      ],
+      title: 'Description',
+    },
+  },
+  type: 'object',
+  required: ['id', 'name', 'cohere_name', 'description'],
+  title: 'ModelSimple',
+} as const;
+
+export const $ModelUpdate = {
+  properties: {
+    name: {
+      anyOf: [
+        {
+          type: 'string',
+        },
+        {
+          type: 'null',
+        },
+      ],
+      title: 'Name',
+    },
+    cohere_name: {
+      anyOf: [
+        {
+          type: 'string',
+        },
+        {
+          type: 'null',
+        },
+      ],
+      title: 'Cohere Name',
+    },
+    description: {
+      anyOf: [
+        {
+          type: 'string',
+        },
+        {
+          type: 'null',
+        },
+      ],
+      title: 'Description',
+    },
+    deployment_id: {
+      anyOf: [
+        {
+          type: 'string',
+        },
+        {
+          type: 'null',
+        },
+      ],
+      title: 'Deployment Id',
+    },
+  },
+  type: 'object',
+  title: 'ModelUpdate',
+} as const;
+
 export const $NonStreamedChatResponse = {
   properties: {
     response_id: {
@@ -2014,6 +2543,32 @@ export const $NonStreamedChatResponse = {
   title: 'NonStreamedChatResponse',
 } as const;
 
+export const $Organization = {
+  properties: {
+    name: {
+      type: 'string',
+      title: 'Name',
+    },
+    id: {
+      type: 'string',
+      title: 'Id',
+    },
+    created_at: {
+      type: 'string',
+      format: 'date-time',
+      title: 'Created At',
+    },
+    updated_at: {
+      type: 'string',
+      format: 'date-time',
+      title: 'Updated At',
+    },
+  },
+  type: 'object',
+  required: ['name', 'id', 'created_at', 'updated_at'],
+  title: 'Organization',
+} as const;
+
 export const $SearchQuery = {
   properties: {
     text: {
@@ -2030,7 +2585,30 @@ export const $SearchQuery = {
   title: 'SearchQuery',
 } as const;
 
-export const $Snapshot = {
+export const $SnapshotData = {
+  properties: {
+    title: {
+      type: 'string',
+      title: 'Title',
+    },
+    description: {
+      type: 'string',
+      title: 'Description',
+    },
+    messages: {
+      items: {
+        $ref: '#/components/schemas/Message',
+      },
+      type: 'array',
+      title: 'Messages',
+    },
+  },
+  type: 'object',
+  required: ['title', 'description', 'messages'],
+  title: 'SnapshotData',
+} as const;
+
+export const $SnapshotPublic = {
   properties: {
     conversation_id: {
       type: 'string',
@@ -2043,21 +2621,6 @@ export const $Snapshot = {
     last_message_id: {
       type: 'string',
       title: 'Last Message Id',
-    },
-    user_id: {
-      type: 'string',
-      title: 'User Id',
-    },
-    organization_id: {
-      anyOf: [
-        {
-          type: 'string',
-        },
-        {
-          type: 'null',
-        },
-      ],
-      title: 'Organization Id',
     },
     version: {
       type: 'integer',
@@ -2082,99 +2645,12 @@ export const $Snapshot = {
     'conversation_id',
     'id',
     'last_message_id',
-    'user_id',
-    'organization_id',
     'version',
     'created_at',
     'updated_at',
     'snapshot',
   ],
-  title: 'Snapshot',
-} as const;
-
-export const $SnapshotAgent = {
-  properties: {
-    id: {
-      type: 'string',
-      title: 'Id',
-    },
-    name: {
-      type: 'string',
-      title: 'Name',
-    },
-    description: {
-      anyOf: [
-        {
-          type: 'string',
-        },
-        {
-          type: 'null',
-        },
-      ],
-      title: 'Description',
-    },
-    preamble: {
-      anyOf: [
-        {
-          type: 'string',
-        },
-        {
-          type: 'null',
-        },
-      ],
-      title: 'Preamble',
-    },
-    tools_metadata: {
-      anyOf: [
-        {
-          items: {
-            $ref: '#/components/schemas/AgentToolMetadata',
-          },
-          type: 'array',
-        },
-        {
-          type: 'null',
-        },
-      ],
-      title: 'Tools Metadata',
-    },
-  },
-  type: 'object',
-  required: ['id', 'name', 'description', 'preamble', 'tools_metadata'],
-  title: 'SnapshotAgent',
-} as const;
-
-export const $SnapshotData = {
-  properties: {
-    title: {
-      type: 'string',
-      title: 'Title',
-    },
-    description: {
-      type: 'string',
-      title: 'Description',
-    },
-    messages: {
-      items: {
-        $ref: '#/components/schemas/Message',
-      },
-      type: 'array',
-      title: 'Messages',
-    },
-    agent: {
-      anyOf: [
-        {
-          $ref: '#/components/schemas/SnapshotAgent',
-        },
-        {
-          type: 'null',
-        },
-      ],
-    },
-  },
-  type: 'object',
-  required: ['title', 'description', 'messages', 'agent'],
-  title: 'SnapshotData',
+  title: 'SnapshotPublic',
 } as const;
 
 export const $SnapshotWithLinks = {
@@ -2190,21 +2666,6 @@ export const $SnapshotWithLinks = {
     last_message_id: {
       type: 'string',
       title: 'Last Message Id',
-    },
-    user_id: {
-      type: 'string',
-      title: 'User Id',
-    },
-    organization_id: {
-      anyOf: [
-        {
-          type: 'string',
-        },
-        {
-          type: 'null',
-        },
-      ],
-      title: 'Organization Id',
     },
     version: {
       type: 'integer',
@@ -2236,8 +2697,6 @@ export const $SnapshotWithLinks = {
     'conversation_id',
     'id',
     'last_message_id',
-    'user_id',
-    'organization_id',
     'version',
     'created_at',
     'updated_at',
@@ -2736,7 +3195,7 @@ export const $ToolInputType = {
   description: 'Type of input passed to the tool',
 } as const;
 
-export const $UpdateAgent = {
+export const $UpdateAgentRequest = {
   properties: {
     name: {
       anyOf: [
@@ -2815,6 +3274,55 @@ export const $UpdateAgent = {
       ],
       title: 'Deployment',
     },
+    deployment_config: {
+      anyOf: [
+        {
+          additionalProperties: {
+            type: 'string',
+          },
+          type: 'object',
+        },
+        {
+          type: 'null',
+        },
+      ],
+      title: 'Deployment Config',
+    },
+    is_default_deployment: {
+      anyOf: [
+        {
+          type: 'boolean',
+        },
+        {
+          type: 'null',
+        },
+      ],
+      title: 'Is Default Deployment',
+      default: false,
+    },
+    is_default_model: {
+      anyOf: [
+        {
+          type: 'boolean',
+        },
+        {
+          type: 'null',
+        },
+      ],
+      title: 'Is Default Model',
+      default: false,
+    },
+    organization_id: {
+      anyOf: [
+        {
+          type: 'string',
+        },
+        {
+          type: 'null',
+        },
+      ],
+      title: 'Organization Id',
+    },
     tools: {
       anyOf: [
         {
@@ -2833,7 +3341,7 @@ export const $UpdateAgent = {
       anyOf: [
         {
           items: {
-            $ref: '#/components/schemas/CreateAgentToolMetadata',
+            $ref: '#/components/schemas/CreateAgentToolMetadataRequest',
           },
           type: 'array',
         },
@@ -2845,10 +3353,10 @@ export const $UpdateAgent = {
     },
   },
   type: 'object',
-  title: 'UpdateAgent',
+  title: 'UpdateAgentRequest',
 } as const;
 
-export const $UpdateAgentToolMetadata = {
+export const $UpdateAgentToolMetadataRequest = {
   properties: {
     id: {
       anyOf: [
@@ -2888,10 +3396,10 @@ export const $UpdateAgentToolMetadata = {
     },
   },
   type: 'object',
-  title: 'UpdateAgentToolMetadata',
+  title: 'UpdateAgentToolMetadataRequest',
 } as const;
 
-export const $UpdateConversation = {
+export const $UpdateConversationRequest = {
   properties: {
     title: {
       anyOf: [
@@ -2917,7 +3425,7 @@ export const $UpdateConversation = {
     },
   },
   type: 'object',
-  title: 'UpdateConversation',
+  title: 'UpdateConversationRequest',
 } as const;
 
 export const $UpdateDeploymentEnv = {
@@ -2935,7 +3443,7 @@ export const $UpdateDeploymentEnv = {
   title: 'UpdateDeploymentEnv',
 } as const;
 
-export const $UpdateFile = {
+export const $UpdateFileRequest = {
   properties: {
     file_name: {
       anyOf: [
@@ -2961,7 +3469,26 @@ export const $UpdateFile = {
     },
   },
   type: 'object',
-  title: 'UpdateFile',
+  title: 'UpdateFileRequest',
+} as const;
+
+export const $UpdateOrganization = {
+  properties: {
+    name: {
+      anyOf: [
+        {
+          type: 'string',
+        },
+        {
+          type: 'null',
+        },
+      ],
+      title: 'Name',
+    },
+  },
+  type: 'object',
+  required: ['name'],
+  title: 'UpdateOrganization',
 } as const;
 
 export const $UpdateUser = {
@@ -3016,7 +3543,7 @@ export const $UpdateUser = {
   title: 'UpdateUser',
 } as const;
 
-export const $UploadFile = {
+export const $UploadFileResponse = {
   properties: {
     id: {
       type: 'string',
@@ -3031,10 +3558,6 @@ export const $UploadFile = {
       type: 'string',
       format: 'date-time',
       title: 'Updated At',
-    },
-    user_id: {
-      type: 'string',
-      title: 'User Id',
     },
     conversation_id: {
       type: 'string',
@@ -3056,16 +3579,8 @@ export const $UploadFile = {
     },
   },
   type: 'object',
-  required: [
-    'id',
-    'created_at',
-    'updated_at',
-    'user_id',
-    'conversation_id',
-    'file_name',
-    'file_path',
-  ],
-  title: 'UploadFile',
+  required: ['id', 'created_at', 'updated_at', 'conversation_id', 'file_name', 'file_path'],
+  title: 'UploadFileResponse',
 } as const;
 
 export const $User = {

--- a/src/interfaces/assistants_web/src/cohere-client/generated/services.gen.ts
+++ b/src/interfaces/assistants_web/src/cohere-client/generated/services.gen.ts
@@ -15,6 +15,12 @@ import type {
   CreateAgentToolMetadataV1AgentsAgentIdToolMetadataPostResponse,
   CreateAgentV1AgentsPostData,
   CreateAgentV1AgentsPostResponse,
+  CreateDeploymentV1DeploymentsPostData,
+  CreateDeploymentV1DeploymentsPostResponse,
+  CreateModelV1ModelsPostData,
+  CreateModelV1ModelsPostResponse,
+  CreateOrganizationV1OrganizationsPostData,
+  CreateOrganizationV1OrganizationsPostResponse,
   CreateSnapshotV1SnapshotsPostData,
   CreateSnapshotV1SnapshotsPostResponse,
   CreateUserV1UsersPostData,
@@ -25,8 +31,14 @@ import type {
   DeleteAgentV1AgentsAgentIdDeleteResponse,
   DeleteConversationV1ConversationsConversationIdDeleteData,
   DeleteConversationV1ConversationsConversationIdDeleteResponse,
+  DeleteDeploymentV1DeploymentsDeploymentIdDeleteData,
+  DeleteDeploymentV1DeploymentsDeploymentIdDeleteResponse,
   DeleteFileV1ConversationsConversationIdFilesFileIdDeleteData,
   DeleteFileV1ConversationsConversationIdFilesFileIdDeleteResponse,
+  DeleteModelV1ModelsModelIdDeleteData,
+  DeleteModelV1ModelsModelIdDeleteResponse,
+  DeleteOrganizationV1OrganizationsOrganizationIdDeleteData,
+  DeleteOrganizationV1OrganizationsOrganizationIdDeleteResponse,
   DeleteSnapshotLinkV1SnapshotsLinkLinkIdDeleteData,
   DeleteSnapshotLinkV1SnapshotsLinkLinkIdDeleteResponse,
   DeleteSnapshotV1SnapshotsSnapshotIdDeleteData,
@@ -37,9 +49,17 @@ import type {
   GenerateTitleV1ConversationsConversationIdGenerateTitlePostResponse,
   GetAgentByIdV1AgentsAgentIdGetData,
   GetAgentByIdV1AgentsAgentIdGetResponse,
+  GetAgentDeploymentsV1AgentsAgentIdDeploymentsGetData,
+  GetAgentDeploymentsV1AgentsAgentIdDeploymentsGetResponse,
   GetConversationV1ConversationsConversationIdGetData,
   GetConversationV1ConversationsConversationIdGetResponse,
   GetDefaultAgentV1DefaultAgentGetResponse,
+  GetDeploymentV1DeploymentsDeploymentIdGetData,
+  GetDeploymentV1DeploymentsDeploymentIdGetResponse,
+  GetModelV1ModelsModelIdGetData,
+  GetModelV1ModelsModelIdGetResponse,
+  GetOrganizationV1OrganizationsOrganizationIdGetData,
+  GetOrganizationV1OrganizationsOrganizationIdGetResponse,
   GetSnapshotV1SnapshotsLinkLinkIdGetData,
   GetSnapshotV1SnapshotsLinkLinkIdGetResponse,
   GetStrategiesV1AuthStrategiesGetResponse,
@@ -59,9 +79,18 @@ import type {
   ListExperimentalFeaturesV1ExperimentalFeaturesGetResponse,
   ListFilesV1ConversationsConversationIdFilesGetData,
   ListFilesV1ConversationsConversationIdFilesGetResponse,
+  ListModelsV1ModelsGetData,
+  ListModelsV1ModelsGetResponse,
+  ListOrganizationAgentsV1AgentsOrganizationOrganizationIdGetData,
+  ListOrganizationAgentsV1AgentsOrganizationOrganizationIdGetResponse,
+  ListOrganizationUserAgentsV1AgentsOrganizationOrganizationIdUserUserIdGetData,
+  ListOrganizationUserAgentsV1AgentsOrganizationOrganizationIdUserUserIdGetResponse,
+  ListOrganizationsV1OrganizationsGetResponse,
   ListSnapshotsV1SnapshotsGetResponse,
   ListToolsV1ToolsGetData,
   ListToolsV1ToolsGetResponse,
+  ListUserAgentsV1AgentsUserUserIdGetData,
+  ListUserAgentsV1AgentsUserUserIdGetResponse,
   ListUsersV1UsersGetData,
   ListUsersV1UsersGetResponse,
   LoginV1LoginPostData,
@@ -78,8 +107,14 @@ import type {
   UpdateAgentV1AgentsAgentIdPutResponse,
   UpdateConversationV1ConversationsConversationIdPutData,
   UpdateConversationV1ConversationsConversationIdPutResponse,
+  UpdateDeploymentV1DeploymentsDeploymentIdPutData,
+  UpdateDeploymentV1DeploymentsDeploymentIdPutResponse,
   UpdateFileV1ConversationsConversationIdFilesFileIdPutData,
   UpdateFileV1ConversationsConversationIdFilesFileIdPutResponse,
+  UpdateModelV1ModelsModelIdPutData,
+  UpdateModelV1ModelsModelIdPutResponse,
+  UpdateOrganizationV1OrganizationsOrganizationIdPutData,
+  UpdateOrganizationV1OrganizationsOrganizationIdPutResponse,
   UpdateUserV1UsersUserIdPutData,
   UpdateUserV1UsersUserIdPutResponse,
   UploadFileV1ConversationsUploadFilePostData,
@@ -93,7 +128,8 @@ export class DefaultService {
    * Get Strategies
    * Retrieves the currently enabled list of Authentication strategies.
    *
-   *
+   * Args:
+   * ctx (Context): Context object.
    * Returns:
    * List[dict]: List of dictionaries containing the enabled auth strategy names.
    * @returns ListAuthStrategy Successful Response
@@ -112,9 +148,9 @@ export class DefaultService {
    * Verifies their credentials, retrieves the user and returns a JWT token.
    *
    * Args:
-   * request (Request): current Request object.
    * login (Login): Login payload.
    * session (DBSessionDep): Database session.
+   * ctx (Context): Context object.
    *
    * Returns:
    * dict: JWT token on Basic auth success
@@ -146,6 +182,8 @@ export class DefaultService {
    * strategy (str): Current strategy name.
    * request (Request): Current Request object.
    * session (Session): DB session.
+   * code (str): OAuth code.
+   * ctx (Context): Context object.
    *
    * Returns:
    * dict: Containing "token" key, on success.
@@ -182,6 +220,9 @@ export class DefaultService {
    *
    * Args:
    * request (Request): current Request object.
+   * session (DBSessionDep): Database session.
+   * token (dict): JWT token payload.
+   * ctx (Context): Context object.
    *
    * Returns:
    * dict: Empty on success
@@ -197,19 +238,23 @@ export class DefaultService {
 
   /**
    * Login
-   * Logs user in, performing basic email/password auth.
-   * Verifies their credentials, retrieves the user and returns a JWT token.
+   * Endpoint for Tool Authentication. Note: The flow is different from
+   * the regular login OAuth flow, the backend initiates it and redirects to the frontend
+   * after completion.
+   *
+   * If completed, a ToolAuth is stored in the DB containing the access token for the tool.
    *
    * Args:
    * request (Request): current Request object.
-   * login (Login): Login payload.
    * session (DBSessionDep): Database session.
+   * ctx (Context): Context object.
    *
    * Returns:
-   * dict: JWT token on Basic auth success
+   * RedirectResponse: A redirect pointing to the frontend, contains an error query parameter if
+   * an unexpected error happens during the authentication.
    *
    * Raises:
-   * HTTPException: If the strategy or payload are invalid, or if the login fails.
+   * HTTPException: If no redirect_uri set.
    * @returns unknown Successful Response
    * @throws ApiError
    */
@@ -228,6 +273,7 @@ export class DefaultService {
    * session (DBSessionDep): Database session.
    * chat_request (CohereChatRequest): Chat request data.
    * request (Request): Request object.
+   * ctx (Context): Context object.
    *
    * Returns:
    * EventSourceResponse: Server-sent event response with chatbot responses.
@@ -258,6 +304,7 @@ export class DefaultService {
    * chat_request (CohereChatRequest): Chat request data.
    * session (DBSessionDep): Database session.
    * request (Request): Request object.
+   * ctx (Context): Context object.
    *
    * Returns:
    * NonStreamedChatResponse: Chatbot response.
@@ -280,6 +327,16 @@ export class DefaultService {
 
   /**
    * Langchain Chat Stream
+   * Stream chat endpoint to handle user messages and return chatbot responses using langchain.
+   *
+   * Args:
+   * session (DBSessionDep): Database session.
+   * chat_request (LangchainChatRequest): Chat request data.
+   * request (Request): Request object.
+   * ctx (Context): Context object.
+   *
+   * Returns:
+   * EventSourceResponse: Server-sent event response with chatbot responses.
    * @param data The data for the request.
    * @param data.requestBody
    * @returns unknown Successful Response
@@ -306,6 +363,7 @@ export class DefaultService {
    * Args:
    * user (CreateUser): User data to be created.
    * session (DBSessionDep): Database session.
+   * ctx (Context): Context object.
    *
    * Returns:
    * User: Created user.
@@ -336,6 +394,7 @@ export class DefaultService {
    * offset (int): Offset to start the list.
    * limit (int): Limit of users to be listed.
    * session (DBSessionDep): Database session.
+   * ctx (Context): Context object.
    *
    * Returns:
    * list[User]: List of users.
@@ -368,6 +427,7 @@ export class DefaultService {
    * Args:
    * user_id (str): User ID.
    * session (DBSessionDep): Database session.
+   * ctx (Context): Context object.
    *
    * Returns:
    * User: User with the given ID.
@@ -402,6 +462,8 @@ export class DefaultService {
    * user_id (str): User ID.
    * new_user (UpdateUser): New user data.
    * session (DBSessionDep): Database session.
+   * request (Request): Request object.
+   * ctx (Context): Context object
    *
    * Returns:
    * User: Updated user.
@@ -439,6 +501,7 @@ export class DefaultService {
    * Args:
    * user_id (str): User ID.
    * session (DBSessionDep): Database session.
+   * ctx (Context): Context object.
    *
    * Returns:
    * DeleteUser: Empty response.
@@ -467,7 +530,6 @@ export class DefaultService {
 
   /**
    * Get Conversation
-   * "
    * Get a conversation by ID.
    *
    * Args:
@@ -476,13 +538,13 @@ export class DefaultService {
    * request (Request): Request object.
    *
    * Returns:
-   * Conversation: Conversation with the given ID.
+   * ConversationPublic: Conversation with the given ID.
    *
    * Raises:
    * HTTPException: If the conversation with the given ID is not found.
    * @param data The data for the request.
    * @param data.conversationId
-   * @returns Conversation Successful Response
+   * @returns ConversationPublic Successful Response
    * @throws ApiError
    */
   public getConversationV1ConversationsConversationIdGet(
@@ -506,19 +568,19 @@ export class DefaultService {
    *
    * Args:
    * conversation_id (str): Conversation ID.
-   * new_conversation (UpdateConversation): New conversation data.
+   * new_conversation (UpdateConversationRequest): New conversation data.
    * session (DBSessionDep): Database session.
-   * request (Request): Request object.
+   * ctx (Context): Context object.
    *
    * Returns:
-   * Conversation: Updated conversation.
+   * ConversationPublic: Updated conversation.
    *
    * Raises:
    * HTTPException: If the conversation with the given ID is not found.
    * @param data The data for the request.
    * @param data.conversationId
    * @param data.requestBody
-   * @returns Conversation Successful Response
+   * @returns ConversationPublic Successful Response
    * @throws ApiError
    */
   public updateConversationV1ConversationsConversationIdPut(
@@ -545,16 +607,16 @@ export class DefaultService {
    * Args:
    * conversation_id (str): Conversation ID.
    * session (DBSessionDep): Database session.
-   * request (Request): Request object.
+   * ctx (Context): Context object.
    *
    * Returns:
-   * DeleteConversation: Empty response.
+   * DeleteConversationResponse: Empty response.
    *
    * Raises:
    * HTTPException: If the conversation with the given ID is not found.
    * @param data The data for the request.
    * @param data.conversationId
-   * @returns DeleteConversation Successful Response
+   * @returns DeleteConversationResponse Successful Response
    * @throws ApiError
    */
   public deleteConversationV1ConversationsConversationIdDelete(
@@ -617,6 +679,10 @@ export class DefaultService {
    * query (str): Query string to search for in conversation titles.
    * session (DBSessionDep): Database session.
    * request (Request): Request object.
+   * offset (int): Offset to start the list.
+   * limit (int): Limit of conversations to be listed.
+   * agent_id (str): Query parameter for agent ID to optionally filter conversations by agent.
+   * ctx (Context): Context object.
    *
    * Returns:
    * list[ConversationWithoutMessages]: List of conversations that match the query.
@@ -653,18 +719,19 @@ export class DefaultService {
    *
    * Args:
    * session (DBSessionDep): Database session.
-   * file (FastAPIUploadFile): File to be uploaded.
    * conversation_id (Optional[str]): Conversation ID passed from request query parameter.
+   * file (FastAPIUploadFile): File to be uploaded.
+   * ctx (Context): Context object.
    *
    * Returns:
-   * UploadFile: Uploaded file.
+   * UploadFileResponse: Uploaded file.
    *
    * Raises:
    * HTTPException: If the conversation with the given ID is not found. Status code 404.
    * HTTPException: If the file wasn't uploaded correctly. Status code 500.
    * @param data The data for the request.
    * @param data.formData
-   * @returns UploadFile Successful Response
+   * @returns UploadFileResponse Successful Response
    * @throws ApiError
    */
   public uploadFileV1ConversationsUploadFilePost(
@@ -688,18 +755,19 @@ export class DefaultService {
    *
    * Args:
    * session (DBSessionDep): Database session.
-   * file (list[FastAPIUploadFile]): List of files to be uploaded.
    * conversation_id (Optional[str]): Conversation ID passed from request query parameter.
+   * files (list[FastAPIUploadFile]): List of files to be uploaded.
+   * ctx (Context): Context object.
    *
    * Returns:
-   * list[UploadFile]: List of uploaded files.
+   * list[UploadFileResponse]: List of uploaded files.
    *
    * Raises:
    * HTTPException: If the conversation with the given ID is not found. Status code 404.
    * HTTPException: If the file wasn't uploaded correctly. Status code 500.
    * @param data The data for the request.
    * @param data.formData
-   * @returns UploadFile Successful Response
+   * @returns UploadFileResponse Successful Response
    * @throws ApiError
    */
   public batchUploadFileV1ConversationsBatchUploadFilePost(
@@ -723,6 +791,7 @@ export class DefaultService {
    * Args:
    * conversation_id (str): Conversation ID.
    * session (DBSessionDep): Database session.
+   * ctx (Context): Context object.
    *
    * Returns:
    * list[ListFile]: List of files from the conversation.
@@ -756,11 +825,12 @@ export class DefaultService {
    * Args:
    * conversation_id (str): Conversation ID.
    * file_id (str): File ID.
-   * new_file (UpdateFile): New file data.
+   * new_file (UpdateFileRequest): New file data.
    * session (DBSessionDep): Database session.
+   * ctx (Context): Context object.
    *
    * Returns:
-   * File: Updated file.
+   * FilePublic: Updated file.
    *
    * Raises:
    * HTTPException: If the conversation with the given ID is not found.
@@ -768,7 +838,7 @@ export class DefaultService {
    * @param data.conversationId
    * @param data.fileId
    * @param data.requestBody
-   * @returns File Successful Response
+   * @returns FilePublic Successful Response
    * @throws ApiError
    */
   public updateFileV1ConversationsConversationIdFilesFileIdPut(
@@ -806,7 +876,7 @@ export class DefaultService {
    * @param data The data for the request.
    * @param data.conversationId
    * @param data.fileId
-   * @returns DeleteFile Successful Response
+   * @returns DeleteFileResponse Successful Response
    * @throws ApiError
    */
   public deleteFileV1ConversationsConversationIdFilesFileIdDelete(
@@ -832,6 +902,8 @@ export class DefaultService {
    * Args:
    * conversation_id (str): Conversation ID.
    * session (DBSessionDep): Database session.
+   * request (Request): Request object.
+   * ctx (Context): Context object.
    *
    * Returns:
    * str: Generated title for the conversation.
@@ -840,7 +912,7 @@ export class DefaultService {
    * HTTPException: If the conversation with the given ID is not found.
    * @param data The data for the request.
    * @param data.conversationId
-   * @returns GenerateTitle Successful Response
+   * @returns GenerateTitleResponse Successful Response
    * @throws ApiError
    */
   public generateTitleV1ConversationsConversationIdGenerateTitlePost(
@@ -862,6 +934,11 @@ export class DefaultService {
    * List Tools
    * List all available tools.
    *
+   * Args:
+   * request (Request): The request to validate
+   * session (DBSessionDep): Database session.
+   * agent_id (str): Agent ID.
+   * ctx (Context): Context object.
    * Returns:
    * list[ManagedTool]: List of available tools.
    * @param data The data for the request.
@@ -885,9 +962,42 @@ export class DefaultService {
   }
 
   /**
+   * Create Deployment
+   * Create a new deployment.
+   *
+   * Args:
+   * deployment (DeploymentCreate): Deployment data to be created.
+   * session (DBSessionDep): Database session.
+   *
+   * Returns:
+   * DeploymentSchema: Created deployment.
+   * @param data The data for the request.
+   * @param data.requestBody
+   * @returns Deployment Successful Response
+   * @throws ApiError
+   */
+  public createDeploymentV1DeploymentsPost(
+    data: CreateDeploymentV1DeploymentsPostData
+  ): CancelablePromise<CreateDeploymentV1DeploymentsPostResponse> {
+    return this.httpRequest.request({
+      method: 'POST',
+      url: '/v1/deployments',
+      body: data.requestBody,
+      mediaType: 'application/json',
+      errors: {
+        422: 'Validation Error',
+      },
+    });
+  }
+
+  /**
    * List Deployments
    * List all available deployments and their models.
    *
+   * Args:
+   * session (DBSessionDep)
+   * all (bool): Include all deployments, regardless of availability.
+   * ctx (Context): Context object.
    * Returns:
    * list[Deployment]: List of available deployment options.
    * @param data The data for the request.
@@ -911,9 +1021,111 @@ export class DefaultService {
   }
 
   /**
+   * Update Deployment
+   * Update a deployment.
+   *
+   * Args:
+   * deployment_id (str): Deployment ID.
+   * new_deployment (DeploymentUpdate): Deployment data to be updated.
+   * session (DBSessionDep): Database session.
+   *
+   * Returns:
+   * Deployment: Updated deployment.
+   *
+   * Raises:
+   * HTTPException: If deployment not found.
+   * @param data The data for the request.
+   * @param data.deploymentId
+   * @param data.requestBody
+   * @returns Deployment Successful Response
+   * @throws ApiError
+   */
+  public updateDeploymentV1DeploymentsDeploymentIdPut(
+    data: UpdateDeploymentV1DeploymentsDeploymentIdPutData
+  ): CancelablePromise<UpdateDeploymentV1DeploymentsDeploymentIdPutResponse> {
+    return this.httpRequest.request({
+      method: 'PUT',
+      url: '/v1/deployments/{deployment_id}',
+      path: {
+        deployment_id: data.deploymentId,
+      },
+      body: data.requestBody,
+      mediaType: 'application/json',
+      errors: {
+        422: 'Validation Error',
+      },
+    });
+  }
+
+  /**
+   * Get Deployment
+   * Get a deployment by ID.
+   *
+   * Returns:
+   * Deployment: Deployment with the given ID.
+   * @param data The data for the request.
+   * @param data.deploymentId
+   * @returns Deployment Successful Response
+   * @throws ApiError
+   */
+  public getDeploymentV1DeploymentsDeploymentIdGet(
+    data: GetDeploymentV1DeploymentsDeploymentIdGetData
+  ): CancelablePromise<GetDeploymentV1DeploymentsDeploymentIdGetResponse> {
+    return this.httpRequest.request({
+      method: 'GET',
+      url: '/v1/deployments/{deployment_id}',
+      path: {
+        deployment_id: data.deploymentId,
+      },
+      errors: {
+        422: 'Validation Error',
+      },
+    });
+  }
+
+  /**
+   * Delete Deployment
+   * Delete a deployment by ID.
+   *
+   * Args:
+   * deployment_id (str): Deployment ID.
+   * session (DBSessionDep): Database session.
+   * request (Request): Request object.
+   *
+   * Returns:
+   * DeleteDeployment: Empty response.
+   *
+   * Raises:
+   * HTTPException: If the deployment with the given ID is not found.
+   * @param data The data for the request.
+   * @param data.deploymentId
+   * @returns DeleteDeployment Successful Response
+   * @throws ApiError
+   */
+  public deleteDeploymentV1DeploymentsDeploymentIdDelete(
+    data: DeleteDeploymentV1DeploymentsDeploymentIdDeleteData
+  ): CancelablePromise<DeleteDeploymentV1DeploymentsDeploymentIdDeleteResponse> {
+    return this.httpRequest.request({
+      method: 'DELETE',
+      url: '/v1/deployments/{deployment_id}',
+      path: {
+        deployment_id: data.deploymentId,
+      },
+      errors: {
+        422: 'Validation Error',
+      },
+    });
+  }
+
+  /**
    * Set Env Vars
    * Set environment variables for the deployment.
    *
+   * Args:
+   * name (str): Deployment name.
+   * env_vars (UpdateDeploymentEnv): Environment variables to set.
+   * valid_env_vars (str): Validated environment variables.
+   * ctx (Context): Context object.
    * Returns:
    * str: Empty string.
    * @param data The data for the request.
@@ -943,6 +1155,8 @@ export class DefaultService {
    * List Experimental Features
    * List all experimental features and if they are enabled
    *
+   * Args:
+   * ctx (Context): Context object.
    * Returns:
    * Dict[str, bool]: Experimental feature and their isEnabled state
    * @returns unknown Successful Response
@@ -958,10 +1172,11 @@ export class DefaultService {
   /**
    * Create Agent
    * Create an agent.
+   *
    * Args:
    * session (DBSessionDep): Database session.
-   * agent (CreateAgent): Agent data.
-   * request (Request): Request object.
+   * agent (CreateAgentRequest): Agent data.
+   * ctx (Context): Context object.
    * Returns:
    * AgentPublic: Created agent with no user ID or organization ID.
    * Raises:
@@ -993,7 +1208,7 @@ export class DefaultService {
    * offset (int): Offset to start the list.
    * limit (int): Limit of agents to be listed.
    * session (DBSessionDep): Database session.
-   * request (Request): Request object.
+   * ctx (Context): Context object.
    *
    * Returns:
    * list[AgentPublic]: List of agents with no user ID or organization ID.
@@ -1020,10 +1235,128 @@ export class DefaultService {
   }
 
   /**
+   * List User Agents
+   * List all agents.
+   *
+   * Args:
+   * user_id (str): User ID.
+   * offset (int): Offset to start the list.
+   * limit (int): Limit of agents to be listed.
+   * session (DBSessionDep): Database session.
+   *
+   * Returns:
+   * list[Agent]: List of agents.
+   * @param data The data for the request.
+   * @param data.userId
+   * @param data.offset
+   * @param data.limit
+   * @returns Agent Successful Response
+   * @throws ApiError
+   */
+  public listUserAgentsV1AgentsUserUserIdGet(
+    data: ListUserAgentsV1AgentsUserUserIdGetData
+  ): CancelablePromise<ListUserAgentsV1AgentsUserUserIdGetResponse> {
+    return this.httpRequest.request({
+      method: 'GET',
+      url: '/v1/agents/user/{user_id}',
+      path: {
+        user_id: data.userId,
+      },
+      query: {
+        offset: data.offset,
+        limit: data.limit,
+      },
+      errors: {
+        422: 'Validation Error',
+      },
+    });
+  }
+
+  /**
+   * List Organization Agents
+   * List all agents.
+   *
+   * Args:
+   * organization_id (str): Organization ID.
+   * offset (int): Offset to start the list.
+   * limit (int): Limit of agents to be listed.
+   * session (DBSessionDep): Database session.
+   *
+   * Returns:
+   * list[Agent]: List of agents.
+   * @param data The data for the request.
+   * @param data.organizationId
+   * @param data.offset
+   * @param data.limit
+   * @returns Agent Successful Response
+   * @throws ApiError
+   */
+  public listOrganizationAgentsV1AgentsOrganizationOrganizationIdGet(
+    data: ListOrganizationAgentsV1AgentsOrganizationOrganizationIdGetData
+  ): CancelablePromise<ListOrganizationAgentsV1AgentsOrganizationOrganizationIdGetResponse> {
+    return this.httpRequest.request({
+      method: 'GET',
+      url: '/v1/agents/organization/{organization_id}',
+      path: {
+        organization_id: data.organizationId,
+      },
+      query: {
+        offset: data.offset,
+        limit: data.limit,
+      },
+      errors: {
+        422: 'Validation Error',
+      },
+    });
+  }
+
+  /**
+   * List Organization User Agents
+   * List all agents.
+   *
+   * Args:
+   * organization_id (str): Organization ID.
+   * user_id (str): User ID.
+   * offset (int): Offset to start the list.
+   * limit (int): Limit of agents to be listed.
+   * session (DBSessionDep): Database session.
+   *
+   * Returns:
+   * list[Agent]: List of agents.
+   * @param data The data for the request.
+   * @param data.organizationId
+   * @param data.userId
+   * @param data.offset
+   * @param data.limit
+   * @returns Agent Successful Response
+   * @throws ApiError
+   */
+  public listOrganizationUserAgentsV1AgentsOrganizationOrganizationIdUserUserIdGet(
+    data: ListOrganizationUserAgentsV1AgentsOrganizationOrganizationIdUserUserIdGetData
+  ): CancelablePromise<ListOrganizationUserAgentsV1AgentsOrganizationOrganizationIdUserUserIdGetResponse> {
+    return this.httpRequest.request({
+      method: 'GET',
+      url: '/v1/agents/organization/{organization_id}/user/{user_id}',
+      path: {
+        organization_id: data.organizationId,
+        user_id: data.userId,
+      },
+      query: {
+        offset: data.offset,
+        limit: data.limit,
+      },
+      errors: {
+        422: 'Validation Error',
+      },
+    });
+  }
+
+  /**
    * Get Agent By Id
    * Args:
    * agent_id (str): Agent ID.
    * session (DBSessionDep): Database session.
+   * ctx (Context): Context object.
    *
    * Returns:
    * Agent: Agent.
@@ -1056,9 +1389,9 @@ export class DefaultService {
    *
    * Args:
    * agent_id (str): Agent ID.
-   * new_agent (UpdateAgent): New agent data.
+   * new_agent (UpdateAgentRequest): New agent data.
    * session (DBSessionDep): Database session.
-   * request (Request): Request object.
+   * ctx (Context): Context object.
    *
    * Returns:
    * AgentPublic: Updated agent with no user ID or organization ID.
@@ -1095,7 +1428,7 @@ export class DefaultService {
    * Args:
    * agent_id (str): Agent ID.
    * session (DBSessionDep): Database session.
-   * request (Request): Request object.
+   * ctx (Context): Context object.
    *
    * Returns:
    * DeleteAgent: Empty response.
@@ -1123,13 +1456,45 @@ export class DefaultService {
   }
 
   /**
+   * Get Agent Deployments
+   * Args:
+   * agent_id (str): Agent ID.
+   * session (DBSessionDep): Database session.
+   * ctx (Context): Context object.
+   *
+   * Returns:
+   * Agent: Agent.
+   *
+   * Raises:
+   * HTTPException: If the agent with the given ID is not found.
+   * @param data The data for the request.
+   * @param data.agentId
+   * @returns Deployment Successful Response
+   * @throws ApiError
+   */
+  public getAgentDeploymentsV1AgentsAgentIdDeploymentsGet(
+    data: GetAgentDeploymentsV1AgentsAgentIdDeploymentsGetData
+  ): CancelablePromise<GetAgentDeploymentsV1AgentsAgentIdDeploymentsGetResponse> {
+    return this.httpRequest.request({
+      method: 'GET',
+      url: '/v1/agents/{agent_id}/deployments',
+      path: {
+        agent_id: data.agentId,
+      },
+      errors: {
+        422: 'Validation Error',
+      },
+    });
+  }
+
+  /**
    * List Agent Tool Metadata
    * List all agent tool metadata by agent ID.
    *
    * Args:
    * agent_id (str): Agent ID.
    * session (DBSessionDep): Database session.
-   * request (Request): Request object.
+   * ctx (Context): Context object.
    *
    * Returns:
    * list[AgentToolMetadataPublic]: List of agent tool metadata with no user ID or organization ID.
@@ -1163,8 +1528,8 @@ export class DefaultService {
    * Args:
    * session (DBSessionDep): Database session.
    * agent_id (str): Agent ID.
-   * agent_tool_metadata (CreateAgentToolMetadata): Agent tool metadata data.
-   * request (Request): Request object.
+   * agent_tool_metadata (CreateAgentToolMetadataRequest): Agent tool metadata data.
+   * ctx (Context): Context object.
    *
    * Returns:
    * AgentToolMetadata: Created agent tool metadata.
@@ -1202,8 +1567,8 @@ export class DefaultService {
    * agent_id (str): Agent ID.
    * agent_tool_metadata_id (str): Agent tool metadata ID.
    * session (DBSessionDep): Database session.
-   * new_agent_tool_metadata (UpdateAgentToolMetadata): New agent tool metadata data.
-   * request (Request): Request object.
+   * new_agent_tool_metadata (UpdateAgentToolMetadataRequest): New agent tool metadata data.
+   * ctx (Context): Context object.
    *
    * Returns:
    * AgentToolMetadata: Updated agent tool metadata.
@@ -1244,7 +1609,7 @@ export class DefaultService {
    * agent_id (str): Agent ID.
    * agent_tool_metadata_id (str): Agent tool metadata ID.
    * session (DBSessionDep): Database session.
-   * request (Request): Request object.
+   * ctx (Context): Context object.
    *
    * Returns:
    * DeleteAgentToolMetadata: Empty response.
@@ -1276,6 +1641,14 @@ export class DefaultService {
 
   /**
    * Get Default Agent
+   * Get the default agent - used for logging purposes.
+   *
+   * Args:
+   * session (DBSessionDep): Database session.
+   * ctx (Context): Context object.
+   *
+   * Returns:
+   * GenericResponseMessage: OK message.
    * @returns GenericResponseMessage Successful Response
    * @throws ApiError
    */
@@ -1292,10 +1665,10 @@ export class DefaultService {
    *
    * Args:
    * session (DBSessionDep): Database session.
-   * request (Request): HTTP request object.
+   * ctx (Context): Context object.
    *
    * Returns:
-   * list[Snapshot]: List of all snapshots.
+   * list[SnapshotWithLinks]: List of all snapshots with their links.
    * @returns SnapshotWithLinks Successful Response
    * @throws ApiError
    */
@@ -1311,9 +1684,9 @@ export class DefaultService {
    * Create a new snapshot and snapshot link to share the conversation.
    *
    * Args:
-   * snapshot_request (CreateSnapshot): Snapshot creation request.
+   * snapshot_request (CreateSnapshotRequest): Snapshot creation request.
    * session (DBSessionDep): Database session.
-   * request (Request): HTTP request object.
+   * ctx (Context): Context object.
    *
    * Returns:
    * CreateSnapshotResponse: Snapshot creation response.
@@ -1343,13 +1716,13 @@ export class DefaultService {
    * Args:
    * link_id (str): Snapshot link ID.
    * session (DBSessionDep): Database session.
-   * request (Request): HTTP request object.
+   * ctx (Context): Context object.
    *
    * Returns:
    * Snapshot: Snapshot with the given link ID.
    * @param data The data for the request.
    * @param data.linkId
-   * @returns Snapshot Successful Response
+   * @returns SnapshotPublic Successful Response
    * @throws ApiError
    */
   public getSnapshotV1SnapshotsLinkLinkIdGet(
@@ -1374,13 +1747,13 @@ export class DefaultService {
    * Args:
    * link_id (str): Snapshot link ID.
    * session (DBSessionDep): Database session.
-   * request (Request): HTTP request object.
+   * ctx (Context): Context object.
    *
    * Returns:
-   * Any: Empty response.
+   * DeleteSnapshotLinkResponse: Empty response.
    * @param data The data for the request.
    * @param data.linkId
-   * @returns unknown Successful Response
+   * @returns DeleteSnapshotLinkResponse Successful Response
    * @throws ApiError
    */
   public deleteSnapshotLinkV1SnapshotsLinkLinkIdDelete(
@@ -1405,13 +1778,13 @@ export class DefaultService {
    * Args:
    * snapshot_id (str): Snapshot ID.
    * session (DBSessionDep): Database session.
-   * request (Request): HTTP request object.
+   * ctx (Context): Context object.
    *
    * Returns:
-   * Any: Empty response.
+   * DeleteSnapshotResponse: Empty response.
    * @param data The data for the request.
    * @param data.snapshotId
-   * @returns unknown Successful Response
+   * @returns DeleteSnapshotResponse Successful Response
    * @throws ApiError
    */
   public deleteSnapshotV1SnapshotsSnapshotIdDelete(
@@ -1422,6 +1795,303 @@ export class DefaultService {
       url: '/v1/snapshots/{snapshot_id}',
       path: {
         snapshot_id: data.snapshotId,
+      },
+      errors: {
+        422: 'Validation Error',
+      },
+    });
+  }
+
+  /**
+   * List Organizations
+   * List all available organizations.
+   *
+   * Args:
+   * request (Request): Request object.
+   * session (DBSessionDep): Database session.
+   *
+   * Returns:
+   * list[ManagedTool]: List of available organizations.
+   * @returns Organization Successful Response
+   * @throws ApiError
+   */
+  public listOrganizationsV1OrganizationsGet(): CancelablePromise<ListOrganizationsV1OrganizationsGetResponse> {
+    return this.httpRequest.request({
+      method: 'GET',
+      url: '/v1/organizations',
+    });
+  }
+
+  /**
+   * Create Organization
+   * Create a new organization.
+   *
+   * Args:
+   * organization (CreateOrganization): Organization data
+   * session (DBSessionDep): Database session.
+   *
+   * Returns:
+   * Organization: Created organization.
+   * @param data The data for the request.
+   * @param data.requestBody
+   * @returns Organization Successful Response
+   * @throws ApiError
+   */
+  public createOrganizationV1OrganizationsPost(
+    data: CreateOrganizationV1OrganizationsPostData
+  ): CancelablePromise<CreateOrganizationV1OrganizationsPostResponse> {
+    return this.httpRequest.request({
+      method: 'POST',
+      url: '/v1/organizations',
+      body: data.requestBody,
+      mediaType: 'application/json',
+      errors: {
+        422: 'Validation Error',
+      },
+    });
+  }
+
+  /**
+   * Update Organization
+   * Update organization by ID.
+   *
+   * Args:
+   * organization_id (str): Tool ID.
+   * new_organization (ToolUpdate): New organization data.
+   * session (DBSessionDep): Database session.
+   *
+   * Returns:
+   * Organization: Updated organization.
+   * @param data The data for the request.
+   * @param data.organizationId
+   * @param data.requestBody
+   * @returns Organization Successful Response
+   * @throws ApiError
+   */
+  public updateOrganizationV1OrganizationsOrganizationIdPut(
+    data: UpdateOrganizationV1OrganizationsOrganizationIdPutData
+  ): CancelablePromise<UpdateOrganizationV1OrganizationsOrganizationIdPutResponse> {
+    return this.httpRequest.request({
+      method: 'PUT',
+      url: '/v1/organizations/{organization_id}',
+      path: {
+        organization_id: data.organizationId,
+      },
+      body: data.requestBody,
+      mediaType: 'application/json',
+      errors: {
+        422: 'Validation Error',
+      },
+    });
+  }
+
+  /**
+   * Get Organization
+   * Get a organization by ID.
+   *
+   * Args:
+   * organization_id (str): Tool ID.
+   * session (DBSessionDep): Database session.
+   *
+   * Returns:
+   * ManagedTool: Tool with the given ID.
+   * @param data The data for the request.
+   * @param data.organizationId
+   * @returns Organization Successful Response
+   * @throws ApiError
+   */
+  public getOrganizationV1OrganizationsOrganizationIdGet(
+    data: GetOrganizationV1OrganizationsOrganizationIdGetData
+  ): CancelablePromise<GetOrganizationV1OrganizationsOrganizationIdGetResponse> {
+    return this.httpRequest.request({
+      method: 'GET',
+      url: '/v1/organizations/{organization_id}',
+      path: {
+        organization_id: data.organizationId,
+      },
+      errors: {
+        422: 'Validation Error',
+      },
+    });
+  }
+
+  /**
+   * Delete Organization
+   * Delete a organization by ID.
+   *
+   * Args:
+   * organization_id (str): Tool ID.
+   * session (DBSessionDep): Database session.
+   *
+   * Returns:
+   * DeleteOrganization: Organization deleted.
+   * @param data The data for the request.
+   * @param data.organizationId
+   * @returns DeleteOrganization Successful Response
+   * @throws ApiError
+   */
+  public deleteOrganizationV1OrganizationsOrganizationIdDelete(
+    data: DeleteOrganizationV1OrganizationsOrganizationIdDeleteData
+  ): CancelablePromise<DeleteOrganizationV1OrganizationsOrganizationIdDeleteResponse> {
+    return this.httpRequest.request({
+      method: 'DELETE',
+      url: '/v1/organizations/{organization_id}',
+      path: {
+        organization_id: data.organizationId,
+      },
+      errors: {
+        422: 'Validation Error',
+      },
+    });
+  }
+
+  /**
+   * Create Model
+   * Create a new model.
+   *
+   * Args:
+   * model (ModelCreate): Model data to be created.
+   * session (DBSessionDep): Database session.
+   *
+   * Returns:
+   * ModelSchema: Created model.
+   * @param data The data for the request.
+   * @param data.requestBody
+   * @returns Model Successful Response
+   * @throws ApiError
+   */
+  public createModelV1ModelsPost(
+    data: CreateModelV1ModelsPostData
+  ): CancelablePromise<CreateModelV1ModelsPostResponse> {
+    return this.httpRequest.request({
+      method: 'POST',
+      url: '/v1/models',
+      body: data.requestBody,
+      mediaType: 'application/json',
+      errors: {
+        422: 'Validation Error',
+      },
+    });
+  }
+
+  /**
+   * List Models
+   * List all available models
+   *
+   * Returns:
+   * list[Model]: List of available models.
+   * @param data The data for the request.
+   * @param data.offset
+   * @param data.limit
+   * @returns Model Successful Response
+   * @throws ApiError
+   */
+  public listModelsV1ModelsGet(
+    data: ListModelsV1ModelsGetData = {}
+  ): CancelablePromise<ListModelsV1ModelsGetResponse> {
+    return this.httpRequest.request({
+      method: 'GET',
+      url: '/v1/models',
+      query: {
+        offset: data.offset,
+        limit: data.limit,
+      },
+      errors: {
+        422: 'Validation Error',
+      },
+    });
+  }
+
+  /**
+   * Update Model
+   * Update a model by ID.
+   *
+   * Args:
+   * model_id (str): Model ID.
+   * new_model (ModelCreateUpdate): New model data.
+   * session (DBSessionDep): Database session.
+   *
+   * Returns:
+   * ModelSchema: Updated model.
+   *
+   * Raises:
+   * HTTPException: If the model with the given ID is not found.
+   * @param data The data for the request.
+   * @param data.modelId
+   * @param data.requestBody
+   * @returns Model Successful Response
+   * @throws ApiError
+   */
+  public updateModelV1ModelsModelIdPut(
+    data: UpdateModelV1ModelsModelIdPutData
+  ): CancelablePromise<UpdateModelV1ModelsModelIdPutResponse> {
+    return this.httpRequest.request({
+      method: 'PUT',
+      url: '/v1/models/{model_id}',
+      path: {
+        model_id: data.modelId,
+      },
+      body: data.requestBody,
+      mediaType: 'application/json',
+      errors: {
+        422: 'Validation Error',
+      },
+    });
+  }
+
+  /**
+   * Get Model
+   * Get a model by ID.
+   *
+   * Returns:
+   * Model: Model with the given ID.
+   * @param data The data for the request.
+   * @param data.modelId
+   * @returns Model Successful Response
+   * @throws ApiError
+   */
+  public getModelV1ModelsModelIdGet(
+    data: GetModelV1ModelsModelIdGetData
+  ): CancelablePromise<GetModelV1ModelsModelIdGetResponse> {
+    return this.httpRequest.request({
+      method: 'GET',
+      url: '/v1/models/{model_id}',
+      path: {
+        model_id: data.modelId,
+      },
+      errors: {
+        422: 'Validation Error',
+      },
+    });
+  }
+
+  /**
+   * Delete Model
+   * Delete a model by ID.
+   *
+   * Args:
+   * model_id (str): Model ID.
+   * session (DBSessionDep): Database session.
+   * request (Request): Request object.
+   *
+   * Returns:
+   * DeleteModel: Empty response.
+   *
+   * Raises:
+   * HTTPException: If the model with the given ID is not found.
+   * @param data The data for the request.
+   * @param data.modelId
+   * @returns DeleteModel Successful Response
+   * @throws ApiError
+   */
+  public deleteModelV1ModelsModelIdDelete(
+    data: DeleteModelV1ModelsModelIdDeleteData
+  ): CancelablePromise<DeleteModelV1ModelsModelIdDeleteResponse> {
+    return this.httpRequest.request({
+      method: 'DELETE',
+      url: '/v1/models/{model_id}',
+      path: {
+        model_id: data.modelId,
       },
       errors: {
         422: 'Validation Error',

--- a/src/interfaces/assistants_web/src/cohere-client/generated/types.gen.ts
+++ b/src/interfaces/assistants_web/src/cohere-client/generated/types.gen.ts
@@ -11,14 +11,14 @@ export type Agent = {
   description: string | null;
   preamble: string | null;
   temperature: number;
-  tools: Array<string>;
-  tools_metadata?: Array<AgentToolMetadataPublic> | null;
-  model: string;
-  deployment: string;
+  tools: Array<string> | null;
+  tools_metadata: Array<AgentToolMetadataPublic>;
+  deployments: Array<DeploymentWithModels>;
+  deployment: string | null;
+  model: string | null;
 };
 
 export type AgentPublic = {
-  user_id: string;
   id: string;
   created_at: string;
   updated_at: string;
@@ -27,16 +27,19 @@ export type AgentPublic = {
   description: string | null;
   preamble: string | null;
   temperature: number;
-  tools: Array<string>;
+  tools: Array<string> | null;
   tools_metadata?: Array<AgentToolMetadataPublic> | null;
-  model: string;
-  deployment: string;
+  deployments: Array<DeploymentWithModels>;
+  deployment: string | null;
+  model: string | null;
 };
 
 export type AgentToolMetadata = {
-  user_id: string;
-  organization_id?: string | null;
   id: string;
+  created_at: string;
+  updated_at: string;
+  user_id: string | null;
+  agent_id: string;
   tool_name: string;
   artifacts: Array<{
     [key: string]: unknown;
@@ -44,8 +47,10 @@ export type AgentToolMetadata = {
 };
 
 export type AgentToolMetadataPublic = {
-  organization_id?: string | null;
   id: string;
+  created_at: string;
+  updated_at: string;
+  agent_id: string;
   tool_name: string;
   artifacts: Array<{
     [key: string]: unknown;
@@ -157,9 +162,7 @@ export type CohereChatRequest = {
   agent_id?: string | null;
 };
 
-export type Conversation = {
-  user_id: string;
-  organization_id?: string | null;
+export type ConversationPublic = {
   id: string;
   created_at: string;
   updated_at: string;
@@ -172,8 +175,6 @@ export type Conversation = {
 };
 
 export type ConversationWithoutMessages = {
-  user_id: string;
-  organization_id?: string | null;
   id: string;
   created_at: string;
   updated_at: string;
@@ -184,19 +185,24 @@ export type ConversationWithoutMessages = {
   readonly total_file_size: number;
 };
 
-export type CreateAgent = {
+export type CreateAgentRequest = {
   name: string;
   version?: number | null;
   description?: string | null;
   preamble?: string | null;
   temperature?: number | null;
+  tools?: Array<string> | null;
+  tools_metadata?: Array<CreateAgentToolMetadataRequest> | null;
+  deployment_config?: {
+    [key: string]: string;
+  } | null;
+  is_default_deployment?: boolean | null;
   model: string;
   deployment: string;
-  tools?: Array<string> | null;
-  tools_metadata?: Array<CreateAgentToolMetadata> | null;
+  organization_id?: string | null;
 };
 
-export type CreateAgentToolMetadata = {
+export type CreateAgentToolMetadataRequest = {
   id?: string | null;
   tool_name: string;
   artifacts: Array<{
@@ -204,13 +210,16 @@ export type CreateAgentToolMetadata = {
   }>;
 };
 
-export type CreateSnapshot = {
+export type CreateOrganization = {
+  name: string;
+};
+
+export type CreateSnapshotRequest = {
   conversation_id: string;
 };
 
 export type CreateSnapshotResponse = {
   snapshot_id: string;
-  user_id: string;
   link_id: string;
   messages: Array<Message>;
 };
@@ -226,17 +235,61 @@ export type DeleteAgent = unknown;
 
 export type DeleteAgentToolMetadata = unknown;
 
-export type DeleteConversation = unknown;
+export type DeleteConversationResponse = unknown;
 
-export type DeleteFile = unknown;
+export type DeleteDeployment = unknown;
+
+export type DeleteFileResponse = unknown;
+
+export type DeleteModel = unknown;
+
+export type DeleteOrganization = unknown;
+
+export type DeleteSnapshotLinkResponse = unknown;
+
+export type DeleteSnapshotResponse = unknown;
 
 export type DeleteUser = unknown;
 
 export type Deployment = {
+  id?: string | null;
   name: string;
   models: Array<string>;
-  is_available: boolean;
-  env_vars: Array<string>;
+  is_available?: boolean;
+  env_vars: Array<string> | null;
+  description?: string | null;
+  is_community?: boolean | null;
+};
+
+export type DeploymentCreate = {
+  id?: string | null;
+  name: string;
+  description?: string | null;
+  deployment_class_name: string;
+  is_community?: boolean;
+  default_deployment_config: {
+    [key: string]: string;
+  };
+};
+
+export type DeploymentUpdate = {
+  name?: string | null;
+  description?: string | null;
+  deployment_class_name?: string | null;
+  is_community?: boolean | null;
+  default_deployment_config?: {
+    [key: string]: string;
+  } | null;
+};
+
+export type DeploymentWithModels = {
+  id?: string | null;
+  name: string;
+  description?: string | null;
+  is_available?: boolean;
+  is_community?: boolean | null;
+  env_vars: Array<string> | null;
+  models: Array<ModelSimple>;
 };
 
 export type Document = {
@@ -261,7 +314,17 @@ export type File = {
   file_size?: number;
 };
 
-export type GenerateTitle = {
+export type FilePublic = {
+  id: string;
+  created_at: string;
+  updated_at: string;
+  conversation_id: string;
+  file_name: string;
+  file_path: string;
+  file_size?: number;
+};
+
+export type GenerateTitleResponse = {
   title: string;
 };
 
@@ -298,7 +361,6 @@ export type ListFile = {
   id: string;
   created_at: string;
   updated_at: string;
-  user_id: string;
   conversation_id: string;
   file_name: string;
   file_path: string;
@@ -354,6 +416,35 @@ export enum MessageAgent {
   CHATBOT = 'CHATBOT',
 }
 
+export type Model = {
+  id: string;
+  name: string;
+  deployment_id: string;
+  cohere_name: string | null;
+  description: string | null;
+};
+
+export type ModelCreate = {
+  name: string;
+  cohere_name: string | null;
+  description: string | null;
+  deployment_id: string;
+};
+
+export type ModelSimple = {
+  id: string;
+  name: string;
+  cohere_name: string | null;
+  description: string | null;
+};
+
+export type ModelUpdate = {
+  name?: string | null;
+  cohere_name?: string | null;
+  description?: string | null;
+  deployment_id?: string | null;
+};
+
 export type NonStreamedChatResponse = {
   response_id: string | null;
   generation_id: string | null;
@@ -370,44 +461,38 @@ export type NonStreamedChatResponse = {
   tool_calls?: Array<ToolCall> | null;
 };
 
+export type Organization = {
+  name: string;
+  id: string;
+  created_at: string;
+  updated_at: string;
+};
+
 export type SearchQuery = {
   text: string;
   generation_id: string;
-};
-
-export type Snapshot = {
-  conversation_id: string;
-  id: string;
-  last_message_id: string;
-  user_id: string;
-  organization_id: string | null;
-  version: number;
-  created_at: string;
-  updated_at: string;
-  snapshot: SnapshotData;
-};
-
-export type SnapshotAgent = {
-  id: string;
-  name: string;
-  description: string | null;
-  preamble: string | null;
-  tools_metadata: Array<AgentToolMetadata> | null;
 };
 
 export type SnapshotData = {
   title: string;
   description: string;
   messages: Array<Message>;
-  agent: SnapshotAgent | null;
+};
+
+export type SnapshotPublic = {
+  conversation_id: string;
+  id: string;
+  last_message_id: string;
+  version: number;
+  created_at: string;
+  updated_at: string;
+  snapshot: SnapshotData;
 };
 
 export type SnapshotWithLinks = {
   conversation_id: string;
   id: string;
   last_message_id: string;
-  user_id: string;
-  organization_id: string | null;
   version: number;
   created_at: string;
   updated_at: string;
@@ -549,7 +634,7 @@ export enum ToolInputType {
   CODE = 'CODE',
 }
 
-export type UpdateAgent = {
+export type UpdateAgentRequest = {
   name?: string | null;
   version?: number | null;
   description?: string | null;
@@ -557,11 +642,17 @@ export type UpdateAgent = {
   temperature?: number | null;
   model?: string | null;
   deployment?: string | null;
+  deployment_config?: {
+    [key: string]: string;
+  } | null;
+  is_default_deployment?: boolean | null;
+  is_default_model?: boolean | null;
+  organization_id?: string | null;
   tools?: Array<string> | null;
-  tools_metadata?: Array<CreateAgentToolMetadata> | null;
+  tools_metadata?: Array<CreateAgentToolMetadataRequest> | null;
 };
 
-export type UpdateAgentToolMetadata = {
+export type UpdateAgentToolMetadataRequest = {
   id?: string | null;
   tool_name?: string | null;
   artifacts?: Array<{
@@ -569,7 +660,7 @@ export type UpdateAgentToolMetadata = {
   }> | null;
 };
 
-export type UpdateConversation = {
+export type UpdateConversationRequest = {
   title?: string | null;
   description?: string | null;
 };
@@ -580,9 +671,13 @@ export type UpdateDeploymentEnv = {
   };
 };
 
-export type UpdateFile = {
+export type UpdateFileRequest = {
   file_name?: string | null;
   message_id?: string | null;
+};
+
+export type UpdateOrganization = {
+  name: string | null;
 };
 
 export type UpdateUser = {
@@ -592,11 +687,10 @@ export type UpdateUser = {
   email?: string | null;
 };
 
-export type UploadFile = {
+export type UploadFileResponse = {
   id: string;
   created_at: string;
   updated_at: string;
-  user_id: string;
   conversation_id: string;
   file_name: string;
   file_path: string;
@@ -690,20 +784,21 @@ export type GetConversationV1ConversationsConversationIdGetData = {
   conversationId: string;
 };
 
-export type GetConversationV1ConversationsConversationIdGetResponse = Conversation;
+export type GetConversationV1ConversationsConversationIdGetResponse = ConversationPublic;
 
 export type UpdateConversationV1ConversationsConversationIdPutData = {
   conversationId: string;
-  requestBody: UpdateConversation;
+  requestBody: UpdateConversationRequest;
 };
 
-export type UpdateConversationV1ConversationsConversationIdPutResponse = Conversation;
+export type UpdateConversationV1ConversationsConversationIdPutResponse = ConversationPublic;
 
 export type DeleteConversationV1ConversationsConversationIdDeleteData = {
   conversationId: string;
 };
 
-export type DeleteConversationV1ConversationsConversationIdDeleteResponse = DeleteConversation;
+export type DeleteConversationV1ConversationsConversationIdDeleteResponse =
+  DeleteConversationResponse;
 
 export type ListConversationsV1ConversationsGetData = {
   agentId?: string;
@@ -727,13 +822,13 @@ export type UploadFileV1ConversationsUploadFilePostData = {
   formData: Body_upload_file_v1_conversations_upload_file_post;
 };
 
-export type UploadFileV1ConversationsUploadFilePostResponse = UploadFile;
+export type UploadFileV1ConversationsUploadFilePostResponse = UploadFileResponse;
 
 export type BatchUploadFileV1ConversationsBatchUploadFilePostData = {
   formData: Body_batch_upload_file_v1_conversations_batch_upload_file_post;
 };
 
-export type BatchUploadFileV1ConversationsBatchUploadFilePostResponse = Array<UploadFile>;
+export type BatchUploadFileV1ConversationsBatchUploadFilePostResponse = Array<UploadFileResponse>;
 
 export type ListFilesV1ConversationsConversationIdFilesGetData = {
   conversationId: string;
@@ -744,23 +839,24 @@ export type ListFilesV1ConversationsConversationIdFilesGetResponse = Array<ListF
 export type UpdateFileV1ConversationsConversationIdFilesFileIdPutData = {
   conversationId: string;
   fileId: string;
-  requestBody: UpdateFile;
+  requestBody: UpdateFileRequest;
 };
 
-export type UpdateFileV1ConversationsConversationIdFilesFileIdPutResponse = File;
+export type UpdateFileV1ConversationsConversationIdFilesFileIdPutResponse = FilePublic;
 
 export type DeleteFileV1ConversationsConversationIdFilesFileIdDeleteData = {
   conversationId: string;
   fileId: string;
 };
 
-export type DeleteFileV1ConversationsConversationIdFilesFileIdDeleteResponse = DeleteFile;
+export type DeleteFileV1ConversationsConversationIdFilesFileIdDeleteResponse = DeleteFileResponse;
 
 export type GenerateTitleV1ConversationsConversationIdGenerateTitlePostData = {
   conversationId: string;
 };
 
-export type GenerateTitleV1ConversationsConversationIdGenerateTitlePostResponse = GenerateTitle;
+export type GenerateTitleV1ConversationsConversationIdGenerateTitlePostResponse =
+  GenerateTitleResponse;
 
 export type ListToolsV1ToolsGetData = {
   agentId?: string | null;
@@ -768,11 +864,36 @@ export type ListToolsV1ToolsGetData = {
 
 export type ListToolsV1ToolsGetResponse = Array<ManagedTool>;
 
+export type CreateDeploymentV1DeploymentsPostData = {
+  requestBody: DeploymentCreate;
+};
+
+export type CreateDeploymentV1DeploymentsPostResponse = Deployment;
+
 export type ListDeploymentsV1DeploymentsGetData = {
   all?: boolean;
 };
 
 export type ListDeploymentsV1DeploymentsGetResponse = Array<Deployment>;
+
+export type UpdateDeploymentV1DeploymentsDeploymentIdPutData = {
+  deploymentId: string;
+  requestBody: DeploymentUpdate;
+};
+
+export type UpdateDeploymentV1DeploymentsDeploymentIdPutResponse = Deployment;
+
+export type GetDeploymentV1DeploymentsDeploymentIdGetData = {
+  deploymentId: string;
+};
+
+export type GetDeploymentV1DeploymentsDeploymentIdGetResponse = Deployment;
+
+export type DeleteDeploymentV1DeploymentsDeploymentIdDeleteData = {
+  deploymentId: string;
+};
+
+export type DeleteDeploymentV1DeploymentsDeploymentIdDeleteResponse = DeleteDeployment;
 
 export type SetEnvVarsV1DeploymentsNameSetEnvVarsPostData = {
   name: string;
@@ -784,7 +905,7 @@ export type SetEnvVarsV1DeploymentsNameSetEnvVarsPostResponse = unknown;
 export type ListExperimentalFeaturesV1ExperimentalFeaturesGetResponse = unknown;
 
 export type CreateAgentV1AgentsPostData = {
-  requestBody: CreateAgent;
+  requestBody: CreateAgentRequest;
 };
 
 export type CreateAgentV1AgentsPostResponse = AgentPublic;
@@ -796,6 +917,32 @@ export type ListAgentsV1AgentsGetData = {
 
 export type ListAgentsV1AgentsGetResponse = Array<AgentPublic>;
 
+export type ListUserAgentsV1AgentsUserUserIdGetData = {
+  limit?: number;
+  offset?: number;
+  userId: string;
+};
+
+export type ListUserAgentsV1AgentsUserUserIdGetResponse = Array<Agent>;
+
+export type ListOrganizationAgentsV1AgentsOrganizationOrganizationIdGetData = {
+  limit?: number;
+  offset?: number;
+  organizationId: string;
+};
+
+export type ListOrganizationAgentsV1AgentsOrganizationOrganizationIdGetResponse = Array<Agent>;
+
+export type ListOrganizationUserAgentsV1AgentsOrganizationOrganizationIdUserUserIdGetData = {
+  limit?: number;
+  offset?: number;
+  organizationId: string;
+  userId: string;
+};
+
+export type ListOrganizationUserAgentsV1AgentsOrganizationOrganizationIdUserUserIdGetResponse =
+  Array<Agent>;
+
 export type GetAgentByIdV1AgentsAgentIdGetData = {
   agentId: string;
 };
@@ -804,7 +951,7 @@ export type GetAgentByIdV1AgentsAgentIdGetResponse = Agent;
 
 export type UpdateAgentV1AgentsAgentIdPutData = {
   agentId: string;
-  requestBody: UpdateAgent;
+  requestBody: UpdateAgentRequest;
 };
 
 export type UpdateAgentV1AgentsAgentIdPutResponse = AgentPublic;
@@ -815,6 +962,12 @@ export type DeleteAgentV1AgentsAgentIdDeleteData = {
 
 export type DeleteAgentV1AgentsAgentIdDeleteResponse = DeleteAgent;
 
+export type GetAgentDeploymentsV1AgentsAgentIdDeploymentsGetData = {
+  agentId: string;
+};
+
+export type GetAgentDeploymentsV1AgentsAgentIdDeploymentsGetResponse = Array<Deployment>;
+
 export type ListAgentToolMetadataV1AgentsAgentIdToolMetadataGetData = {
   agentId: string;
 };
@@ -824,7 +977,7 @@ export type ListAgentToolMetadataV1AgentsAgentIdToolMetadataGetResponse =
 
 export type CreateAgentToolMetadataV1AgentsAgentIdToolMetadataPostData = {
   agentId: string;
-  requestBody: CreateAgentToolMetadata;
+  requestBody: CreateAgentToolMetadataRequest;
 };
 
 export type CreateAgentToolMetadataV1AgentsAgentIdToolMetadataPostResponse =
@@ -833,7 +986,7 @@ export type CreateAgentToolMetadataV1AgentsAgentIdToolMetadataPostResponse =
 export type UpdateAgentToolMetadataV1AgentsAgentIdToolMetadataAgentToolMetadataIdPutData = {
   agentId: string;
   agentToolMetadataId: string;
-  requestBody: UpdateAgentToolMetadata;
+  requestBody: UpdateAgentToolMetadataRequest;
 };
 
 export type UpdateAgentToolMetadataV1AgentsAgentIdToolMetadataAgentToolMetadataIdPutResponse =
@@ -852,7 +1005,7 @@ export type GetDefaultAgentV1DefaultAgentGetResponse = GenericResponseMessage;
 export type ListSnapshotsV1SnapshotsGetResponse = Array<SnapshotWithLinks>;
 
 export type CreateSnapshotV1SnapshotsPostData = {
-  requestBody: CreateSnapshot;
+  requestBody: CreateSnapshotRequest;
 };
 
 export type CreateSnapshotV1SnapshotsPostResponse = CreateSnapshotResponse;
@@ -861,19 +1014,78 @@ export type GetSnapshotV1SnapshotsLinkLinkIdGetData = {
   linkId: string;
 };
 
-export type GetSnapshotV1SnapshotsLinkLinkIdGetResponse = Snapshot;
+export type GetSnapshotV1SnapshotsLinkLinkIdGetResponse = SnapshotPublic;
 
 export type DeleteSnapshotLinkV1SnapshotsLinkLinkIdDeleteData = {
   linkId: string;
 };
 
-export type DeleteSnapshotLinkV1SnapshotsLinkLinkIdDeleteResponse = unknown;
+export type DeleteSnapshotLinkV1SnapshotsLinkLinkIdDeleteResponse = DeleteSnapshotLinkResponse;
 
 export type DeleteSnapshotV1SnapshotsSnapshotIdDeleteData = {
   snapshotId: string;
 };
 
-export type DeleteSnapshotV1SnapshotsSnapshotIdDeleteResponse = unknown;
+export type DeleteSnapshotV1SnapshotsSnapshotIdDeleteResponse = DeleteSnapshotResponse;
+
+export type ListOrganizationsV1OrganizationsGetResponse = Array<Organization>;
+
+export type CreateOrganizationV1OrganizationsPostData = {
+  requestBody: CreateOrganization;
+};
+
+export type CreateOrganizationV1OrganizationsPostResponse = Organization;
+
+export type UpdateOrganizationV1OrganizationsOrganizationIdPutData = {
+  organizationId: string;
+  requestBody: UpdateOrganization;
+};
+
+export type UpdateOrganizationV1OrganizationsOrganizationIdPutResponse = Organization;
+
+export type GetOrganizationV1OrganizationsOrganizationIdGetData = {
+  organizationId: string;
+};
+
+export type GetOrganizationV1OrganizationsOrganizationIdGetResponse = Organization;
+
+export type DeleteOrganizationV1OrganizationsOrganizationIdDeleteData = {
+  organizationId: string;
+};
+
+export type DeleteOrganizationV1OrganizationsOrganizationIdDeleteResponse = DeleteOrganization;
+
+export type CreateModelV1ModelsPostData = {
+  requestBody: ModelCreate;
+};
+
+export type CreateModelV1ModelsPostResponse = Model;
+
+export type ListModelsV1ModelsGetData = {
+  limit?: number;
+  offset?: number;
+};
+
+export type ListModelsV1ModelsGetResponse = Array<Model>;
+
+export type UpdateModelV1ModelsModelIdPutData = {
+  modelId: string;
+  requestBody: ModelUpdate;
+};
+
+export type UpdateModelV1ModelsModelIdPutResponse = Model;
+
+export type GetModelV1ModelsModelIdGetData = {
+  modelId: string;
+};
+
+export type GetModelV1ModelsModelIdGetResponse = Model;
+
+export type DeleteModelV1ModelsModelIdDeleteData = {
+  modelId: string;
+};
+
+export type DeleteModelV1ModelsModelIdDeleteResponse = DeleteModel;
 
 export type HealthHealthGetResponse = unknown;
 
@@ -1061,7 +1273,7 @@ export type $OpenApiTs = {
         /**
          * Successful Response
          */
-        200: Conversation;
+        200: ConversationPublic;
         /**
          * Validation Error
          */
@@ -1074,7 +1286,7 @@ export type $OpenApiTs = {
         /**
          * Successful Response
          */
-        200: Conversation;
+        200: ConversationPublic;
         /**
          * Validation Error
          */
@@ -1087,7 +1299,7 @@ export type $OpenApiTs = {
         /**
          * Successful Response
          */
-        200: DeleteConversation;
+        200: DeleteConversationResponse;
         /**
          * Validation Error
          */
@@ -1132,7 +1344,7 @@ export type $OpenApiTs = {
         /**
          * Successful Response
          */
-        200: UploadFile;
+        200: UploadFileResponse;
         /**
          * Validation Error
          */
@@ -1147,7 +1359,7 @@ export type $OpenApiTs = {
         /**
          * Successful Response
          */
-        200: Array<UploadFile>;
+        200: Array<UploadFileResponse>;
         /**
          * Validation Error
          */
@@ -1177,7 +1389,7 @@ export type $OpenApiTs = {
         /**
          * Successful Response
          */
-        200: File;
+        200: FilePublic;
         /**
          * Validation Error
          */
@@ -1190,7 +1402,7 @@ export type $OpenApiTs = {
         /**
          * Successful Response
          */
-        200: DeleteFile;
+        200: DeleteFileResponse;
         /**
          * Validation Error
          */
@@ -1205,7 +1417,7 @@ export type $OpenApiTs = {
         /**
          * Successful Response
          */
-        200: GenerateTitle;
+        200: GenerateTitleResponse;
         /**
          * Validation Error
          */
@@ -1229,6 +1441,19 @@ export type $OpenApiTs = {
     };
   };
   '/v1/deployments': {
+    post: {
+      req: CreateDeploymentV1DeploymentsPostData;
+      res: {
+        /**
+         * Successful Response
+         */
+        200: Deployment;
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError;
+      };
+    };
     get: {
       req: ListDeploymentsV1DeploymentsGetData;
       res: {
@@ -1236,6 +1461,47 @@ export type $OpenApiTs = {
          * Successful Response
          */
         200: Array<Deployment>;
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError;
+      };
+    };
+  };
+  '/v1/deployments/{deployment_id}': {
+    put: {
+      req: UpdateDeploymentV1DeploymentsDeploymentIdPutData;
+      res: {
+        /**
+         * Successful Response
+         */
+        200: Deployment;
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError;
+      };
+    };
+    get: {
+      req: GetDeploymentV1DeploymentsDeploymentIdGetData;
+      res: {
+        /**
+         * Successful Response
+         */
+        200: Deployment;
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError;
+      };
+    };
+    delete: {
+      req: DeleteDeploymentV1DeploymentsDeploymentIdDeleteData;
+      res: {
+        /**
+         * Successful Response
+         */
+        200: DeleteDeployment;
         /**
          * Validation Error
          */
@@ -1296,6 +1562,51 @@ export type $OpenApiTs = {
       };
     };
   };
+  '/v1/agents/user/{user_id}': {
+    get: {
+      req: ListUserAgentsV1AgentsUserUserIdGetData;
+      res: {
+        /**
+         * Successful Response
+         */
+        200: Array<Agent>;
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError;
+      };
+    };
+  };
+  '/v1/agents/organization/{organization_id}': {
+    get: {
+      req: ListOrganizationAgentsV1AgentsOrganizationOrganizationIdGetData;
+      res: {
+        /**
+         * Successful Response
+         */
+        200: Array<Agent>;
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError;
+      };
+    };
+  };
+  '/v1/agents/organization/{organization_id}/user/{user_id}': {
+    get: {
+      req: ListOrganizationUserAgentsV1AgentsOrganizationOrganizationIdUserUserIdGetData;
+      res: {
+        /**
+         * Successful Response
+         */
+        200: Array<Agent>;
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError;
+      };
+    };
+  };
   '/v1/agents/{agent_id}': {
     get: {
       req: GetAgentByIdV1AgentsAgentIdGetData;
@@ -1330,6 +1641,21 @@ export type $OpenApiTs = {
          * Successful Response
          */
         200: DeleteAgent;
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError;
+      };
+    };
+  };
+  '/v1/agents/{agent_id}/deployments': {
+    get: {
+      req: GetAgentDeploymentsV1AgentsAgentIdDeploymentsGetData;
+      res: {
+        /**
+         * Successful Response
+         */
+        200: Array<Deployment>;
         /**
          * Validation Error
          */
@@ -1433,7 +1759,7 @@ export type $OpenApiTs = {
         /**
          * Successful Response
          */
-        200: Snapshot;
+        200: SnapshotPublic;
         /**
          * Validation Error
          */
@@ -1446,7 +1772,7 @@ export type $OpenApiTs = {
         /**
          * Successful Response
          */
-        200: unknown;
+        200: DeleteSnapshotLinkResponse;
         /**
          * Validation Error
          */
@@ -1461,7 +1787,140 @@ export type $OpenApiTs = {
         /**
          * Successful Response
          */
-        200: unknown;
+        200: DeleteSnapshotResponse;
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError;
+      };
+    };
+  };
+  '/v1/organizations': {
+    get: {
+      res: {
+        /**
+         * Successful Response
+         */
+        200: Array<Organization>;
+      };
+    };
+    post: {
+      req: CreateOrganizationV1OrganizationsPostData;
+      res: {
+        /**
+         * Successful Response
+         */
+        200: Organization;
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError;
+      };
+    };
+  };
+  '/v1/organizations/{organization_id}': {
+    put: {
+      req: UpdateOrganizationV1OrganizationsOrganizationIdPutData;
+      res: {
+        /**
+         * Successful Response
+         */
+        200: Organization;
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError;
+      };
+    };
+    get: {
+      req: GetOrganizationV1OrganizationsOrganizationIdGetData;
+      res: {
+        /**
+         * Successful Response
+         */
+        200: Organization;
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError;
+      };
+    };
+    delete: {
+      req: DeleteOrganizationV1OrganizationsOrganizationIdDeleteData;
+      res: {
+        /**
+         * Successful Response
+         */
+        200: DeleteOrganization;
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError;
+      };
+    };
+  };
+  '/v1/models': {
+    post: {
+      req: CreateModelV1ModelsPostData;
+      res: {
+        /**
+         * Successful Response
+         */
+        200: Model;
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError;
+      };
+    };
+    get: {
+      req: ListModelsV1ModelsGetData;
+      res: {
+        /**
+         * Successful Response
+         */
+        200: Array<Model>;
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError;
+      };
+    };
+  };
+  '/v1/models/{model_id}': {
+    put: {
+      req: UpdateModelV1ModelsModelIdPutData;
+      res: {
+        /**
+         * Successful Response
+         */
+        200: Model;
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError;
+      };
+    };
+    get: {
+      req: GetModelV1ModelsModelIdGetData;
+      res: {
+        /**
+         * Successful Response
+         */
+        200: Model;
+        /**
+         * Validation Error
+         */
+        422: HTTPValidationError;
+      };
+    };
+    delete: {
+      req: DeleteModelV1ModelsModelIdDeleteData;
+      res: {
+        /**
+         * Successful Response
+         */
+        200: DeleteModel;
         /**
          * Validation Error
          */

--- a/src/interfaces/assistants_web/src/components/Agents/AgentSettings/AgentSettingsForm.tsx
+++ b/src/interfaces/assistants_web/src/components/Agents/AgentSettings/AgentSettingsForm.tsx
@@ -4,7 +4,7 @@ import { uniqBy } from 'lodash';
 import { useSearchParams } from 'next/navigation';
 import { useEffect, useState } from 'react';
 
-import { CreateAgent, UpdateAgent } from '@/cohere-client';
+import { CreateAgentRequest, UpdateAgentRequest } from '@/cohere-client';
 import { DataSourcesStep } from '@/components/Agents/AgentSettings/DataSourcesStep';
 import { DefineAssistantStep } from '@/components/Agents/AgentSettings/DefineStep';
 import { ToolsStep } from '@/components/Agents/AgentSettings/ToolsStep';
@@ -24,7 +24,8 @@ type RequiredAndNotNull<T> = {
 type RequireAndNotNullSome<T, K extends keyof T> = RequiredAndNotNull<Pick<T, K>> & Omit<T, K>;
 
 export type AgentSettingsFields = RequireAndNotNullSome<
-  Omit<UpdateAgent, 'version' | 'temperature'> | Omit<CreateAgent, 'version' | 'temperature'>,
+  | Omit<UpdateAgentRequest, 'version' | 'temperature'>
+  | Omit<CreateAgentRequest, 'version' | 'temperature'>,
   'name' | 'model' | 'deployment'
 >;
 

--- a/src/interfaces/assistants_web/src/components/Agents/DiscoverAgents.tsx
+++ b/src/interfaces/assistants_web/src/components/Agents/DiscoverAgents.tsx
@@ -2,7 +2,7 @@
 
 import { PropsWithChildren, useDeferredValue, useState } from 'react';
 
-import { Agent, ConversationWithoutMessages } from '@/cohere-client';
+import { AgentPublic, ConversationWithoutMessages } from '@/cohere-client';
 import { DiscoverAgentCard } from '@/components/Agents/DiscoverAgentCard';
 import { Button, Icon, Input, Tabs, Text, Tooltip } from '@/components/Shared';
 import { useListAgents } from '@/hooks/agents';
@@ -20,12 +20,12 @@ const tabs = [
   </div>,
 ];
 
-const BASE_AGENTS: Array<Agent & { isBaseAgent: boolean }> = [
+const BASE_AGENTS: Array<AgentPublic & { isBaseAgent: boolean }> = [
   {
     id: '',
+    deployments: [],
     name: 'Command R+',
     description: 'Review, understand and ask questions about internal financial documents.',
-    user_id: 'xxxx',
     created_at: '2021-09-01T00:00:00Z',
     updated_at: '2021-09-01T00:00:00Z',
     preamble: '',
@@ -88,7 +88,7 @@ const Wrapper: React.FC<PropsWithChildren> = ({ children }) => (
   <div className="max-w-screen-xl flex-grow overflow-y-auto py-10">{children}</div>
 );
 
-const GroupAgents: React.FC<{ agents: Agent[]; title: string; subTitle: string }> = ({
+const GroupAgents: React.FC<{ agents: AgentPublic[]; title: string; subTitle: string }> = ({
   agents,
   title,
   subTitle,
@@ -131,7 +131,7 @@ const GroupAgents: React.FC<{ agents: Agent[]; title: string; subTitle: string }
 };
 
 const CompanyAgents: React.FC<{
-  agents: Agent[];
+  agents: AgentPublic[];
   conversations: ConversationWithoutMessages[];
 }> = ({ agents, conversations }) => {
   const [query, setQuery] = useState('');
@@ -164,7 +164,7 @@ const CompanyAgents: React.FC<{
     }
     return acc;
   }, {} as Record<string, number>);
-  const trendingAgents: Agent[] = Object.keys(mostUsedAgents)
+  const trendingAgents: AgentPublic[] = Object.keys(mostUsedAgents)
     .sort((a, b) => mostUsedAgents[b] - mostUsedAgents[a])
     .map((id) => filteredAgents.find((a) => a.id === id))
     .filter((agent) => !!agent);
@@ -207,6 +207,6 @@ const CompanyAgents: React.FC<{
   );
 };
 
-const PrivateAgents: React.FC<{ agents: Agent[] }> = () => {
+const PrivateAgents: React.FC<{ agents: AgentPublic[] }> = () => {
   return <Wrapper>tbd</Wrapper>;
 };

--- a/src/interfaces/assistants_web/src/components/Agents/UpdateAgent.tsx
+++ b/src/interfaces/assistants_web/src/components/Agents/UpdateAgent.tsx
@@ -10,6 +10,7 @@ import {
 } from '@/components/Agents/AgentSettings/AgentSettingsForm';
 import { DeleteAgent } from '@/components/Agents/DeleteAgent';
 import { Button, Icon, Spinner, Text } from '@/components/Shared';
+import { DEFAULT_AGENT_MODEL, DEPLOYMENT_COHERE_PLATFORM } from '@/constants';
 import { useContextStore } from '@/context';
 import { useAgent, useIsAgentNameUnique, useUpdateAgent } from '@/hooks/agents';
 import { useNotify } from '@/hooks/toast';
@@ -41,8 +42,8 @@ export const UpdateAgent: React.FC<Props> = ({ agentId }) => {
       setFields({
         name: agent.name,
         description: agent.description,
-        deployment: agent.deployment,
-        model: agent.model,
+        deployment: agent.deployment ?? DEPLOYMENT_COHERE_PLATFORM,
+        model: agent.model ?? DEFAULT_AGENT_MODEL,
         tools: agent.tools,
         preamble: agent.preamble,
         tools_metadata: agent.tools_metadata,

--- a/src/interfaces/assistants_web/src/components/Conversation/Composer/DragDropFileUploadOverlay.tsx
+++ b/src/interfaces/assistants_web/src/components/Conversation/Composer/DragDropFileUploadOverlay.tsx
@@ -4,8 +4,8 @@ import React from 'react';
 
 import { DragDropFileInput } from '@/components/Shared';
 import { ACCEPTED_FILE_TYPES } from '@/constants';
-import { cn } from '@/utils';
 import { useFocusFileInput } from '@/hooks/actions';
+import { cn } from '@/utils';
 
 export const DragDropFileUploadOverlay: React.FC<{
   active: boolean;
@@ -14,7 +14,7 @@ export const DragDropFileUploadOverlay: React.FC<{
   const { focusFileInput } = useFocusFileInput();
 
   const handleUploadFile = async (files: File[]) => {
-      focusFileInput();
+    focusFileInput();
     onUploadFile(files);
   };
 

--- a/src/interfaces/assistants_web/src/components/ConversationList/ConversationCard.tsx
+++ b/src/interfaces/assistants_web/src/components/ConversationList/ConversationCard.tsx
@@ -2,7 +2,7 @@
 
 import Link from 'next/link';
 
-import { Agent } from '@/cohere-client';
+import { AgentPublic } from '@/cohere-client';
 import { KebabMenu, KebabMenuItem } from '@/components/KebabMenu';
 import { ShareModal } from '@/components/ShareModal';
 import { CoralLogo, Text, Tooltip } from '@/components/Shared';
@@ -20,7 +20,7 @@ export type ConversationListItem = {
   title: string;
   description: string | null;
   weekHeading?: string;
-  agent?: Agent;
+  agent?: AgentPublic;
 };
 
 type Props = {

--- a/src/interfaces/assistants_web/src/components/EditEnvVariablesButton.tsx
+++ b/src/interfaces/assistants_web/src/components/EditEnvVariablesButton.tsx
@@ -36,7 +36,7 @@ export const EditEnvVariablesModal: React.FC<{
   const [envVariables, setEnvVariables] = useState<Record<string, string>>(() => {
     const selectedDeployment = deployments?.find(({ name }) => name === defaultDeployment);
     return (
-      selectedDeployment?.env_vars.reduce<Record<string, string>>((acc, envVar) => {
+      selectedDeployment?.env_vars?.reduce<Record<string, string>>((acc, envVar) => {
         acc[envVar] = '';
         return acc;
       }, {}) ?? {}
@@ -60,7 +60,7 @@ export const EditEnvVariablesModal: React.FC<{
     setDeployment(newDeployment);
     const selectedDeployment = deployments?.find(({ name }) => name === newDeployment);
     const emptyEnvVariables =
-      selectedDeployment?.env_vars.reduce<Record<string, string>>((acc, envVar) => {
+      selectedDeployment?.env_vars?.reduce<Record<string, string>>((acc, envVar) => {
         acc[envVar] = '';
         return acc;
       }, {}) ?? {};

--- a/src/interfaces/assistants_web/src/hooks/agents.ts
+++ b/src/interfaces/assistants_web/src/hooks/agents.ts
@@ -2,7 +2,13 @@ import { useLocalStorageValue } from '@react-hookz/web';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useMemo } from 'react';
 
-import { Agent, ApiError, CreateAgent, UpdateAgent, useCohereClient } from '@/cohere-client';
+import {
+  AgentPublic,
+  ApiError,
+  CreateAgentRequest,
+  UpdateAgentRequest,
+  useCohereClient,
+} from '@/cohere-client';
 import { LOCAL_STORAGE_KEYS } from '@/constants';
 
 export const useListAgents = () => {
@@ -17,7 +23,7 @@ export const useCreateAgent = () => {
   const cohereClient = useCohereClient();
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: (request: CreateAgent) => cohereClient.createAgent(request),
+    mutationFn: (request: CreateAgentRequest) => cohereClient.createAgent(request),
     onSettled: () => {
       queryClient.invalidateQueries({ queryKey: ['listAgents'] });
     },
@@ -85,7 +91,7 @@ export const useIsAgentNameUnique = () => {
 export const useUpdateAgent = () => {
   const cohereClient = useCohereClient();
   const queryClient = useQueryClient();
-  return useMutation<Agent, ApiError, { request: UpdateAgent; agentId: string }>({
+  return useMutation<AgentPublic, ApiError, { request: UpdateAgentRequest; agentId: string }>({
     mutationFn: ({ request, agentId }) => cohereClient.updateAgent(request, agentId),
     onSettled: (agent) => {
       queryClient.invalidateQueries({ queryKey: ['agent', agent?.id] });
@@ -114,7 +120,7 @@ export const useRecentAgents = () => {
     set(recentAgentsIds.filter((id) => id !== agentId));
   };
 
-  const recentAgents = useMemo<Agent[]>(() => {
+  const recentAgents = useMemo<AgentPublic[]>(() => {
     if (!recentAgentsIds) return [];
     return recentAgentsIds
       .map((id) => agents?.find((agent) => agent.id === id))

--- a/src/interfaces/assistants_web/src/hooks/conversation.tsx
+++ b/src/interfaces/assistants_web/src/hooks/conversation.tsx
@@ -3,10 +3,10 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import {
   ApiError,
   CohereNetworkError,
-  Conversation,
+  ConversationPublic,
   ConversationWithoutMessages,
-  DeleteConversation,
-  UpdateConversation,
+  DeleteConversationResponse,
+  UpdateConversationRequest,
   useCohereClient,
 } from '@/cohere-client';
 import { DeleteConversations } from '@/components/Modals/DeleteConversations';
@@ -38,7 +38,7 @@ export const useConversation = ({
 }) => {
   const client = useCohereClient();
 
-  return useQuery<Conversation | undefined, Error>({
+  return useQuery<ConversationPublic | undefined, Error>({
     queryKey: ['conversation', conversationId],
     enabled: !!conversationId && !disabledOnMount,
     queryFn: async () => {
@@ -63,9 +63,9 @@ export const useEditConversation = () => {
   const client = useCohereClient();
   const queryClient = useQueryClient();
   return useMutation<
-    Conversation,
+    ConversationPublic,
     CohereNetworkError,
-    { request: UpdateConversation; conversationId: string }
+    { request: UpdateConversationRequest; conversationId: string }
   >({
     mutationFn: ({ request, conversationId }) => client.editConversation(request, conversationId),
     onSettled: () => {
@@ -77,11 +77,11 @@ export const useEditConversation = () => {
 export const useDeleteConversation = () => {
   const client = useCohereClient();
   const queryClient = useQueryClient();
-  return useMutation<DeleteConversation, CohereNetworkError, { conversationId: string }>({
+  return useMutation<DeleteConversationResponse, CohereNetworkError, { conversationId: string }>({
     mutationFn: ({ conversationId }: { conversationId: string }) =>
       client.deleteConversation({ conversationId }),
     onSettled: (_, _err, { conversationId }: { conversationId: string }) => {
-      queryClient.setQueriesData<Conversation[]>(
+      queryClient.setQueriesData<ConversationPublic[]>(
         { queryKey: ['conversations'] },
         (oldConversations) => {
           return oldConversations?.filter((c) => c.id === conversationId);

--- a/src/interfaces/assistants_web/src/hooks/files.ts
+++ b/src/interfaces/assistants_web/src/hooks/files.ts
@@ -1,6 +1,6 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
-import { ApiError, DeleteFile, ListFile, useCohereClient } from '@/cohere-client';
+import { ApiError, DeleteFileResponse, ListFile, useCohereClient } from '@/cohere-client';
 import { ACCEPTED_FILE_TYPES, MAX_NUM_FILES_PER_UPLOAD_BATCH } from '@/constants';
 import { useNotify } from '@/hooks/toast';
 import { useFilesStore, useParamsStore } from '@/stores';
@@ -47,7 +47,7 @@ export const useDeleteUploadedFile = () => {
   const cohereClient = useCohereClient();
   const queryClient = useQueryClient();
 
-  return useMutation<DeleteFile, ApiError, { conversationId: string; fileId: string }>({
+  return useMutation<DeleteFileResponse, ApiError, { conversationId: string; fileId: string }>({
     mutationFn: async ({ conversationId, fileId }) =>
       cohereClient.deletefile({ conversationId, fileId }),
     onSettled: () => {

--- a/src/interfaces/assistants_web/src/hooks/generateTitle.ts
+++ b/src/interfaces/assistants_web/src/hooks/generateTitle.ts
@@ -1,11 +1,11 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
-import { GenerateTitle, useCohereClient } from '@/cohere-client';
+import { GenerateTitleResponse, useCohereClient } from '@/cohere-client';
 
 export const useUpdateConversationTitle = () => {
   const cohereClient = useCohereClient();
   const queryClient = useQueryClient();
-  return useMutation<GenerateTitle, Error, string>({
+  return useMutation<GenerateTitleResponse, Error, string>({
     mutationFn: (conversationId) => cohereClient.generateTitle({ conversationId }),
     onSettled: () => queryClient.invalidateQueries({ queryKey: ['conversations'] }),
     retry: 1,

--- a/src/interfaces/assistants_web/src/hooks/snapshots.ts
+++ b/src/interfaces/assistants_web/src/hooks/snapshots.ts
@@ -3,14 +3,14 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import {
   GetSnapshotV1SnapshotsLinkLinkIdGetResponse,
   ListSnapshotsV1SnapshotsGetResponse,
-  Snapshot,
   SnapshotData,
+  SnapshotPublic,
   useCohereClient,
 } from '@/cohere-client';
 import { ChatMessage } from '@/types/message';
 
 type FormattedSnapshotData = Omit<SnapshotData, 'messages'> & { messages?: ChatMessage[] };
-export type ChatSnapshot = Omit<Snapshot, 'snapshot'> & { snapshot: FormattedSnapshotData };
+export type ChatSnapshot = Omit<SnapshotPublic, 'snapshot'> & { snapshot: FormattedSnapshotData };
 export type ChatSnapshotWithLinks = ChatSnapshot & { links: string[] };
 
 /**

--- a/src/interfaces/assistants_web/src/hooks/streamChat.ts
+++ b/src/interfaces/assistants_web/src/hooks/streamChat.ts
@@ -6,7 +6,7 @@ import {
   ChatResponseEvent as ChatResponse,
   CohereChatRequest,
   CohereNetworkError,
-  Conversation,
+  ConversationPublic as Conversation,
   FinishReason,
   StreamEnd,
   StreamEvent,

--- a/src/interfaces/assistants_web/src/stores/slices/citationsSlice.ts
+++ b/src/interfaces/assistants_web/src/stores/slices/citationsSlice.ts
@@ -11,14 +11,6 @@ const INITIAL_STATE: State = {
   outputFiles: {},
 };
 
-type Citation = {
-  generationId: string;
-  start: string;
-  end: string;
-  /** Used to scroll to highlight position */
-  yPosition: number | null;
-};
-
 type CitationReferences = {
   [generationId: string]: {
     /** In the format: {startIndex}-{endIndex} */

--- a/src/interfaces/assistants_web/src/stores/slices/filesSlice.ts
+++ b/src/interfaces/assistants_web/src/stores/slices/filesSlice.ts
@@ -1,6 +1,6 @@
 import { StateCreator } from 'zustand';
 
-import { File as CohereFile } from '@/cohere-client';
+import { FilePublic as CohereFile } from '@/cohere-client';
 
 import { StoreState } from '..';
 

--- a/src/interfaces/assistants_web/src/types/message.ts
+++ b/src/interfaces/assistants_web/src/types/message.ts
@@ -1,4 +1,4 @@
-import { Citation, File, StreamToolCallsGeneration, StreamToolInput } from '@/cohere-client';
+import { Citation, FilePublic, StreamToolCallsGeneration, StreamToolInput } from '@/cohere-client';
 
 export enum BotState {
   LOADING = 'loading',
@@ -84,7 +84,7 @@ export type ErrorMessage = BaseMessage & {
  */
 export type UserMessage = BaseMessage & {
   type: MessageType.USER;
-  files?: File[];
+  files?: FilePublic[];
 };
 
 export type ChatMessage = UserMessage | BotMessage;


### PR DESCRIPTION
Updates the OpenAPI schema


**AI Description**

<!-- begin-generated-description -->

This pull request makes changes to the agent and conversation data models and their respective components. It also adds new features and fixes to the Cohere client.

- **Agent data model changes**:
  - Added deployments and model as optional fields.
  - Changed deployment and tools_metadata to optional fields.
  - Added created_at and updated_at fields to AgentToolMetadata.

- **Conversation data model changes**:
  - Removed user_id and organization_id fields.

- **Cohere client changes**:
  - Added CreateDeployment, UpdateDeployment, and DeleteDeployment methods.
  - Added CreateOrganization, UpdateOrganization, and DeleteOrganization methods.
  - Added CreateModel, UpdateModel, and DeleteModel methods.
  - Added ListModels and ListOrganizations methods.
  - Added ListUserAgents, ListOrganizationAgents, and ListOrganizationUserAgents methods.
  - Added GetAgentDeployments method.

- **Component changes**:
  - Updated AgentSettingsForm to use the new CreateAgentRequest and UpdateAgentRequest types.
  - Updated DiscoverAgents to use the new AgentPublic type.
  - Updated UpdateAgent to use the new UpdateAgentRequest type and set default values for deployment and model.
  - Updated ConversationCard to use the new AgentPublic type.
  - Updated EditEnvVariablesModal to handle optional env_vars field.

- **Other changes**:
  - Updated Chat.tsx to fix an issue with the agentTools variable.
  - Updated services.gen.ts to include ctx as a parameter for the login method.
  - Updated types.gen.ts to reflect the changes in the data models.

<!-- end-generated-description -->
