### PR TITLE
fix(frontend): remove `defaultProps` from `react-scroll-to-bottom`

### DIFF
--- a/src/interfaces/assistants_web/Dockerfile
+++ b/src/interfaces/assistants_web/Dockerfile
@@ -4,6 +4,7 @@ WORKDIR /app
 
 # Install dependencies based on the preferred package manager
 COPY package.json package-lock.json ./
+COPY patches ./patches
 RUN npm ci
 
 COPY src ./src

--- a/src/interfaces/assistants_web/package-lock.json
+++ b/src/interfaces/assistants_web/package-lock.json
@@ -99,6 +99,7 @@
         "eslint-config-prettier": "^9.0.0",
         "eslint-plugin-storybook": "^0.8.0",
         "jsdom": "^24.1.1",
+        "patch-package": "^8.0.0",
         "postcss-100vh-fix": "^1.0.2",
         "prettier": "2.8.7",
         "prettier-plugin-tailwindcss": "0.4.1",
@@ -8134,6 +8135,13 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
       "dev": true
     },
+    "node_modules/@yarnpkg/lockfile": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz",
+      "integrity": "sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
     "node_modules/abort-controller": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
@@ -8616,6 +8624,16 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+    },
+    "node_modules/at-least-node": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
+      "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
     },
     "node_modules/autoprefixer": {
       "version": "10.4.19",
@@ -9555,6 +9573,22 @@
       "dev": true,
       "engines": {
         "node": ">=6.0"
+      }
+    },
+    "node_modules/ci-info": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
+      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/cipher-base": {
@@ -12142,6 +12176,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/find-yarn-workspace-root": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/find-yarn-workspace-root/-/find-yarn-workspace-root-2.0.0.tgz",
+      "integrity": "sha512-1IMnbjt4KzsQfnhnzNd8wUEgXZ44IzZaZmnLYx7D5FZlaHt2gW20Cri8Q+E/t5tIj4+epTBub+2Zxu/vNILzqQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "micromatch": "^4.0.2"
+      }
+    },
     "node_modules/flat-cache": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.2.0.tgz",
@@ -13883,6 +13927,22 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/is-docker": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+      "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -14231,6 +14291,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-wsl": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/isarray": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
@@ -14569,6 +14642,25 @@
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true
     },
+    "node_modules/json-stable-stringify": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.1.1.tgz",
+      "integrity": "sha512-SU/971Kt5qVQfJpyDveVhQ/vya+5hvrjClFOcr8c0Fq5aODJjMwutrOfCU+eCnVD5gpx1Q3fEqkyom77zH1iIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.5",
+        "isarray": "^2.0.5",
+        "jsonify": "^0.0.1",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
@@ -14597,6 +14689,16 @@
       },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/jsonify": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.1.tgz",
+      "integrity": "sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==",
+      "dev": true,
+      "license": "Public Domain",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/jsx-ast-utils": {
@@ -14661,6 +14763,16 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/klaw-sync": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/klaw-sync/-/klaw-sync-6.0.0.tgz",
+      "integrity": "sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.1.11"
       }
     },
     "node_modules/kleur": {
@@ -16761,6 +16873,23 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/open": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/open/-/open-7.4.2.tgz",
+      "integrity": "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^2.0.0",
+        "is-wsl": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.3",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.3.tgz",
@@ -16876,6 +17005,16 @@
       "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.3.0.tgz",
       "integrity": "sha512-gjcpUc3clBf9+210TRaDWbf+rZZZEshZ+DlXMRCeAjp0xhTrnQsKHypIy1J3d5hKdUzj69t708EHtU8P6bUn0A==",
       "dev": true
+    },
+    "node_modules/os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/p-limit": {
       "version": "3.1.0",
@@ -17058,6 +17197,179 @@
       "dependencies": {
         "no-case": "^3.0.4",
         "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/patch-package": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/patch-package/-/patch-package-8.0.0.tgz",
+      "integrity": "sha512-da8BVIhzjtgScwDJ2TtKsfT5JFWz1hYoBl9rUQ1f38MC2HwnEIkK8VN3dKMKcP7P7bvvgzNDbfNHtx3MsQb5vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@yarnpkg/lockfile": "^1.1.0",
+        "chalk": "^4.1.2",
+        "ci-info": "^3.7.0",
+        "cross-spawn": "^7.0.3",
+        "find-yarn-workspace-root": "^2.0.0",
+        "fs-extra": "^9.0.0",
+        "json-stable-stringify": "^1.0.2",
+        "klaw-sync": "^6.0.0",
+        "minimist": "^1.2.6",
+        "open": "^7.4.2",
+        "rimraf": "^2.6.3",
+        "semver": "^7.5.3",
+        "slash": "^2.0.0",
+        "tmp": "^0.0.33",
+        "yaml": "^2.2.2"
+      },
+      "bin": {
+        "patch-package": "index.js"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">5"
+      }
+    },
+    "node_modules/patch-package/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/patch-package/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/patch-package/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/patch-package/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/patch-package/node_modules/fs-extra": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "at-least-node": "^1.0.0",
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/patch-package/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/patch-package/node_modules/rimraf": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      }
+    },
+    "node_modules/patch-package/node_modules/semver": {
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/patch-package/node_modules/slash": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+      "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/patch-package/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/patch-package/node_modules/yaml": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.5.0.tgz",
+      "integrity": "sha512-2wWLbGbYDiSqqIKoPjar3MPgB94ErzCtrNE1FdqGuaO0pi2JGjmE8aW8TDZwzU7vuxcGRdL/4gPQwQ7hD5AMSw==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/path-browserify": {
@@ -20955,6 +21267,19 @@
       "dev": true,
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tmp": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "os-tmpdir": "~1.0.2"
+      },
+      "engines": {
+        "node": ">=0.6.0"
       }
     },
     "node_modules/to-fast-properties": {

--- a/src/interfaces/assistants_web/package.json
+++ b/src/interfaces/assistants_web/package.json
@@ -22,7 +22,8 @@
     "start:single-docker-proxy": "next start --port 8090",
     "generate:client": "openapi-ts",
     "storybook": "storybook dev -p 6006",
-    "build-storybook": "storybook build"
+    "build-storybook": "storybook build",
+    "postinstall": "patch-package"
   },
   "dependencies": {
     "@floating-ui/react": "^0.26.9",
@@ -116,6 +117,7 @@
     "eslint-config-prettier": "^9.0.0",
     "eslint-plugin-storybook": "^0.8.0",
     "jsdom": "^24.1.1",
+    "patch-package": "^8.0.0",
     "postcss-100vh-fix": "^1.0.2",
     "prettier": "2.8.7",
     "prettier-plugin-tailwindcss": "0.4.1",

--- a/src/interfaces/assistants_web/patches/react-scroll-to-bottom+4.2.0.patch
+++ b/src/interfaces/assistants_web/patches/react-scroll-to-bottom+4.2.0.patch
@@ -1,0 +1,295 @@
+diff --git a/node_modules/react-scroll-to-bottom/lib/BasicScrollToBottom.js b/node_modules/react-scroll-to-bottom/lib/BasicScrollToBottom.js
+index a2ce383..0c4d0fd 100644
+--- a/node_modules/react-scroll-to-bottom/lib/BasicScrollToBottom.js
++++ b/node_modules/react-scroll-to-bottom/lib/BasicScrollToBottom.js
+@@ -43,12 +43,6 @@ var BasicScrollToBottomCore = function BasicScrollToBottomCore(_ref) {
+   }));
+ };
+
+-BasicScrollToBottomCore.defaultProps = {
+-  children: undefined,
+-  className: undefined,
+-  followButtonClassName: undefined,
+-  scrollViewClassName: undefined
+-};
+ BasicScrollToBottomCore.propTypes = {
+   children: _propTypes["default"].any,
+   className: _propTypes["default"].string,
+@@ -63,7 +57,7 @@ var BasicScrollToBottom = function BasicScrollToBottom(_ref2) {
+       debounce = _ref2.debounce,
+       debug = _ref2.debug,
+       followButtonClassName = _ref2.followButtonClassName,
+-      initialScrollBehavior = _ref2.initialScrollBehavior,
++      initialScrollBehavior = _ref2.initialScrollBehavior || 'smooth',
+       mode = _ref2.mode,
+       nonce = _ref2.nonce,
+       scroller = _ref2.scroller,
+@@ -83,19 +77,6 @@ var BasicScrollToBottom = function BasicScrollToBottom(_ref2) {
+   }, children));
+ };
+
+-BasicScrollToBottom.defaultProps = {
+-  checkInterval: undefined,
+-  children: undefined,
+-  className: undefined,
+-  debounce: undefined,
+-  debug: undefined,
+-  followButtonClassName: undefined,
+-  initialScrollBehavior: 'smooth',
+-  mode: undefined,
+-  nonce: undefined,
+-  scroller: undefined,
+-  scrollViewClassName: undefined
+-};
+ BasicScrollToBottom.propTypes = {
+   checkInterval: _propTypes["default"].number,
+   children: _propTypes["default"].any,
+diff --git a/node_modules/react-scroll-to-bottom/lib/EventSpy.js b/node_modules/react-scroll-to-bottom/lib/EventSpy.js
+index 61ad8cb..a780148 100644
+--- a/node_modules/react-scroll-to-bottom/lib/EventSpy.js
++++ b/node_modules/react-scroll-to-bottom/lib/EventSpy.js
+@@ -19,7 +19,7 @@ var _react = require("react");
+ var _debounce = _interopRequireDefault(require("./debounce"));
+
+ var EventSpy = function EventSpy(_ref) {
+-  var debounce = _ref.debounce,
++  var debounce = _ref.debounce || 200,
+       name = _ref.name,
+       onEvent = _ref.onEvent,
+       target = _ref.target;
+@@ -52,9 +52,6 @@ var EventSpy = function EventSpy(_ref) {
+   return false;
+ };
+
+-EventSpy.defaultProps = {
+-  debounce: 200
+-};
+ var _default = EventSpy;
+ exports["default"] = _default;
+ //# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbIi4uL3NyYy9FdmVudFNweS5qcyJdLCJuYW1lcyI6WyJFdmVudFNweSIsImRlYm91bmNlIiwibmFtZSIsIm9uRXZlbnQiLCJ0YXJnZXQiLCJvbkV2ZW50UmVmIiwiY3VycmVudCIsImRlYm91bmNlciIsImV2ZW50IiwiaGFuZGxlRXZlbnQiLCJ0aW1lU3RhbXBMb3ciLCJhZGRFdmVudExpc3RlbmVyIiwicGFzc2l2ZSIsInR5cGUiLCJyZW1vdmVFdmVudExpc3RlbmVyIiwiZGVmYXVsdFByb3BzIl0sIm1hcHBpbmdzIjoiOzs7Ozs7Ozs7Ozs7Ozs7O0FBQUE7O0FBRUE7O0FBRUEsSUFBTUEsUUFBUSxHQUFHLFNBQVhBLFFBQVcsT0FBeUM7QUFBQSxNQUF0Q0MsUUFBc0MsUUFBdENBLFFBQXNDO0FBQUEsTUFBNUJDLElBQTRCLFFBQTVCQSxJQUE0QjtBQUFBLE1BQXRCQyxPQUFzQixRQUF0QkEsT0FBc0I7QUFBQSxNQUFiQyxNQUFhLFFBQWJBLE1BQWE7QUFDeEQ7QUFDQTtBQUNBLE1BQU1DLFVBQVUsR0FBRyxvQkFBbkI7QUFFQUEsRUFBQUEsVUFBVSxDQUFDQyxPQUFYLEdBQXFCSCxPQUFyQjtBQUVBLE1BQU1JLFNBQVMsR0FBRyxvQkFDaEI7QUFBQSxXQUNFLDBCQUFXLFVBQUFDLEtBQUssRUFBSTtBQUNsQixVQUFRRixPQUFSLEdBQW9CRCxVQUFwQixDQUFRQyxPQUFSO0FBRUFBLE1BQUFBLE9BQU8sSUFBSUEsT0FBTyxDQUFDRSxLQUFELENBQWxCO0FBQ0QsS0FKRCxFQUlHUCxRQUpILENBREY7QUFBQSxHQURnQixFQU9oQixDQUFDQSxRQUFELEVBQVdJLFVBQVgsQ0FQZ0IsQ0FBbEI7QUFVQSxNQUFNSSxXQUFXLEdBQUcsd0JBQ2xCLFVBQUFELEtBQUssRUFBSTtBQUNQQSxJQUFBQSxLQUFLLENBQUNFLFlBQU4sR0FBcUIsc0JBQXJCO0FBRUFILElBQUFBLFNBQVMsQ0FBQ0MsS0FBRCxDQUFUO0FBQ0QsR0FMaUIsRUFNbEIsQ0FBQ0QsU0FBRCxDQU5rQixDQUFwQjtBQVNBLDhCQUFnQixZQUFNO0FBQ3BCSCxJQUFBQSxNQUFNLENBQUNPLGdCQUFQLENBQXdCVCxJQUF4QixFQUE4Qk8sV0FBOUIsRUFBMkM7QUFBRUcsTUFBQUEsT0FBTyxFQUFFO0FBQVgsS0FBM0M7QUFDQUgsSUFBQUEsV0FBVyxDQUFDO0FBQUVMLE1BQUFBLE1BQU0sRUFBTkEsTUFBRjtBQUFVUyxNQUFBQSxJQUFJLEVBQUVYO0FBQWhCLEtBQUQsQ0FBWDtBQUVBLFdBQU87QUFBQSxhQUFNRSxNQUFNLENBQUNVLG1CQUFQLENBQTJCWixJQUEzQixFQUFpQ08sV0FBakMsQ0FBTjtBQUFBLEtBQVA7QUFDRCxHQUxELEVBS0csQ0FBQ1AsSUFBRCxFQUFPTyxXQUFQLEVBQW9CTCxNQUFwQixDQUxIO0FBT0EsU0FBTyxLQUFQO0FBQ0QsQ0FsQ0Q7O0FBb0NBSixRQUFRLENBQUNlLFlBQVQsR0FBd0I7QUFDdEJkLEVBQUFBLFFBQVEsRUFBRTtBQURZLENBQXhCO2VBSWVELFEiLCJzb3VyY2VzQ29udGVudCI6WyJpbXBvcnQgeyB1c2VDYWxsYmFjaywgdXNlTGF5b3V0RWZmZWN0LCB1c2VNZW1vLCB1c2VSZWYgfSBmcm9tICdyZWFjdCc7XG5cbmltcG9ydCBkZWJvdW5jZUZuIGZyb20gJy4vZGVib3VuY2UnO1xuXG5jb25zdCBFdmVudFNweSA9ICh7IGRlYm91bmNlLCBuYW1lLCBvbkV2ZW50LCB0YXJnZXQgfSkgPT4ge1xuICAvLyBXZSBuZWVkIHRvIHNhdmUgdGhlIFwib25FdmVudFwiIHRvIHJlZi5cbiAgLy8gVGhpcyBpcyBiZWNhdXNlIFwib25FdmVudFwiIG1heSBjaGFuZ2UgZnJvbSB0aW1lIHRvIHRpbWUsIGJ1dCBkZWJvdW5jZSBtYXkgc3RpbGwgZmlyZSB0byB0aGUgb2xkZXIgY2FsbGJhY2suXG4gIGNvbnN0IG9uRXZlbnRSZWYgPSB1c2VSZWYoKTtcblxuICBvbkV2ZW50UmVmLmN1cnJlbnQgPSBvbkV2ZW50O1xuXG4gIGNvbnN0IGRlYm91bmNlciA9IHVzZU1lbW8oXG4gICAgKCkgPT5cbiAgICAgIGRlYm91bmNlRm4oZXZlbnQgPT4ge1xuICAgICAgICBjb25zdCB7IGN1cnJlbnQgfSA9IG9uRXZlbnRSZWY7XG5cbiAgICAgICAgY3VycmVudCAmJiBjdXJyZW50KGV2ZW50KTtcbiAgICAgIH0sIGRlYm91bmNlKSxcbiAgICBbZGVib3VuY2UsIG9uRXZlbnRSZWZdXG4gICk7XG5cbiAgY29uc3QgaGFuZGxlRXZlbnQgPSB1c2VDYWxsYmFjayhcbiAgICBldmVudCA9PiB7XG4gICAgICBldmVudC50aW1lU3RhbXBMb3cgPSBEYXRlLm5vdygpO1xuXG4gICAgICBkZWJvdW5jZXIoZXZlbnQpO1xuICAgIH0sXG4gICAgW2RlYm91bmNlcl1cbiAgKTtcblxuICB1c2VMYXlvdXRFZmZlY3QoKCkgPT4ge1xuICAgIHRhcmdldC5hZGRFdmVudExpc3RlbmVyKG5hbWUsIGhhbmRsZUV2ZW50LCB7IHBhc3NpdmU6IHRydWUgfSk7XG4gICAgaGFuZGxlRXZlbnQoeyB0YXJnZXQsIHR5cGU6IG5hbWUgfSk7XG5cbiAgICByZXR1cm4gKCkgPT4gdGFyZ2V0LnJlbW92ZUV2ZW50TGlzdGVuZXIobmFtZSwgaGFuZGxlRXZlbnQpO1xuICB9LCBbbmFtZSwgaGFuZGxlRXZlbnQsIHRhcmdldF0pO1xuXG4gIHJldHVybiBmYWxzZTtcbn07XG5cbkV2ZW50U3B5LmRlZmF1bHRQcm9wcyA9IHtcbiAgZGVib3VuY2U6IDIwMFxufTtcblxuZXhwb3J0IGRlZmF1bHQgRXZlbnRTcHk7XG4iXX0=
+diff --git a/node_modules/react-scroll-to-bottom/lib/ScrollToBottom/AutoHideFollowButton.js b/node_modules/react-scroll-to-bottom/lib/ScrollToBottom/AutoHideFollowButton.js
+index 79c5ade..7e1c3aa 100644
+--- a/node_modules/react-scroll-to-bottom/lib/ScrollToBottom/AutoHideFollowButton.js
++++ b/node_modules/react-scroll-to-bottom/lib/ScrollToBottom/AutoHideFollowButton.js
+@@ -45,7 +45,7 @@ var ROOT_STYLE = {
+
+ var AutoHideFollowButton = function AutoHideFollowButton(_ref) {
+   var children = _ref.children,
+-      className = _ref.className;
++      className = _ref.className || '';
+
+   var _useSticky = (0, _useSticky3["default"])(),
+       _useSticky2 = (0, _slicedToArray2["default"])(_useSticky, 1),
+@@ -60,10 +60,6 @@ var AutoHideFollowButton = function AutoHideFollowButton(_ref) {
+   }, children);
+ };
+
+-AutoHideFollowButton.defaultProps = {
+-  children: undefined,
+-  className: ''
+-};
+ AutoHideFollowButton.propTypes = {
+   children: _propTypes["default"].any,
+   className: _propTypes["default"].string
+diff --git a/node_modules/react-scroll-to-bottom/lib/ScrollToBottom/Composer.js b/node_modules/react-scroll-to-bottom/lib/ScrollToBottom/Composer.js
+index 1d5f8b1..130643e 100644
+--- a/node_modules/react-scroll-to-bottom/lib/ScrollToBottom/Composer.js
++++ b/node_modules/react-scroll-to-bottom/lib/ScrollToBottom/Composer.js
+@@ -129,14 +129,14 @@ function isEnd(animateTo, mode) {
+ }
+
+ var Composer = function Composer(_ref2) {
+-  var checkInterval = _ref2.checkInterval,
++  var checkInterval = _ref2.checkInterval || 100,
+       children = _ref2.children,
+-      debounce = _ref2.debounce,
++      debounce = _ref2.debounce || 17,
+       debugFromProp = _ref2.debug,
+-      initialScrollBehavior = _ref2.initialScrollBehavior,
++      initialScrollBehavior = _ref2.initialScrollBehavior || 'smooth',
+       mode = _ref2.mode,
+       nonce = _ref2.nonce,
+-      scroller = _ref2.scroller;
++      scroller = _ref2.scroller || DEFAULT_SCROLLER;
+   var debug = (0, _react.useMemo)(function () {
+     return (0, _debug["default"])("<ScrollToBottom>", {
+       force: debugFromProp
+@@ -660,16 +660,6 @@ var Composer = function Composer(_ref2) {
+   }))))));
+ };
+
+-Composer.defaultProps = {
+-  checkInterval: 100,
+-  children: undefined,
+-  debounce: 17,
+-  debug: undefined,
+-  initialScrollBehavior: 'smooth',
+-  mode: undefined,
+-  nonce: undefined,
+-  scroller: DEFAULT_SCROLLER
+-};
+ Composer.propTypes = {
+   checkInterval: _propTypes["default"].number,
+   children: _propTypes["default"].any,
+diff --git a/node_modules/react-scroll-to-bottom/lib/ScrollToBottom/Panel.js b/node_modules/react-scroll-to-bottom/lib/ScrollToBottom/Panel.js
+index 24f9403..f8047e3 100644
+--- a/node_modules/react-scroll-to-bottom/lib/ScrollToBottom/Panel.js
++++ b/node_modules/react-scroll-to-bottom/lib/ScrollToBottom/Panel.js
+@@ -50,10 +50,6 @@ var Panel = function Panel(_ref) {
+   }, children);
+ };
+
+-Panel.defaultProps = {
+-  children: undefined,
+-  className: undefined
+-};
+ Panel.propTypes = {
+   children: _propTypes["default"].any,
+   className: _propTypes["default"].string
+diff --git a/node_modules/react-scroll-to-bottom/lib/esm/BasicScrollToBottom.js b/node_modules/react-scroll-to-bottom/lib/esm/BasicScrollToBottom.js
+index 5b18efa..5f38d2f 100644
+--- a/node_modules/react-scroll-to-bottom/lib/esm/BasicScrollToBottom.js
++++ b/node_modules/react-scroll-to-bottom/lib/esm/BasicScrollToBottom.js
+@@ -24,12 +24,6 @@ var BasicScrollToBottomCore = function BasicScrollToBottomCore(_ref) {
+   }));
+ };
+
+-BasicScrollToBottomCore.defaultProps = {
+-  children: undefined,
+-  className: undefined,
+-  followButtonClassName: undefined,
+-  scrollViewClassName: undefined
+-};
+ BasicScrollToBottomCore.propTypes = {
+   children: PropTypes.any,
+   className: PropTypes.string,
+@@ -44,7 +38,7 @@ var BasicScrollToBottom = function BasicScrollToBottom(_ref2) {
+       debounce = _ref2.debounce,
+       debug = _ref2.debug,
+       followButtonClassName = _ref2.followButtonClassName,
+-      initialScrollBehavior = _ref2.initialScrollBehavior,
++      initialScrollBehavior = _ref2.initialScrollBehavior || 'smooth',
+       mode = _ref2.mode,
+       nonce = _ref2.nonce,
+       scroller = _ref2.scroller,
+@@ -64,19 +58,6 @@ var BasicScrollToBottom = function BasicScrollToBottom(_ref2) {
+   }, children));
+ };
+
+-BasicScrollToBottom.defaultProps = {
+-  checkInterval: undefined,
+-  children: undefined,
+-  className: undefined,
+-  debounce: undefined,
+-  debug: undefined,
+-  followButtonClassName: undefined,
+-  initialScrollBehavior: 'smooth',
+-  mode: undefined,
+-  nonce: undefined,
+-  scroller: undefined,
+-  scrollViewClassName: undefined
+-};
+ BasicScrollToBottom.propTypes = {
+   checkInterval: PropTypes.number,
+   children: PropTypes.any,
+diff --git a/node_modules/react-scroll-to-bottom/lib/esm/EventSpy.js b/node_modules/react-scroll-to-bottom/lib/esm/EventSpy.js
+index d0fd800..b5fd3cb 100644
+--- a/node_modules/react-scroll-to-bottom/lib/esm/EventSpy.js
++++ b/node_modules/react-scroll-to-bottom/lib/esm/EventSpy.js
+@@ -4,7 +4,7 @@ import { useCallback, useLayoutEffect, useMemo, useRef } from 'react';
+ import debounceFn from './debounce';
+
+ var EventSpy = function EventSpy(_ref) {
+-  var debounce = _ref.debounce,
++  var debounce = _ref.debounce || 200,
+       name = _ref.name,
+       onEvent = _ref.onEvent,
+       target = _ref.target;
+@@ -37,8 +37,5 @@ var EventSpy = function EventSpy(_ref) {
+   return false;
+ };
+
+-EventSpy.defaultProps = {
+-  debounce: 200
+-};
+ export default EventSpy;
+ //# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbIi4uLy4uL3NyYy9FdmVudFNweS5qcyJdLCJuYW1lcyI6WyJ1c2VDYWxsYmFjayIsInVzZUxheW91dEVmZmVjdCIsInVzZU1lbW8iLCJ1c2VSZWYiLCJkZWJvdW5jZUZuIiwiRXZlbnRTcHkiLCJkZWJvdW5jZSIsIm5hbWUiLCJvbkV2ZW50IiwidGFyZ2V0Iiwib25FdmVudFJlZiIsImN1cnJlbnQiLCJkZWJvdW5jZXIiLCJldmVudCIsImhhbmRsZUV2ZW50IiwidGltZVN0YW1wTG93IiwiYWRkRXZlbnRMaXN0ZW5lciIsInBhc3NpdmUiLCJ0eXBlIiwicmVtb3ZlRXZlbnRMaXN0ZW5lciIsImRlZmF1bHRQcm9wcyJdLCJtYXBwaW5ncyI6Ijs7QUFBQSxTQUFTQSxXQUFULEVBQXNCQyxlQUF0QixFQUF1Q0MsT0FBdkMsRUFBZ0RDLE1BQWhELFFBQThELE9BQTlEO0FBRUEsT0FBT0MsVUFBUCxNQUF1QixZQUF2Qjs7QUFFQSxJQUFNQyxRQUFRLEdBQUcsU0FBWEEsUUFBVyxPQUF5QztBQUFBLE1BQXRDQyxRQUFzQyxRQUF0Q0EsUUFBc0M7QUFBQSxNQUE1QkMsSUFBNEIsUUFBNUJBLElBQTRCO0FBQUEsTUFBdEJDLE9BQXNCLFFBQXRCQSxPQUFzQjtBQUFBLE1BQWJDLE1BQWEsUUFBYkEsTUFBYTtBQUN4RDtBQUNBO0FBQ0EsTUFBTUMsVUFBVSxHQUFHUCxNQUFNLEVBQXpCO0FBRUFPLEVBQUFBLFVBQVUsQ0FBQ0MsT0FBWCxHQUFxQkgsT0FBckI7QUFFQSxNQUFNSSxTQUFTLEdBQUdWLE9BQU8sQ0FDdkI7QUFBQSxXQUNFRSxVQUFVLENBQUMsVUFBQVMsS0FBSyxFQUFJO0FBQ2xCLFVBQVFGLE9BQVIsR0FBb0JELFVBQXBCLENBQVFDLE9BQVI7QUFFQUEsTUFBQUEsT0FBTyxJQUFJQSxPQUFPLENBQUNFLEtBQUQsQ0FBbEI7QUFDRCxLQUpTLEVBSVBQLFFBSk8sQ0FEWjtBQUFBLEdBRHVCLEVBT3ZCLENBQUNBLFFBQUQsRUFBV0ksVUFBWCxDQVB1QixDQUF6QjtBQVVBLE1BQU1JLFdBQVcsR0FBR2QsV0FBVyxDQUM3QixVQUFBYSxLQUFLLEVBQUk7QUFDUEEsSUFBQUEsS0FBSyxDQUFDRSxZQUFOLEdBQXFCLFdBQXJCO0FBRUFILElBQUFBLFNBQVMsQ0FBQ0MsS0FBRCxDQUFUO0FBQ0QsR0FMNEIsRUFNN0IsQ0FBQ0QsU0FBRCxDQU42QixDQUEvQjtBQVNBWCxFQUFBQSxlQUFlLENBQUMsWUFBTTtBQUNwQlEsSUFBQUEsTUFBTSxDQUFDTyxnQkFBUCxDQUF3QlQsSUFBeEIsRUFBOEJPLFdBQTlCLEVBQTJDO0FBQUVHLE1BQUFBLE9BQU8sRUFBRTtBQUFYLEtBQTNDO0FBQ0FILElBQUFBLFdBQVcsQ0FBQztBQUFFTCxNQUFBQSxNQUFNLEVBQU5BLE1BQUY7QUFBVVMsTUFBQUEsSUFBSSxFQUFFWDtBQUFoQixLQUFELENBQVg7QUFFQSxXQUFPO0FBQUEsYUFBTUUsTUFBTSxDQUFDVSxtQkFBUCxDQUEyQlosSUFBM0IsRUFBaUNPLFdBQWpDLENBQU47QUFBQSxLQUFQO0FBQ0QsR0FMYyxFQUtaLENBQUNQLElBQUQsRUFBT08sV0FBUCxFQUFvQkwsTUFBcEIsQ0FMWSxDQUFmO0FBT0EsU0FBTyxLQUFQO0FBQ0QsQ0FsQ0Q7O0FBb0NBSixRQUFRLENBQUNlLFlBQVQsR0FBd0I7QUFDdEJkLEVBQUFBLFFBQVEsRUFBRTtBQURZLENBQXhCO0FBSUEsZUFBZUQsUUFBZiIsInNvdXJjZXNDb250ZW50IjpbImltcG9ydCB7IHVzZUNhbGxiYWNrLCB1c2VMYXlvdXRFZmZlY3QsIHVzZU1lbW8sIHVzZVJlZiB9IGZyb20gJ3JlYWN0JztcblxuaW1wb3J0IGRlYm91bmNlRm4gZnJvbSAnLi9kZWJvdW5jZSc7XG5cbmNvbnN0IEV2ZW50U3B5ID0gKHsgZGVib3VuY2UsIG5hbWUsIG9uRXZlbnQsIHRhcmdldCB9KSA9PiB7XG4gIC8vIFdlIG5lZWQgdG8gc2F2ZSB0aGUgXCJvbkV2ZW50XCIgdG8gcmVmLlxuICAvLyBUaGlzIGlzIGJlY2F1c2UgXCJvbkV2ZW50XCIgbWF5IGNoYW5nZSBmcm9tIHRpbWUgdG8gdGltZSwgYnV0IGRlYm91bmNlIG1heSBzdGlsbCBmaXJlIHRvIHRoZSBvbGRlciBjYWxsYmFjay5cbiAgY29uc3Qgb25FdmVudFJlZiA9IHVzZVJlZigpO1xuXG4gIG9uRXZlbnRSZWYuY3VycmVudCA9IG9uRXZlbnQ7XG5cbiAgY29uc3QgZGVib3VuY2VyID0gdXNlTWVtbyhcbiAgICAoKSA9PlxuICAgICAgZGVib3VuY2VGbihldmVudCA9PiB7XG4gICAgICAgIGNvbnN0IHsgY3VycmVudCB9ID0gb25FdmVudFJlZjtcblxuICAgICAgICBjdXJyZW50ICYmIGN1cnJlbnQoZXZlbnQpO1xuICAgICAgfSwgZGVib3VuY2UpLFxuICAgIFtkZWJvdW5jZSwgb25FdmVudFJlZl1cbiAgKTtcblxuICBjb25zdCBoYW5kbGVFdmVudCA9IHVzZUNhbGxiYWNrKFxuICAgIGV2ZW50ID0+IHtcbiAgICAgIGV2ZW50LnRpbWVTdGFtcExvdyA9IERhdGUubm93KCk7XG5cbiAgICAgIGRlYm91bmNlcihldmVudCk7XG4gICAgfSxcbiAgICBbZGVib3VuY2VyXVxuICApO1xuXG4gIHVzZUxheW91dEVmZmVjdCgoKSA9PiB7XG4gICAgdGFyZ2V0LmFkZEV2ZW50TGlzdGVuZXIobmFtZSwgaGFuZGxlRXZlbnQsIHsgcGFzc2l2ZTogdHJ1ZSB9KTtcbiAgICBoYW5kbGVFdmVudCh7IHRhcmdldCwgdHlwZTogbmFtZSB9KTtcblxuICAgIHJldHVybiAoKSA9PiB0YXJnZXQucmVtb3ZlRXZlbnRMaXN0ZW5lcihuYW1lLCBoYW5kbGVFdmVudCk7XG4gIH0sIFtuYW1lLCBoYW5kbGVFdmVudCwgdGFyZ2V0XSk7XG5cbiAgcmV0dXJuIGZhbHNlO1xufTtcblxuRXZlbnRTcHkuZGVmYXVsdFByb3BzID0ge1xuICBkZWJvdW5jZTogMjAwXG59O1xuXG5leHBvcnQgZGVmYXVsdCBFdmVudFNweTtcbiJdfQ==
+diff --git a/node_modules/react-scroll-to-bottom/lib/esm/ScrollToBottom/AutoHideFollowButton.js b/node_modules/react-scroll-to-bottom/lib/esm/ScrollToBottom/AutoHideFollowButton.js
+index eca67c2..8bdc2a5 100644
+--- a/node_modules/react-scroll-to-bottom/lib/esm/ScrollToBottom/AutoHideFollowButton.js
++++ b/node_modules/react-scroll-to-bottom/lib/esm/ScrollToBottom/AutoHideFollowButton.js
+@@ -26,7 +26,7 @@ var ROOT_STYLE = {
+
+ var AutoHideFollowButton = function AutoHideFollowButton(_ref) {
+   var children = _ref.children,
+-      className = _ref.className;
++      className = _ref.className || '';
+
+   var _useSticky = useSticky(),
+       _useSticky2 = _slicedToArray(_useSticky, 1),
+@@ -41,10 +41,6 @@ var AutoHideFollowButton = function AutoHideFollowButton(_ref) {
+   }, children);
+ };
+
+-AutoHideFollowButton.defaultProps = {
+-  children: undefined,
+-  className: ''
+-};
+ AutoHideFollowButton.propTypes = {
+   children: PropTypes.any,
+   className: PropTypes.string
+diff --git a/node_modules/react-scroll-to-bottom/lib/esm/ScrollToBottom/Composer.js b/node_modules/react-scroll-to-bottom/lib/esm/ScrollToBottom/Composer.js
+index f5cec94..d063e1c 100644
+--- a/node_modules/react-scroll-to-bottom/lib/esm/ScrollToBottom/Composer.js
++++ b/node_modules/react-scroll-to-bottom/lib/esm/ScrollToBottom/Composer.js
+@@ -79,14 +79,14 @@ function isEnd(animateTo, mode) {
+ }
+
+ var Composer = function Composer(_ref2) {
+-  var checkInterval = _ref2.checkInterval,
++  var checkInterval = _ref2.checkInterval || 100,
+       children = _ref2.children,
+-      debounce = _ref2.debounce,
++      debounce = _ref2.debounce || 17,
+       debugFromProp = _ref2.debug,
+-      initialScrollBehavior = _ref2.initialScrollBehavior,
++      initialScrollBehavior = _ref2.initialScrollBehavior || 'smooth',
+       mode = _ref2.mode,
+       nonce = _ref2.nonce,
+-      scroller = _ref2.scroller;
++      scroller = _ref2.scroller || DEFAULT_SCROLLER;
+   var debug = useMemo(function () {
+     return createDebug("<ScrollToBottom>", {
+       force: debugFromProp
+@@ -613,16 +613,6 @@ var Composer = function Composer(_ref2) {
+   }))))));
+ };
+
+-Composer.defaultProps = {
+-  checkInterval: 100,
+-  children: undefined,
+-  debounce: 17,
+-  debug: undefined,
+-  initialScrollBehavior: 'smooth',
+-  mode: undefined,
+-  nonce: undefined,
+-  scroller: DEFAULT_SCROLLER
+-};
+ Composer.propTypes = {
+   checkInterval: PropTypes.number,
+   children: PropTypes.any,
+diff --git a/node_modules/react-scroll-to-bottom/lib/esm/ScrollToBottom/Panel.js b/node_modules/react-scroll-to-bottom/lib/esm/ScrollToBottom/Panel.js
+index 02008df..5e5b11c 100644
+--- a/node_modules/react-scroll-to-bottom/lib/esm/ScrollToBottom/Panel.js
++++ b/node_modules/react-scroll-to-bottom/lib/esm/ScrollToBottom/Panel.js
+@@ -23,10 +23,6 @@ var Panel = function Panel(_ref) {
+   }, children);
+ };
+
+-Panel.defaultProps = {
+-  children: undefined,
+-  className: undefined
+-};
+ Panel.propTypes = {
+   children: PropTypes.any,
+   className: PropTypes.string


### PR DESCRIPTION
This fixes the React warnings of package `react-scroll-to-bottom` regarding `defaultProps`. Package development seems to be stalled at the moment, therefore applying as patch.

Fix is automatically applied when running node package install.

Reference: [PR on `react-scroll-to-bottom`](https://github.com/compulim/react-scroll-to-bottom/pull/141)
