### PR TITLE
chore(helm): do not set probes by default

### DIFF
--- a/charts/cohere-toolkit/values.yaml
+++ b/charts/cohere-toolkit/values.yaml
@@ -89,15 +89,15 @@ backend:
     targetCPUUtilizationPercentage: 80
     # targetMemoryUtilizationPercentage: 80
 
-  livenessProbe:
-    httpGet:
-      path: "/health"
-      port: http
-
-  readinessProbe:
-    httpGet:
-      path: "/health"
-      port: http
+#  livenessProbe:
+#    httpGet:
+#      path: "/health"
+#      port: http
+#
+#  readinessProbe:
+#    httpGet:
+#      path: "/health"
+#      port: http
 
   nodeSelector: {}
 
@@ -162,15 +162,15 @@ frontend:
     targetCPUUtilizationPercentage: 80
     targetMemoryUtilizationPercentage: 80
 
-  livenessProbe:
-    httpGet:
-      path: "/"
-      port: http
-
-  readinessProbe:
-    httpGet:
-      path: "/"
-      port: http
+#  livenessProbe:
+#    httpGet:
+#      path: "/"
+#      port: http
+#
+#  readinessProbe:
+#    httpGet:
+#      path: "/"
+#      port: http
 
   nodeSelector: {}
 
@@ -237,15 +237,15 @@ terrarium:
     targetCPUUtilizationPercentage: 80
     targetMemoryUtilizationPercentage: 80
 
-  livenessProbe:
-    httpGet:
-      path: "/health"
-      port: http
+#  livenessProbe:
+#    httpGet:
+#      path: "/health"
+#      port: http
 
-  readinessProbe:
-    httpGet:
-      path: "/health"
-      port: http
+#  readinessProbe:
+#    httpGet:
+#      path: "/health"
+#      port: http
 
   nodeSelector: { }
 


### PR DESCRIPTION
Thank you for contributing to the Cohere Toolkit!

- [ ] **PR title**: "area: description"
  - Where "area" is whichever of interface, frontend, model, tools, backend, etc. is being modified. Use "docs: ..." for purely docs changes, "infra: ..." for CI changes.
  - Example: "deployment: add Azure model option"


- [ ] **PR message**: ***Delete this entire checklist*** and replace with
    - **Description:** a description of the change
    - **Issue:** the issue # it fixes, if applicable
    - **Dependencies:** any dependencies required for this change


- [ ] **Add tests and docs**: Please include testing and documentation for your changes
- [ ] **Lint and test**: Run `make lint` and `make run-tests`

**AI Description**

<!-- begin-generated-description -->

This pull request makes changes to the `charts/cohere-toolkit/values.yaml` file.

- The `livenessProbe` and `readinessProbe` configurations for the `backend`, `frontend`, and `terrarium` sections have been commented out.
- The `path` and `port` settings for the `httpGet` requests within these probes have been removed.

The impact of these changes is to disable the health checks for the specified components, which may be useful if an alternative method for health monitoring is being implemented or if the probes are causing issues in the current setup.

<!-- end-generated-description -->
