### PR TITLE
Create search_orders.py

### DIFF
--- a/src/backend/tools/search_orders.py
+++ b/src/backend/tools/search_orders.py
@@ -1,0 +1,48 @@
+from typing import Any, Dict, List
+
+from backend.tools.base import BaseTool
+
+
+class SearchPendingOrders(BaseTool):
+    """
+    Searches the order management database for customers with pending verification.
+    """
+
+    NAME = "search_pending_orders"
+
+    @classmethod
+    def is_available(cls) -> bool:
+        return True
+
+    async def call(
+        self, parameters: dict, ctx: Any, **kwargs: Any
+    ) -> List[Dict[str, Any]]:
+        logger = ctx.get_logger()
+
+        # Get the status parameter from the request
+        status = parameters.get("status", "")
+
+        # Mock database query, in a real scenario, this would connect to a database
+        mock_database = [
+            {'customer': 'Alice Johnson', 'email': 'alice@example.com', 'status': 'pending verification'},
+            {'customer': 'Bob Smith', 'email': 'bob@example.com', 'status': 'completed'},
+            {'customer': 'Carol Davis', 'email': 'carol@example.com', 'status': 'pending verification'},
+            # ... more mock data ...
+        ]
+
+        # Filter the mock database for orders with the specified status
+        filtered_orders = [order for order in mock_database if order['status'] == status]
+
+        customers_info = []
+        for order in filtered_orders:
+            customer_info = {
+                "customer": order['customer'],
+                "email": order['email']
+            }
+            customers_info.append(customer_info)
+
+        result = {
+            "customers_with_pending_verification": customers_info
+        }
+
+        return [result]


### PR DESCRIPTION
Thank you for contributing to the Cohere Toolkit!

- [ ] **PR title**: "area: description"
  - Where "area" is whichever of interface, frontend, model, tools, backend, etc. is being modified. Use "docs: ..." for purely docs changes, "infra: ..." for CI changes.
  - Example: "deployment: add Azure model option"


- [ ] **PR message**: ***Delete this entire checklist*** and replace with
    - **Description:** a description of the change
    - **Issue:** the issue # it fixes, if applicable
    - **Dependencies:** any dependencies required for this change


- [ ] **Add tests and docs**: Please include testing and documentation for your changes
- [ ] **Lint and test**: Run `make lint` and `make run-tests`

**AI Description**

<!-- begin-generated-description -->

The PR introduces a new class `SearchPendingOrders` that extends the `BaseTool` class. This class is designed to search the order management database for customers with pending verification.

- The `SearchPendingOrders` class is defined with a `NAME` attribute set to "search_pending_orders".
- The `is_available` class method returns `True`, indicating that the tool is available for use.
- The `call` method is an asynchronous function that takes parameters, context, and keyword arguments as inputs. It returns a list of dictionaries containing customer information.
- Inside the `call` method, a logger is obtained from the context, and the status parameter is extracted from the request parameters.
- A mock database is defined as a list of dictionaries, each representing a customer with their details, including customer name, email, and status.
- The mock database is filtered based on the specified status, creating a list of orders with the matching status.
- A loop iterates over the filtered orders, extracting customer and email information and appending it to a `customers_info` list.
- Finally, the `result` dictionary is created, containing the `customers_info` list under the key "customers_with_pending_verification". The method returns a list containing this result.

<!-- end-generated-description -->
