### PR TITLE
backend: rename community llamaindex file reader 

### DIFF
--- a/src/community/config/tools.py
+++ b/src/community/config/tools.py
@@ -64,7 +64,7 @@ COMMUNITY_TOOLS = {
         description="Retrieves documents from Pub Med.",
     ),
     CommunityToolName.File_Upload_LlamaIndex: ManagedTool(
-        display_name="File Reader",
+        display_name="LlamaIndex File Reader",
         implementation=LlamaIndexUploadPDFRetriever,
         is_visible=True,
         is_available=LlamaIndexUploadPDFRetriever.is_available(),


### PR DESCRIPTION
To avoid confusion with the native read documents tool 

**AI Description**

<!-- begin-generated-description -->

This pull request updates the `display_name` of the `CommunityToolName.File_Upload_LlamaIndex` managed tool to "LlamaIndex File Reader" in `src/community/config/tools.py`.

- The `display_name` attribute of the `CommunityToolName.File_Upload_LlamaIndex` managed tool is updated from "File Reader" to "LlamaIndex File Reader".

<!-- end-generated-description -->
