### PR TITLE
backend: more compass file fixes

### DIFF
--- a/src/backend/routers/agent.py
+++ b/src/backend/routers/agent.py
@@ -138,7 +138,7 @@ async def create_agent(
                 }
             )
             if file_ids:
-                await consolidate_agent_files_in_compass(file_ids, created_agent.id)
+                await consolidate_agent_files_in_compass(file_ids, created_agent.id, ctx)
 
         if deployment_db and model_db:
             deployment_config = (

--- a/src/backend/schemas/file.py
+++ b/src/backend/schemas/file.py
@@ -1,4 +1,5 @@
 import datetime
+from typing import Optional
 
 from pydantic import BaseModel, Field
 
@@ -9,8 +10,8 @@ class File(BaseModel):
     updated_at: datetime.datetime
 
     user_id: str
-    conversation_id: str
-    file_content: str
+    conversation_id: Optional[str] = ""
+    file_content: Optional[str] = ""
     file_name: str
     file_path: str
     file_size: int = Field(default=0, ge=0)

--- a/src/backend/services/file.py
+++ b/src/backend/services/file.py
@@ -68,12 +68,18 @@ def get_compass():
 
     if compass is None:
         try:
-            compass = Compass()
+            compass = Compass(
+                compass_api_url=Settings().compass.api_url,
+                compass_parser_url=Settings().compass.parser_url,
+                compass_username=Settings().compass.username,
+                compass_password=Settings().compass.password,
+            )
         except Exception as e:
             logger.error(
                 event=f"[Compass File Service] Error initializing Compass: {e}"
             )
             raise e
+
     return compass
 
 
@@ -157,7 +163,7 @@ class FileService:
             Since agents are created after the files are upload we index files into dummy indices first
             We later consolidate them in consolidate_agent_files_in_compass() to a singular index when an agent is created.
             """
-            uploaded_files = await insert_files_in_compass(files, ctx, user_id)
+            uploaded_files = await insert_files_in_compass(files, user_id, ctx)
         else:
             uploaded_files = await insert_files_in_db(session, files, user_id)
 
@@ -460,11 +466,20 @@ async def consolidate_agent_files_in_compass(
     compass = get_compass()
 
     try:
-        compass.invoke(
+        logger.info(
+            event="[Compass File Service] Creating index for agent files",
+            agent_id=agent_id
+        )
+        response = compass.invoke(
             action=Compass.ValidActions.CREATE_INDEX,
             parameters={
                 "index": agent_id,
             },
+        )
+        logger.info(
+            event="[Compass File Service] Finished creating index for agent files",
+            agent_id=agent_id,
+            response=response
         )
     except Exception as e:
         logger.Error(
@@ -481,13 +496,13 @@ async def consolidate_agent_files_in_compass(
                 action=Compass.ValidActions.GET_DOCUMENT,
                 parameters={"index": file_id, "file_id": file_id},
             ).result["doc"]["content"]
-            compass().invoke(
+            compass.invoke(
                 action=Compass.ValidActions.CREATE,
                 parameters={
                     "index": agent_id,
                     "file_id": file_id,
                     "file_bytes": fetched_doc["text"],
-                    "filename": fetched_doc["file_name"],
+                    "file_extension": get_file_extension(fetched_doc["file_name"]),
                     "custom_context": {
                         "file_id": file_id,
                         "file_name": fetched_doc["file_name"],
@@ -508,7 +523,7 @@ async def consolidate_agent_files_in_compass(
             )
             # Remove the temporary file index entry
             compass.invoke(
-                action=Compass.ValidActions.DELETE_INDEX, parameters={"index": agent_id}
+                action=Compass.ValidActions.DELETE_INDEX, parameters={"index": file_id}
             )
         except Exception as e:
             logger.error(
@@ -570,7 +585,7 @@ async def insert_files_in_compass(
                     "index": new_file_id if index is None else index,
                     "file_id": new_file_id,
                     "file_bytes": file_bytes,
-                    "filename": filename,
+                    "file_extension": get_file_extension(filename),
                     "custom_context": {
                         "file_id": new_file_id,
                         "file_name": filename,

--- a/src/backend/tools/files.py
+++ b/src/backend/tools/files.py
@@ -64,7 +64,6 @@ def compass_file_search(
     if search_results.result:
         results.extend(search_results.result["hits"])
 
-    print("results here", results, len(results))
     chunks = sorted(
         [
             {

--- a/src/backend/tools/files.py
+++ b/src/backend/tools/files.py
@@ -33,39 +33,38 @@ def compass_file_search(
         for file_id in file_ids
     ]
 
+    compass = get_compass()
+
     # Search conversation ID index
-    hits = (
-        get_compass()
-        .invoke(
+    search_results = compass.invoke(
             action=Compass.ValidActions.SEARCH,
             parameters={
                 "index": conversation_id,
                 "query": query,
                 "top_k": search_limit,
                 "filters": search_filters,
-            },
-        )
-        .result["hits"]
+        },
     )
-    results.extend(hits)
+
+    if search_results.result:
+        results.extend(search_results.result["hits"])
 
     # Search agent ID index
     if agent_id:
-        hits = (
-            get_compass()
-            .invoke(
-                action=Compass.ValidActions.SEARCH,
-                parameters={
-                    "index": agent_id,
-                    "query": query,
-                    "top_k": search_limit,
-                    "filters": search_filters,
-                },
-            )
-            .result["hits"]
+        search_results = compass.invoke(
+            action=Compass.ValidActions.SEARCH,
+            parameters={
+                "index": agent_id,
+                "query": query,
+                "top_k": search_limit,
+                "filters": search_filters,
+            },
         )
-        results.extend(hits)
 
+    if search_results.result:
+        results.extend(search_results.result["hits"])
+
+    print("results here", results, len(results))
     chunks = sorted(
         [
             {


### PR DESCRIPTION
Thank you for contributing to the Cohere Toolkit!

- [ ] **PR title**: "area: description"
  - Where "area" is whichever of interface, frontend, model, tools, backend, etc. is being modified. Use "docs: ..." for purely docs changes, "infra: ..." for CI changes.
  - Example: "deployment: add Azure model option"


- [ ] **PR message**: ***Delete this entire checklist*** and replace with
    - **Description:** a description of the change
    - **Issue:** the issue # it fixes, if applicable
    - **Dependencies:** any dependencies required for this change


- [ ] **Add tests and docs**: Please include testing and documentation for your changes
- [ ] **Lint and test**: Run `make lint` and `make run-tests`

**AI Description**

<!-- begin-generated-description -->

This pull request makes changes to the file handling and indexing mechanisms in the backend services. 

**Changed Files:**
- `src/backend/routers/agent.py`
- `src/backend/schemas/file.py`
- `src/backend/services/file.py`
- `src/backend/tools/files.py`

**Summary:**
- The `File` class in `src/backend/schemas/file.py` has been updated to make the `conversation_id` and `file_content` fields optional.
- The `get_compass()` function in `src/backend/services/file.py` now accepts additional parameters, including `compass_api_url`, `compass_parser_url`, `compass_username`, and `compass_password`.
- The `insert_files_in_compass` function now passes the `ctx` parameter after the `files` and `user_id` parameters.
- The `consolidate_agent_files_in_compass` function now includes logging statements before and after invoking the `create_index` action. It also uses the `get_file_extension` function to determine the `file_extension` instead of directly using `filename`.
- The `insert_files_in_compass` function has been updated similarly to use the `get_file_extension` function.
- The `compass_file_search` function in `src/backend/tools/files.py` now uses the `get_compass()` function to retrieve the compass instance and invokes the search action directly on it. It also includes additional error handling and prints the search results.

<!-- end-generated-description -->
