### PR TITLE
fix: citations with the same text in a code block response

### DIFF
--- a/src/interfaces/assistants_web/src/utils/citations.test.ts
+++ b/src/interfaces/assistants_web/src/utils/citations.test.ts
@@ -394,6 +394,39 @@ describe('fixInlineCitationsForMarkdown', () => {
       },
     ]);
   });
+
+  test('should be able to fix repeated citations', () => {
+    const citations = [
+      {
+        text: 'test',
+        start: 13,
+        end: 17,
+        document_ids: ['12345'],
+      },
+      {
+        text: 'test',
+        start: 18,
+        end: 22,
+        document_ids: ['44444'],
+      },
+    ];
+    const text = '``` test ``` test test';
+    const result = fixInlineCitationsForMarkdown(citations, text);
+    expect(result).toStrictEqual([
+      {
+        text: 'test',
+        start: 13,
+        end: 17,
+        document_ids: ['12345'],
+      },
+      {
+        text: 'test',
+        start: 18,
+        end: 22,
+        document_ids: ['44444'],
+      },
+    ]);
+  });
 });
 
 describe('isReferenceBetweenSpecialTags', () => {

--- a/src/interfaces/assistants_web/src/utils/citations.test.ts
+++ b/src/interfaces/assistants_web/src/utils/citations.test.ts
@@ -427,6 +427,39 @@ describe('fixInlineCitationsForMarkdown', () => {
       },
     ]);
   });
+
+  test('should be able to fix repeated citations - complex', () => {
+    const citations = [
+      {
+        text: 'test',
+        start: 20,
+        end: 24,
+        document_ids: ['12345'],
+      },
+      {
+        text: 'test',
+        start: 28,
+        end: 34,
+        document_ids: ['44444'],
+      },
+    ];
+    const text = 'test ``` test ``` test test test';
+    const result = fixInlineCitationsForMarkdown(citations, text);
+    expect(result).toStrictEqual([
+      {
+        text: 'test',
+        start: 18,
+        end: 22,
+        document_ids: ['12345'],
+      },
+      {
+        text: 'test',
+        start: 28,
+        end: 32,
+        document_ids: ['44444'],
+      },
+    ]);
+  });
 });
 
 describe('isReferenceBetweenSpecialTags', () => {

--- a/src/interfaces/assistants_web/src/utils/citations.ts
+++ b/src/interfaces/assistants_web/src/utils/citations.ts
@@ -38,13 +38,24 @@ const tryToFixCitationsInCodeBlock = (citations: Citation[], originalText: strin
     }
 
     try {
-      const match = originalText.match(new RegExp(escapeRegex(citation.text)));
-      if (match) {
-        const [firstMatch] = match;
-        const start = match.index || citation.start;
-        const end = start + firstMatch.length;
-        citation.start = start;
-        citation.end = end;
+      const regex = new RegExp(escapeRegex(citation.text), 'dg');
+      const matches = Array.from(originalText.matchAll(regex)).filter(
+        (match) => !isReferenceBetweenSpecialTags(CODE_BLOCK_REGEX_EXP, originalText, match.index)
+      );
+
+      const citationsWithSameCitationText = citationsCopy.filter((c) => c.text === citation.text);
+      const minIndexToBeFound = citationsWithSameCitationText.findIndex(
+        (c) => c.start === citation.start && c.end === citation.end
+      );
+
+      for (let i = minIndexToBeFound; i <= matches.length; i++) {
+        const match = matches[i];
+        if (match.indices) {
+          const [start, end] = match.indices[0];
+          citation.start = start;
+          citation.end = end;
+        }
+        break;
       }
     } catch (e) {
       console.error('error updating citation', citation, e);


### PR DESCRIPTION
## Description

If we try to find a citation's start and end point but another citation has the exact text, it will always fall into the first match.

Closes TLK-1047
