### PR TITLE
fix(toolkit): feedback nits

### DIFF
--- a/src/interfaces/assistants_web/src/components/Conversation/Composer/DataSourceMenu.tsx
+++ b/src/interfaces/assistants_web/src/components/Conversation/Composer/DataSourceMenu.tsx
@@ -49,7 +49,7 @@ export const DataSourceMenu: React.FC<Props> = ({ agent, tools }) => {
             as="span"
             className={cn('font-medium', text, { [contrastText]: open })}
           >
-            Tools: {paramsTools?.length ?? 0}
+            Tools: {availableTools.length ?? 0}
           </Text>
         )}
       </PopoverButton>

--- a/src/interfaces/assistants_web/src/components/Conversation/Composer/DataSourceMenu.tsx
+++ b/src/interfaces/assistants_web/src/components/Conversation/Composer/DataSourceMenu.tsx
@@ -31,6 +31,7 @@ export const DataSourceMenu: React.FC<Props> = ({ agent, tools }) => {
 
   const { text, contrastText, border, bg } = useBrandedColors(agent?.id);
 
+  const isBaseAgent = checkIsBaseAgent(agent);
   return (
     <Popover className="relative">
       <PopoverButton
@@ -49,7 +50,7 @@ export const DataSourceMenu: React.FC<Props> = ({ agent, tools }) => {
             as="span"
             className={cn('font-medium', text, { [contrastText]: open })}
           >
-            Tools: {availableTools.length ?? 0}
+            Tools: {isBaseAgent ? paramsTools?.length ?? 0 : availableTools.length ?? 0}
           </Text>
         )}
       </PopoverButton>
@@ -110,7 +111,7 @@ export const DataSourceMenu: React.FC<Props> = ({ agent, tools }) => {
                     <Text as="span">{tool.display_name}</Text>
                   </div>
                 </div>
-                {checkIsBaseAgent(agent) && (
+                {isBaseAgent && (
                   <Switch
                     theme="evolved-blue"
                     checked={!!paramsTools?.find((t) => t.name === tool.name)}

--- a/src/interfaces/assistants_web/src/constants.ts
+++ b/src/interfaces/assistants_web/src/constants.ts
@@ -77,7 +77,7 @@ export const TOOL_ID_TO_DISPLAY_INFO: { [id: string]: { icon: IconName } } = {
 };
 
 export const MAX_TIMEOUT_PREFETCH = 5000;
-export const DEFAULT_AGENT_TOOLS = [TOOL_SEARCH_FILE_ID, TOOL_READ_DOCUMENT_ID];
+export const DEFAULT_AGENT_TOOLS = [TOOL_SEARCH_FILE_ID, TOOL_READ_DOCUMENT_ID, TOOL_WEB_SCRAPE_ID];
 
 export type COHERE_BRANDED_COLORS =
   | 'blue'


### PR DESCRIPTION
Thank you for contributing to the Cohere Toolkit!
- Default and hide web scrape tool
- Show correct count of tools in composer toolbar

- [ ] **PR title**: "area: description"
  - Where "area" is whichever of interface, frontend, model, tools, backend, etc. is being modified. Use "docs: ..." for purely docs changes, "infra: ..." for CI changes.
  - Example: "deployment: add Azure model option"


- [ ] **PR message**: ***Delete this entire checklist*** and replace with
    - **Description:** a description of the change
    - **Issue:** the issue # it fixes, if applicable
    - **Dependencies:** any dependencies required for this change


- [ ] **Add tests and docs**: Please include testing and documentation for your changes
- [ ] **Lint and test**: Run `make lint` and `make run-tests`

**AI Description**

<!-- begin-generated-description -->

This pull request updates the `DataSourceMenu` component in the `Conversation/Composer` section of the assistants web interface. 

**Code Changes:**
- Introduces a new constant `isBaseAgent` to store the result of the `checkIsBaseAgent(agent)` function.
- Updates the text displayed for the number of tools to include a conditional check for `isBaseAgent`. If `isBaseAgent` is true, it displays the length of `paramsTools`, otherwise, it displays the length of `availableTools`.
- Replaces the `checkIsBaseAgent(agent)` condition with the new `isBaseAgent` constant in the render logic for the tool display name and switch.

**Other Changes:**
- Adds `TOOL_WEB_SCRAPE_ID` to the `DEFAULT_AGENT_TOOLS` array in `src/interfaces/assistants_web/src/constants.ts`.

<!-- end-generated-description -->
