### PR TITLE
fix: use actual conversation_id or undefined

### DIFF
--- a/src/interfaces/assistants_web/src/hooks/chat.ts
+++ b/src/interfaces/assistants_web/src/hooks/chat.ts
@@ -93,7 +93,7 @@ export const useChat = (config?: { onSend?: (msg: string) => void }) => {
   } = useFilesStore();
   const queryClient = useQueryClient();
 
-  const currentConversationId = id || composerFiles[0]?.conversation_id || '';
+  const currentConversationId = id || (composerFiles[0]?.conversation_id ?? undefined);
 
   const [userMessage, setUserMessage] = useState('');
   const [isStreaming, setIsStreaming] = useState(false);


### PR DESCRIPTION
### Description

fix: the `composerFile` is nullable, so if it's null it will fall into empty string
