### PR TITLE
fix(toolkit): integrate redirect URL for tool auth

### DIFF
--- a/src/interfaces/assistants_web/src/components/Agents/AgentSettings/AgentSettingsForm.tsx
+++ b/src/interfaces/assistants_web/src/components/Agents/AgentSettings/AgentSettingsForm.tsx
@@ -16,6 +16,7 @@ import { useIsAgentNameUnique } from '@/hooks/agents';
 import { useListTools, useOpenGoogleDrivePicker } from '@/hooks/tools';
 import { DataSourceArtifact } from '@/types/tools';
 import { cn } from '@/utils';
+import { getToolAuthUrl } from '@/utils/getToolAuthUrl';
 
 type RequiredAndNotNull<T> = {
   [P in keyof T]-?: Exclude<T[P], null | undefined>;
@@ -37,7 +38,6 @@ export type AgentSettingsFields = CreateAgentSettingsFields | UpdateAgentSetting
 
 type BaseProps = {
   fields: AgentSettingsFields;
-  savePendingAssistant: VoidFunction;
   setFields: (fields: AgentSettingsFields) => void;
   onSubmit: VoidFunction;
 };
@@ -54,13 +54,28 @@ type UpdateProps = BaseProps & {
 export type Props = CreateProps | UpdateProps;
 
 export const AgentSettingsForm: React.FC<Props> = (props) => {
-  const { source = 'create', fields, savePendingAssistant, setFields, onSubmit } = props;
+  const { source = 'create', fields, setFields, onSubmit } = props;
   const agentId = 'agentId' in props ? props.agentId : undefined;
 
   const { data: listToolsData, status: listToolsStatus } = useListTools();
   const isAgentNameUnique = useIsAgentNameUnique();
   const params = useSearchParams();
   const defaultStep = params.has('datasources');
+  const defaultState = params.has('state');
+
+  useEffect(() => {
+    if (defaultState) {
+      const state = params.get('state');
+      if (state) {
+        try {
+          const fields = JSON.parse(atob(state));
+          setFields(fields);
+        } catch {
+          console.error('Error parsing state');
+        }
+      }
+    }
+  }, [defaultState, params, setFields]);
 
   const [currentStep, setCurrentStep] = useState<
     'define' | 'dataSources' | 'tools' | 'visibility' | undefined
@@ -143,7 +158,6 @@ export const AgentSettingsForm: React.FC<Props> = (props) => {
   });
 
   const handleGoogleFilePicker = () => {
-    savePendingAssistant();
     const googleDriveTool = listToolsData?.find((t) => t.name === TOOL_GOOGLE_DRIVE_ID);
     if (!googleDriveTool?.is_available) {
       return;
@@ -151,7 +165,15 @@ export const AgentSettingsForm: React.FC<Props> = (props) => {
 
     // If auth is required and token is not present, redirect to auth url
     if (googleDriveTool?.is_auth_required && googleDriveTool.auth_url) {
-      window.open(googleDriveTool.auth_url, '_self');
+      const state = JSON.stringify(fields);
+
+      window.open(
+        getToolAuthUrl(
+          googleDriveTool.auth_url,
+          `${window.location.href}?datasources=1&state=${btoa(state)}`
+        ),
+        '_self'
+      );
     } else {
       openGoogleFilePicker?.();
     }

--- a/src/interfaces/assistants_web/src/components/Agents/CreateAgent.tsx
+++ b/src/interfaces/assistants_web/src/components/Agents/CreateAgent.tsx
@@ -1,10 +1,9 @@
 'use client';
 
-import { useLocalStorageValue } from '@react-hookz/web';
 import { cloneDeep } from 'lodash';
 import Link from 'next/link';
-import { usePathname, useRouter, useSearchParams } from 'next/navigation';
-import React, { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import React, { useState } from 'react';
 
 import {
   AgentSettingsFields,
@@ -36,8 +35,6 @@ const DEFAULT_FIELD_VALUES = {
  */
 export const CreateAgent: React.FC = () => {
   const router = useRouter();
-  const pathname = usePathname();
-  const searchParams = useSearchParams();
   const { open, close } = useContextStore();
 
   const { error } = useNotify();
@@ -45,27 +42,6 @@ export const CreateAgent: React.FC = () => {
 
   const [fields, setFields] = useState<AgentSettingsFields>(cloneDeep(DEFAULT_FIELD_VALUES));
   const [isSubmitting, setIsSubmitting] = useState(false);
-
-  const {
-    value: pendingAssistant,
-    set: setPendingAssistant,
-    remove: removePendingAssistant,
-  } = useLocalStorageValue<AgentSettingsFields>('pending_assistant', {
-    initializeWithValue: false,
-    defaultValue: undefined,
-  });
-
-  const queryString = searchParams.get('p');
-  useEffect(() => {
-    if (queryString) {
-      if (pendingAssistant) {
-        setFields(pendingAssistant);
-        removePendingAssistant();
-      }
-
-      window.history.replaceState(null, '', pathname);
-    }
-  }, [queryString, pendingAssistant]);
 
   const handleOpenSubmitModal = () => {
     if (fields.is_private) {
@@ -91,7 +67,6 @@ export const CreateAgent: React.FC = () => {
       setIsSubmitting(true);
       const agent = await createAgent(fields);
       close();
-      setIsSubmitting(false);
       router.push(`/a/${agent.id}`);
     } catch (e) {
       setIsSubmitting(false);
@@ -121,7 +96,6 @@ export const CreateAgent: React.FC = () => {
             fields={fields}
             setFields={setFields}
             onSubmit={handleOpenSubmitModal}
-            savePendingAssistant={() => setPendingAssistant(fields)}
           />
         </div>
       </div>

--- a/src/interfaces/assistants_web/src/components/Agents/Settings.tsx
+++ b/src/interfaces/assistants_web/src/components/Agents/Settings.tsx
@@ -8,6 +8,7 @@ import { Button, Icon, Tabs, Text } from '@/components/Shared';
 import { useNotify } from '@/hooks/toast';
 import { useDeleteAuthTool, useListTools } from '@/hooks/tools';
 import { cn } from '@/utils';
+import { getToolAuthUrl } from '@/utils/getToolAuthUrl';
 
 const tabs = [
   <div className="flex items-center gap-2" key="company">
@@ -115,7 +116,7 @@ const GoogleDriveConnection = () => {
   };
 
   const isGoogleDriveConnected = !googleDriveTool.is_auth_required ?? false;
-  const authUrl = googleDriveTool.auth_url;
+  const authUrl = getToolAuthUrl(googleDriveTool.auth_url);
 
   return (
     <article className="rounded-md border border-marble-800 p-4 dark:border-volcanic-500">
@@ -159,7 +160,7 @@ const GoogleDriveConnection = () => {
         ) : (
           <Button
             label="Authenticate"
-            href={googleDriveTool.auth_url ?? ''}
+            href={getToolAuthUrl(googleDriveTool.auth_url)}
             kind="secondary"
             theme="evolved-green"
             icon="arrow-up-right"

--- a/src/interfaces/assistants_web/src/components/Agents/UpdateAgent.tsx
+++ b/src/interfaces/assistants_web/src/components/Agents/UpdateAgent.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { useLocalStorageValue } from '@react-hookz/web';
 import Link from 'next/link';
 import React, { useState } from 'react';
 
@@ -39,14 +38,6 @@ export const UpdateAgent: React.FC<Props> = ({ agent }) => {
     is_private: agent.is_private,
   });
 
-  const { set: setPendingAssistant } = useLocalStorageValue<AgentSettingsFields>(
-    'pending_assistant',
-    {
-      defaultValue: fields,
-      initializeWithValue: false,
-    }
-  );
-
   const handleOpenDeleteModal = () => {
     open({
       title: `Delete ${agent.name}`,
@@ -65,7 +56,6 @@ export const UpdateAgent: React.FC<Props> = ({ agent }) => {
         request: { ...fields, tools_metadata },
         agentId: agent.id,
       });
-      setIsSubmitting(false);
       success(`Updated ${newAgent?.name}`);
     } catch (e) {
       setIsSubmitting(false);
@@ -94,7 +84,6 @@ export const UpdateAgent: React.FC<Props> = ({ agent }) => {
             fields={fields}
             setFields={setFields}
             onSubmit={handleSubmit}
-            savePendingAssistant={() => setPendingAssistant(fields)}
             agentId={agent.id}
           />
         </div>

--- a/src/interfaces/assistants_web/src/hooks/tools.ts
+++ b/src/interfaces/assistants_web/src/hooks/tools.ts
@@ -134,6 +134,6 @@ export const useDeleteAuthTool = () => {
     },
     onSettled: () => {
       queryClient.invalidateQueries({ queryKey: ['tools'] });
-    }
+    },
   });
 };

--- a/src/interfaces/assistants_web/src/utils/getToolAuthUrl.ts
+++ b/src/interfaces/assistants_web/src/utils/getToolAuthUrl.ts
@@ -1,0 +1,22 @@
+/**
+ * The Tool Auth URL is the URL that the Assistant will use to authenticate with the Tool.
+ * It accepts configuring the frontend redirect URL by adding the `frontend_redirect_url` query parameter to the state.
+ */
+export const getToolAuthUrl = (toolAuthUrl?: string | null, customRedirect?: string) => {
+  let authUrl;
+  if (toolAuthUrl) {
+    authUrl = new URL(toolAuthUrl);
+    const state = authUrl.searchParams.get('state');
+
+    if (state) {
+      try {
+        const stateJson = JSON.parse(state);
+        stateJson.frontend_redirect = customRedirect ?? window.location.href;
+        authUrl.searchParams.set('state', JSON.stringify(stateJson));
+        return authUrl.href;
+      } catch {
+        // fail silently
+      }
+    }
+  }
+};


### PR DESCRIPTION
Closes OS-2422

Integrates redirect URL for tool auth.

We currently have 3 different pages from where users can authenticate their GDrive. 
- `/settings`
- `/new`
- `/edit/:agent_id`

For the tool auth redirection we had to introduce deep linking state management, for which we use the `state` query param in the tool auth, where we pass a value of `frontend_redirect` which contains the URL the flow will redirect once it successfully gets the auth token. 

For the case when the user has state that we want to preserve, we can pass a hash of the JSON object for the state we want, in this case we use `atob` and `btoa` to encode and decode the state, which we will persist once the page loads with the value in the query params.