### PR TITLE
infra: pin version of ruff in github workflow

### DIFF
--- a/.github/workflows/python-lint.yml
+++ b/.github/workflows/python-lint.yml
@@ -14,3 +14,4 @@ jobs:
         uses: chartboost/ruff-action@v1
         with:
           src: './src/'
+          version: 0.6.0


### PR DESCRIPTION
Pins the version to 0.6.0 in the python-lint workflow