### PR TITLE
fix(toolkit): dark mode for iframe artifact

### DIFF
--- a/src/interfaces/assistants_web/src/components/Agents/AgentRightPanel.tsx
+++ b/src/interfaces/assistants_web/src/components/Agents/AgentRightPanel.tsx
@@ -11,6 +11,7 @@ import { useAgent } from '@/hooks/agents';
 import { useBrandedColors } from '@/hooks/brandedColors';
 import { useChatRoutes } from '@/hooks/chatRoutes';
 import { useFileActions, useListFiles } from '@/hooks/files';
+import { useSession } from '@/hooks/session';
 import { useParamsStore, useSettingsStore } from '@/stores';
 import { DataSourceArtifact } from '@/types/tools';
 import { pluralize } from '@/utils';
@@ -29,7 +30,7 @@ const AgentRightPanel: React.FC<Props> = () => {
     params: { fileIds },
     setParams,
   } = useParamsStore();
-
+  const session = useSession();
   const { data: files } = useListFiles(conversationId);
   const { deleteFile } = useFileActions();
 
@@ -123,7 +124,7 @@ const AgentRightPanel: React.FC<Props> = () => {
               leaveTo="opacity-0 scale-90"
               as="div"
             >
-              {agentKnowledgeFiles.length === 0 ? (
+              {agentKnowledgeFiles.length === 0 && session.userId === agent?.user_id ? (
                 <Banner className="flex flex-col">
                   Add a data source to expand the assistant’s knowledge.
                   <Button

--- a/src/interfaces/assistants_web/src/components/Agents/AgentRightPanel.tsx
+++ b/src/interfaces/assistants_web/src/components/Agents/AgentRightPanel.tsx
@@ -108,11 +108,12 @@ const AgentRightPanel: React.FC<Props> = () => {
                   label="Enables assistant knowledge to provide more accurate responses."
                 />
               </span>
-              <Switch
+              {/* @DEV_NOTE: This is disabled while we add the ability in BE to enable/disable assistant knowledge */}
+              {/* <Switch
                 theme={theme}
                 checked={!disabledAssistantKnowledge.includes(agentId)}
                 onChange={(checked) => setUseAssistantKnowledge(checked, agentId)}
-              />
+              /> */}
             </div>
             <Transition
               show={!disabledAssistantKnowledge.includes(agentId) ?? false}

--- a/src/interfaces/assistants_web/src/components/Conversation/Header.tsx
+++ b/src/interfaces/assistants_web/src/components/Conversation/Header.tsx
@@ -73,7 +73,8 @@ export const Header: React.FC<Props> = ({ agent }) => {
               styleAs="label-sm"
               className={cn(
                 'rounded bg-mushroom-950 px-2  py-1 font-bold uppercase dark:bg-volcanic-200',
-                text
+                text,
+                dark(lightText)
               )}
             >
               {agent.is_private ? 'Private' : 'Public'}

--- a/src/interfaces/assistants_web/src/components/Shared/CodeSnippet/CodeSnippet.tsx
+++ b/src/interfaces/assistants_web/src/components/Shared/CodeSnippet/CodeSnippet.tsx
@@ -65,7 +65,7 @@ export const CodeSnippet: React.FC<Props> = ({
 
   return (
     <div
-      className="group relative h-full w-full cursor-pointer rounded-lg bg-mushroom-900"
+      className="group relative h-full w-full cursor-pointer rounded-lg bg-mushroom-900 dark:bg-volcanic-60"
       onClick={handleCodeSnippetClick}
     >
       <CopyToClipboardButton
@@ -73,7 +73,7 @@ export const CodeSnippet: React.FC<Props> = ({
         value={codeSnippet}
         size="md"
         kind="secondary"
-        className="absolute right-3 top-3 rounded-lg bg-mushroom-800 px-2 py-1 group-hover:bg-mushroom-800"
+        className="absolute right-3 top-3 rounded-lg bg-mushroom-800 px-2 py-1 group-hover:bg-mushroom-800 dark:bg-volcanic-150 dark:group-hover:bg-volcanic-150"
       />
       <SyntaxHighlighter
         showLineNumbers

--- a/src/interfaces/assistants_web/src/components/Shared/Markdown/tags/Iframe.tsx
+++ b/src/interfaces/assistants_web/src/components/Shared/Markdown/tags/Iframe.tsx
@@ -66,7 +66,7 @@ export const Iframe: Component<ComponentPropsWithoutRef<'iframe'> & { 'data-src'
           <iframe
             srcDoc={code}
             ref={iframeRef}
-            className="max-h-[450px] min-h-[450px] w-full overflow-y-auto rounded-lg border border-mushroom-800 bg-white"
+            className="max-h-[450px] min-h-[450px] w-full overflow-y-auto rounded-lg border border-mushroom-800 bg-white dark:border-volcanic-300 dark:bg-volcanic-150"
           />
         </TabPanel>
         <TabPanel>
@@ -78,14 +78,15 @@ export const Iframe: Component<ComponentPropsWithoutRef<'iframe'> & { 'data-src'
           />
         </TabPanel>
       </TabPanels>
-      <TabList className="ml-auto mt-2 flex w-fit gap-x-2 rounded bg-mushroom-900 p-1">
+      <TabList className="ml-auto mt-2 flex w-fit gap-x-2 rounded bg-mushroom-900 p-1 dark:bg-volcanic-200">
         <Tab as={Fragment}>
           {({ selected }) => (
             <button
               className={cn(
-                'w-[60px] rounded p-1 outline-none transition-colors hover:bg-mushroom-800',
+                'w-[60px] rounded p-1 outline-none transition-colors hover:bg-mushroom-800 dark:hover:bg-volcanic-60',
                 {
-                  'bg-mushroom-800 shadow hover:bg-mushroom-800': selected,
+                  'bg-mushroom-800 shadow hover:bg-mushroom-800 dark:bg-volcanic-60 dark:hover:bg-volcanic-60':
+                    selected,
                 }
               )}
             >
@@ -97,9 +98,10 @@ export const Iframe: Component<ComponentPropsWithoutRef<'iframe'> & { 'data-src'
           {({ selected }) => (
             <button
               className={cn(
-                'w-[60px] rounded p-1 outline-none transition-colors hover:bg-mushroom-800',
+                'w-[60px] rounded p-1 outline-none transition-colors hover:bg-mushroom-800 dark:hover:bg-volcanic-60',
                 {
-                  'bg-mushroom-800 shadow hover:bg-mushroom-800': selected,
+                  'bg-mushroom-800 shadow hover:bg-mushroom-800 dark:bg-volcanic-60 dark:hover:bg-volcanic-60':
+                    selected,
                 }
               )}
             >


### PR DESCRIPTION
Fixes background color for the Iframe artifact output.
**AI Description**

<!-- begin-generated-description -->

This pull request updates the `CodeSnippet.tsx` and `Iframe.tsx` components to support a dark theme.

## Changes
- Added `dark:` modifiers to the `className` props in `CodeSnippet.tsx` and `Iframe.tsx` to apply dark theme styles.
- Modified the `className` prop in `Iframe.tsx` to use a darker background color for the `TabList` component.

<!-- end-generated-description -->
