### PR TITLE
fix(toolkit): fix download file

### DIFF
--- a/src/interfaces/assistants_web/src/components/Markdown/tags/Anchor.tsx
+++ b/src/interfaces/assistants_web/src/components/Markdown/tags/Anchor.tsx
@@ -6,19 +6,21 @@ import { ComponentPropsWithoutRef } from 'react';
 import { Icon } from '@/components/UI';
 import { useOutputFiles } from '@/stores';
 
-export const Anchor: Component<ComponentPropsWithoutRef<'a'> & ExtraProps> = ({ children }) => {
+export const Anchor: Component<ComponentPropsWithoutRef<'a'> & ExtraProps> = ({
+  children,
+  node,
+}) => {
   const { outputFiles } = useOutputFiles();
+  const nodeHref = node?.properties.href;
 
-  if (typeof children === 'string') {
-    const snakeCaseUrl = children.replace(/\s/g, '_').toLowerCase();
-    const outputFile = Object.entries(outputFiles).find(([key]) =>
-      key.startsWith(snakeCaseUrl)
-    )?.[1];
+  if (typeof children === 'string' && typeof nodeHref === 'string') {
+    const outputFile = Object.entries(outputFiles).find(([key]) => nodeHref.includes(key))?.[1];
+
     const downloadUrl = outputFile?.downloadUrl;
 
     if (downloadUrl) {
       return (
-        <a href={downloadUrl} download={snakeCaseUrl} className="flex items-center gap-1">
+        <a href={downloadUrl} download={outputFile.name} className="flex items-center gap-1">
           {children}
           <Icon name="download" />
         </a>


### PR DESCRIPTION
Fix for file download option not showing up -> model file naming convention not consistent enough to use a regex replace.
| Before | After |
|--------|--------|
| <img width="500"  alt="Screenshot 2024-08-23 at 4 45 51 PM" src="https://github.com/user-attachments/assets/5898e071-f9cd-41ed-983d-209a55319356"> | <img width="500"  alt="Screenshot 2024-08-23 at 4 45 51 PM" src="https://github.com/user-attachments/assets/7ebb5633-ad04-4a05-a3ee-8958d548f9f3"> | 


Thank you for contributing to the Cohere Toolkit!

- [ ] **PR title**: "area: description"
  - Where "area" is whichever of interface, frontend, model, tools, backend, etc. is being modified. Use "docs: ..." for purely docs changes, "infra: ..." for CI changes.
  - Example: "deployment: add Azure model option"


- [ ] **PR message**: ***Delete this entire checklist*** and replace with
    - **Description:** a description of the change
    - **Issue:** the issue # it fixes, if applicable
    - **Dependencies:** any dependencies required for this change


- [ ] **Add tests and docs**: Please include testing and documentation for your changes
- [ ] **Lint and test**: Run `make lint` and `make run-tests`

**AI Description**

<!-- begin-generated-description -->

This pull request updates the `Anchor` component in the `src/interfaces/assistants_web/src/components/Markdown/tags/Anchor.tsx` file. Specifically, it:

- Adds `node` as a prop to the `Anchor` component.
- Introduces a new `nodeHref` variable, derived from the `node` prop, to store the href property of the node.
- Modifies the condition for rendering the download link:
  - Previously, it converted the `children` text to a snake case URL and looked for a matching output file.
  - Now, it directly uses the `nodeHref` to find the corresponding output file and constructs the download URL using the output file's name.

<!-- end-generated-description -->
