### PR TITLE
fix: failing community tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ run-unit-tests:
 
 .PHONY: run-community-tests
 run-community-tests:
-	docker compose run --build backend poetry run pytest src/community/tests/$(file)
+	poetry run pytest src/community/tests --cov=src/community --cov-report=xml
 
 .PHONY: run-integration-tests
 run-integration-tests:

--- a/src/community/tests/tools/test_arxiv.py
+++ b/src/community/tests/tools/test_arxiv.py
@@ -1,9 +1,12 @@
+import pytest
+
 from community.tools import ArxivRetriever
 
 
-def test_arxiv_retriever():
+@pytest.mark.asyncio
+async def test_arxiv_retriever():
     retriever = ArxivRetriever()
-    result = retriever.call({"query": "quantum"})
+    result = await retriever.call({"query": "quantum"})
     assert len(result) > 0
     assert "text" in result[0]
     assert "quantum" in result[0]["text"].lower()

--- a/src/community/tests/tools/test_clinicaltrials.py
+++ b/src/community/tests/tools/test_clinicaltrials.py
@@ -1,9 +1,12 @@
+import pytest
+
 from community.tools import ClinicalTrials
 
 
-def test_clinicaltrials_tool():
+@pytest.mark.asyncio
+async def test_clinicaltrials_tool():
     retriever = ClinicalTrials()
-    result = retriever.call(
+    result = await retriever.call(
         parameters={
             "condition": "lung cancer",
             "location": "Canada",

--- a/src/community/tests/tools/test_llama_index.py
+++ b/src/community/tests/tools/test_llama_index.py
@@ -1,7 +1,10 @@
+import pytest
+
 from community.tools import LlamaIndexUploadPDFRetriever
 
 
-def test_pdf_retriever() -> None:
+@pytest.mark.asyncio
+async def test_pdf_retriever() -> None:
     file_path = "src/backend/tests/unit/test_data/Mariana_Trench.pdf"
     retriever = LlamaIndexUploadPDFRetriever(file_path)
     query = "What is the mariana trench?"
@@ -34,6 +37,6 @@ def test_pdf_retriever() -> None:
             "text": '49. Robbins, Gary (5 September 2019). "UCSD discovers surge in plastics pollution off Santa\nBarbara" (https://www.latimes.com/california/story/2019-09-04/uc-san-diego-discovers-explo\nsion-in-plastics-products-in-seafloor-off-santa-barbara). Los Angeles Times. Retrieved\n5 September 2019.\n50. Street, Francesca (13 May 2019). "Deepest ocean dive recorded: How Victor Vescovo did it"\n(https://www.cnn.com/travel/article/victor-vescovo-deepest-dive-pacific/index.html). CNN\nTravel. CNN. Retrieved 13 May 2019.\n51. Levy, Adam (15 May 2019). ""Bomb Carbon" Has Been Found in Deep-Ocean Creatures" (h\nttps://www.scientificamerican.com/article/bomb-carbon-has-been-found-in-deep-ocean-creat\nures/). Scientific American.\n52. Hafemeister, David W. (2007). Physics of societal issues: calculations on national security,\nenvironment, and energy (https://books.google.com/books?id=LT4MSqv9QUIC&pg=PA187).\nBerlin: Springer. p. 187. ISBN 978-0-387-95560-5.\n53. Kingsley, Marvin G.; Rogers, Kenneth H. (2007). Calculated risks: highly radioactive waste\nand homeland security (https://books.google.com/books?id=bOP4-BpYXrEC&pg=PA75).\nAldershot, Hants, England: Ashgate. pp. 75–76. ISBN 978-0-7546-7133-6.\n54. "Dumping and Loss overview" (https://web.archive.org/web/20110605190619/http://www.la\nw.berkeley.edu/centers/ilr/ona/pages/dumping2.htm). Oceans in the Nuclear Age. Archived\nfrom the original (http://www.law.berkeley.edu/centers/ilr/ona/pages/dumping2.htm) on 5\nJune 2011. Retrieved 18 September 2010.\nMariana Trench Dive (25 March 2012) (https://web.archive.org/web/20140625050833/http://d\neepseachallenge.com/) – Deepsea Challenger\nMariana Trench Dive (23 January 1960) (http://www.britishpathe.com/video/they-dived-7-mil\nes/query/mariana+trench) – Trieste (Newsreel)\nMariana Trench Dive (50th Anniv) (http://www.vvdailypress.com/articles/walsh-18116-regret-\nmiles.html) Archived (https://web.archive.org/web/20130603064615/http://www.vvdailypress.\ncom/articles/walsh-18116-regret-miles.html) 3 June 2013 at the Wayback Machine – Trieste\n– Capt Don Walsh\nMariana Trench – Maps (Google) (https://maps.google.com/maps?q=11.317,+142.25(Marian\na+Trench)&z=6)\nNOAA – Ocean Explorer (http://oceanexplorer.noaa.gov) (Ofc Ocean Exploration & Rsch)\nNOAA – Ocean Explorer – Multimedia (http://oceanexplorer.noaa.gov/explorations/06fire/bac\nkground/marianaarc/marianaarc.html) – Mariana Arc (podcast (http://oceanexplorer.noaa.go\nv/explorations/podcast/oceanexplorer_podcast.xml))\nNOAA – Ocean Explorer – Video Playlist (https://www.youtube.com/view_play_list?p=94B79\n5FD631011E0) – Ring of Fire (2004–2006)\nRetrieved from "https://en.wikipedia.org/w/index.php?title=Mariana_Trench&oldid=1187694887"External links\n'
         },
     ]
-    result = retriever.call({"query": query})
+    result = await retriever.call({"query": query})
 
     assert expected_docs == result

--- a/src/community/tests/tools/test_pub_med.py
+++ b/src/community/tests/tools/test_pub_med.py
@@ -1,8 +1,11 @@
+import pytest
+
 from community.tools import PubMedRetriever
 
 
-def test_pub_med_retriever():
+@pytest.mark.asyncio
+async def test_pub_med_retriever():
     retriever = PubMedRetriever()
-    result = retriever.call({"query": "What causes lung cancer?"})
+    result = await retriever.call({"query": "What causes lung cancer?"})
     assert len(result) > 0
     assert "text" in result[0]

--- a/src/community/tools/arxiv.py
+++ b/src/community/tools/arxiv.py
@@ -15,9 +15,7 @@ class ArxivRetriever(BaseTool):
     def is_available(cls) -> bool:
         return True
 
-    async def call(
-        self, parameters: dict, ctx: Any, **kwargs: Any
-    ) -> List[Dict[str, Any]]:
+    async def call(self, parameters: dict, **kwargs: Any) -> List[Dict[str, Any]]:
         query = parameters.get("query", "")
         result = self.client.run(query)
         return [{"text": result}]

--- a/src/community/tools/clinicaltrials.py
+++ b/src/community/tools/clinicaltrials.py
@@ -22,7 +22,7 @@ class ClinicalTrials(BaseTool):
         return True
 
     async def call(
-        self, parameters: Dict[str, Any], ctx: Any, n_max_studies: int = 10, **kwargs
+        self, parameters: Dict[str, Any], n_max_studies: int = 10, **kwargs
     ) -> List[Dict[str, Any]]:
         query_params = {"sort": "LastUpdatePostDate"}
         if condition := parameters.get("condition", ""):

--- a/src/community/tools/connector.py
+++ b/src/community/tools/connector.py
@@ -25,9 +25,7 @@ class ConnectorRetriever(BaseTool):
     def is_available(cls) -> bool:
         return True
 
-    async def call(
-        self, parameters: dict, ctx: Any, **kwargs: Any
-    ) -> List[Dict[str, Any]]:
+    async def call(self, parameters: dict, **kwargs: Any) -> List[Dict[str, Any]]:
         body = {"query": parameters}
         headers = {
             "Content-Type": "application/json",

--- a/src/community/tools/llama_index.py
+++ b/src/community/tools/llama_index.py
@@ -29,8 +29,6 @@ class LlamaIndexUploadPDFRetriever(BaseTool):
     def is_available(cls) -> bool:
         return True
 
-    async def call(
-        self, parameters: dict, ctx: Any, **kwargs: Any
-    ) -> List[Dict[str, Any]]:
+    async def call(self, parameters: dict, **kwargs: Any) -> List[Dict[str, Any]]:
         docs = SimpleDirectoryReader(input_files=[self.filepath]).load_data()
         return [{"text": doc.text} for doc in docs]

--- a/src/community/tools/pub_med.py
+++ b/src/community/tools/pub_med.py
@@ -15,9 +15,7 @@ class PubMedRetriever(BaseTool):
     def is_available(cls) -> bool:
         return True
 
-    async def call(
-        self, parameters: dict, ctx: Any, **kwargs: Any
-    ) -> List[Dict[str, Any]]:
+    async def call(self, parameters: dict, **kwargs: Any) -> List[Dict[str, Any]]:
         query = parameters.get("query", "")
         result = self.client.invoke(query)
         return [{"text": result}]

--- a/src/community/tools/wolfram.py
+++ b/src/community/tools/wolfram.py
@@ -25,9 +25,7 @@ class WolframAlpha(BaseTool):
     def is_available(cls) -> bool:
         return cls.wolfram_app_id is not None
 
-    async def call(
-        self, parameters: dict, ctx: Any, **kwargs: Any
-    ) -> List[Dict[str, Any]]:
+    async def call(self, parameters: dict, **kwargs: Any) -> List[Dict[str, Any]]:
         to_evaluate = parameters.get("expression", "")
         result = self.tool.run(to_evaluate)
         return {"result": result, "text": result}


### PR DESCRIPTION
Fixes failing community tests.

**AI Description**

<!-- begin-generated-description -->

This PR introduces changes to the community tools and tests. 

The main updates include:
- Refactoring the `run-community-tests` command in `Makefile` to use `poetry` directly instead of `docker compose`.
- Modifying the test functions in `test_arxiv.py`, `test_clinicaltrials.py`, `test_llama_index.py`, and `test_pub_med.py` to use the `pytest` async marking and async function calls.
- Removing the `ctx` parameter from the `call` functions in `arxiv.py`, `clinicaltrials.py`, `connector.py`, `llama_index.py`, `pub_med.py`, and `wolfram.py`.

The PR also includes some minor code formatting adjustments.

<!-- end-generated-description -->
