### PR TITLE
chore(toolkit): add assistants to run in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -160,8 +160,29 @@ services:
         - action: sync
           path: ./src/interfaces/coral_web
           target: /app
-          ignore:
-            - node_modules/
+
+  frontend-assistants:
+    build:
+      target: ${BUILD_TARGET:-prod}
+      context: ./src/interfaces/assistants_web
+      dockerfile: Dockerfile
+    # Set environment variables directly in the docker-compose file
+    environment:
+      API_HOSTNAME: http://backend:8000
+      NEXT_PUBLIC_API_HOSTNAME: ${NEXT_PUBLIC_API_HOSTNAME}
+      NEXT_PUBLIC_FRONTEND_HOSTNAME: ${NEXT_PUBLIC_FRONTEND_HOSTNAME}
+      NEXT_PUBLIC_GOOGLE_DRIVE_CLIENT_ID: ${NEXT_PUBLIC_GOOGLE_DRIVE_CLIENT_ID}
+      NEXT_PUBLIC_GOOGLE_DRIVE_DEVELOPER_KEY: ${NEXT_PUBLIC_GOOGLE_DRIVE_DEVELOPER_KEY}
+    restart: always
+    networks:
+      - proxynet
+    ports:
+      - 4444:4444
+    develop:
+      watch:
+        - action: sync
+          path: ./src/interfaces/assistants_web
+          target: /app
 
   terrarium:
     image: ghcr.io/cohere-ai/terrarium:latest


### PR DESCRIPTION
Thank you for contributing to the Cohere Toolkit!

- [ ] **PR title**: "area: description"
  - Where "area" is whichever of interface, frontend, model, tools, backend, etc. is being modified. Use "docs: ..." for purely docs changes, "infra: ..." for CI changes.
  - Example: "deployment: add Azure model option"


- [ ] **PR message**: ***Delete this entire checklist*** and replace with
    - **Description:** a description of the change
    - **Issue:** the issue # it fixes, if applicable
    - **Dependencies:** any dependencies required for this change


- [ ] **Add tests and docs**: Please include testing and documentation for your changes
- [ ] **Lint and test**: Run `make lint` and `make run-tests`

**AI Description**

<!-- begin-generated-description -->

The PR introduces a new `frontend-assistants` service to the `docker-compose.yml` file. This service is built using a Dockerfile and includes configurations for environment variables, networking, ports, and watch targets.

**Changes:**
- Adds the `frontend-assistants` service with a build target of `prod` and a context of `./src/interfaces/assistants_web`.
- Sets environment variables directly in the docker-compose file, including `API_HOSTNAME`, `NEXT_PUBLIC_API_HOSTNAME`, `NEXT_PUBLIC_FRONTEND_HOSTNAME`, and Google Drive-related variables.
- Configures the service to always restart and use the `proxynet` network.
- Exposes port `4444` on the host machine and maps it to port `4444` inside the container.
- Sets up a watch target for the `./src/interfaces/assistants_web` path, synchronizing changes to the `/app` directory inside the container.

<!-- end-generated-description -->
