### PR TITLE
feat(toolkit): hide instruction textarea for new assistants

### DIFF
--- a/src/interfaces/assistants_web/src/components/AgentSettingsForm/DefineStep.tsx
+++ b/src/interfaces/assistants_web/src/components/AgentSettingsForm/DefineStep.tsx
@@ -1,15 +1,26 @@
+'use client';
+
 import Link from 'next/link';
+import { useState } from 'react';
 
 import { AgentSettingsFields } from '@/components/AgentSettingsForm';
-import { Input, Text, Textarea } from '@/components/UI';
+import { Button, Input, Text, Textarea } from '@/components/UI';
 
 type Props = {
   fields: AgentSettingsFields;
+  isNewAssistant: boolean;
   nameError?: string;
   setFields: (fields: AgentSettingsFields) => void;
 };
 
-export const DefineAssistantStep: React.FC<Props> = ({ fields, nameError, setFields }) => {
+export const DefineAssistantStep: React.FC<Props> = ({
+  fields,
+  isNewAssistant,
+  nameError,
+  setFields,
+}) => {
+  const [showInstructions, setShowInstructions] = useState(!isNewAssistant);
+
   return (
     <div className="flex flex-col space-y-4">
       <Input
@@ -26,24 +37,33 @@ export const DefineAssistantStep: React.FC<Props> = ({ fields, nameError, setFie
         value={fields.description ?? ''}
         onChange={(e) => setFields({ ...fields, description: e.target.value })}
       />
-      <Textarea
-        label="Instructions"
-        labelTooltip={
-          <Text>
-            Learn about writing a custom assistant instructions with{' '}
-            <Link
-              href="https://docs.cohere.com/docs/preambles#advanced-techniques-for-writing-a-preamble"
-              className="underline"
-            >
-              Cohere&apos;s guide
-            </Link>
-          </Text>
-        }
-        placeholder="e.g., You are friendly and helpful. You answer questions based on files in Google Drive."
-        defaultRows={8}
-        value={fields.preamble || ''}
-        onChange={(e) => setFields({ ...fields, preamble: e.target.value })}
-      />
+      {showInstructions ? (
+        <Textarea
+          label="Instructions"
+          labelTooltip={
+            <Text>
+              Learn about writing a custom assistant instructions with{' '}
+              <Link
+                href="https://docs.cohere.com/docs/preambles#advanced-techniques-for-writing-a-preamble"
+                className="underline"
+              >
+                Cohere&apos;s guide
+              </Link>
+            </Text>
+          }
+          placeholder="e.g., You are friendly and helpful. You answer questions based on files in Google Drive."
+          defaultRows={8}
+          value={fields.preamble || ''}
+          onChange={(e) => setFields({ ...fields, preamble: e.target.value })}
+        />
+      ) : (
+        <Button
+          label="Custom assistant instructions"
+          icon="add"
+          kind="secondary"
+          onClick={() => setShowInstructions(true)}
+        />
+      )}
     </div>
   );
 };

--- a/src/interfaces/assistants_web/src/components/AgentSettingsForm/index.tsx
+++ b/src/interfaces/assistants_web/src/components/AgentSettingsForm/index.tsx
@@ -186,7 +186,12 @@ export const AgentSettingsForm: React.FC<Props> = (props) => {
         isExpanded={currentStep === 'define'}
         setIsExpanded={(expanded) => setCurrentStep(expanded ? 'define' : undefined)}
       >
-        <DefineAssistantStep fields={fields} setFields={setFields} nameError={nameError} />
+        <DefineAssistantStep
+          fields={fields}
+          setFields={setFields}
+          nameError={nameError}
+          isNewAssistant={source === 'create'}
+        />
         <StepButtons
           handleNext={() => setCurrentStep('dataSources')}
           hide={source !== 'create'}

--- a/src/interfaces/assistants_web/src/components/UI/Tooltip.tsx
+++ b/src/interfaces/assistants_web/src/components/UI/Tooltip.tsx
@@ -129,7 +129,7 @@ export const Tooltip: React.FC<TooltipProps> = ({
               {
                 'max-w-[400px] rounded-sm border-none bg-mushroom-150 px-1 py-0.5 dark:bg-volcanic-300':
                   size === 'sm',
-                'max-w-[300px] rounded border border-marble-950 bg-marble-980 px-4 py-2.5':
+                'max-w-[300px] rounded border border-marble-950 bg-marble-980 px-4 py-2.5 dark:border-volcanic-400 dark:bg-volcanic-300':
                   size === 'md',
               },
               className


### PR DESCRIPTION

https://github.com/user-attachments/assets/efafa9ed-0ebe-48cf-a91d-67f280a4cb23


- [ ] **PR title**: "area: description"
  - Where "area" is whichever of interface, frontend, model, tools, backend, etc. is being modified. Use "docs: ..." for purely docs changes, "infra: ..." for CI changes.
  - Example: "deployment: add Azure model option"


- [ ] **PR message**: ***Delete this entire checklist*** and replace with
    - **Description:** a description of the change
    - **Issue:** the issue # it fixes, if applicable
    - **Dependencies:** any dependencies required for this change


- [ ] **Add tests and docs**: Please include testing and documentation for your changes
- [ ] **Lint and test**: Run `make lint` and `make run-tests`

**AI Description**

<!-- begin-generated-description -->

This pull request makes changes to the `AgentSettingsForm` component and its `DefineStep` sub-component.

## Summary
The `AgentSettingsForm` component now includes an additional prop, `isNewAssistant`, which is passed to the `DefineAssistantStep` sub-component. This prop is used to conditionally render either a `Textarea` for custom assistant instructions or a `Button` that, when clicked, toggles the display of these instructions.

## Changes
- Add `use client` statement to `DefineStep.tsx`.
- Add `isNewAssistant` prop to `DefineAssistantStep` in `DefineStep.tsx`.
- Add `useState` import and `showInstructions` state variable to `DefineStep.tsx`.
- Conditionally render `Textarea` or `Button` based on `showInstructions` state in `DefineStep.tsx`.
- Update CSS class in `Tooltip.tsx` to include `dark:border-volcanic-400 dark:bg-volcanic-300`.

<!-- end-generated-description -->
