### PR TITLE
fix(toolkit): do not highlight citations with no documents

### DIFF
--- a/src/interfaces/assistants_web/src/hooks/tools.ts
+++ b/src/interfaces/assistants_web/src/hooks/tools.ts
@@ -134,6 +134,6 @@ export const useDeleteAuthTool = () => {
     },
     onSettled: () => {
       queryClient.invalidateQueries({ queryKey: ['tools'] });
-    }
+    },
   });
 };

--- a/src/interfaces/assistants_web/src/utils/citations.ts
+++ b/src/interfaces/assistants_web/src/utils/citations.ts
@@ -29,31 +29,33 @@ export const replaceTextWithCitations = (
 
   let lengthDifference = 0; // Track the cumulative length difference
   let notFoundReferences: string[] = [];
-  citations.forEach(({ start = 0, end = 0, text: citationText }, index) => {
-    const citeStart = start + lengthDifference;
-    const citeEnd = end + lengthDifference;
+  citations
+    .filter((citation) => citation.document_ids.length)
+    .forEach(({ start = 0, end = 0, text: citationText }, index) => {
+      const citeStart = start + lengthDifference;
+      const citeEnd = end + lengthDifference;
 
-    // if citeStart is higher than the length of the text, add it to the bottom of the text as "Reference #n"
-    if (start >= text.length || isReferenceBetweenIframes(replacedText, start)) {
-      const ref = `Reference #${index + 1}`;
-      notFoundReferences.push(
-        `:cite[${ref}]{generationId="${generationId}" start="${start}" end="${end}"}`
-      );
-      return;
-    }
+      // if citeStart is higher than the length of the text, add it to the bottom of the text as "Reference #n"
+      if (start >= text.length || isReferenceBetweenIframes(replacedText, start)) {
+        const ref = `Reference #${index + 1}`;
+        notFoundReferences.push(
+          `:cite[${ref}]{generationId="${generationId}" start="${start}" end="${end}"}`
+        );
+        return;
+      }
 
-    const fixedText = fixMarkdownImagesInText(citationText);
+      const fixedText = fixMarkdownImagesInText(citationText);
 
-    // Encode the citationText in case there are any weird characters or unclosed brackets that will
-    // interfere with parsing the markdown. However, let markdown images through so they may be properly
-    // rendered.
-    const isMarkdownImage = fixedText.match(/!\[.*\]\(.*\)/);
-    const encodedCitationText = isMarkdownImage ? fixedText : encodeURIComponent(fixedText);
-    const citationId = `:cite[${encodedCitationText}]{generationId="${generationId}" start="${start}" end="${end}"}`;
+      // Encode the citationText in case there are any weird characters or unclosed brackets that will
+      // interfere with parsing the markdown. However, let markdown images through so they may be properly
+      // rendered.
+      const isMarkdownImage = fixedText.match(/!\[.*\]\(.*\)/);
+      const encodedCitationText = isMarkdownImage ? fixedText : encodeURIComponent(fixedText);
+      const citationId = `:cite[${encodedCitationText}]{generationId="${generationId}" start="${start}" end="${end}"}`;
 
-    replacedText = replacedText.slice(0, citeStart) + citationId + replacedText.slice(citeEnd);
-    lengthDifference += citationId.length - (citeEnd - citeStart);
-  });
+      replacedText = replacedText.slice(0, citeStart) + citationId + replacedText.slice(citeEnd);
+      lengthDifference += citationId.length - (citeEnd - citeStart);
+    });
 
   const references = 'From: ' + formatter.format(notFoundReferences);
   if (notFoundReferences.length > 0) {


### PR DESCRIPTION

**AI Description**

<!-- begin-generated-description -->

The pull request makes changes to the `replaceTextWithCitations` function in the `citations.ts` file. This function is responsible for replacing text with citations and handling references.

Here are the key changes:

- The function now includes a `filter` step before iterating over the `citations`. It filters out citations that do not have any `document_ids`.
- The rest of the function remains largely the same, with minor formatting changes and the addition of comments to explain the purpose of certain code blocks.
- The logic for handling the case where `citeStart` is higher than the length of the text has been retained, adding the reference to the bottom of the text.
- The `fixedText` variable is still assigned the result of calling `fixMarkdownImagesInText` on `citationText`, ensuring that markdown images are handled properly.
- The encoding of `citationText` to handle special characters and unclosed brackets has been kept, along with the construction of the `citationId`.
- The replacement of the text with the `citationId` and the update of `lengthDifference` occur in the same way as before.

<!-- end-generated-description -->
