### PR TITLE
chore: Add more frontend codeowners to deal with security issues

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,3 @@
 * @cohere-ai/toolkit @EugeneLightsOn @malexw @scottmx81 @tianjing-li
-src/interfaces/coral_web @tomtobac @abimacarmes @knajjars @BeatrixCohere
-src/interfaces/assistants_web @tomtobac @abimacarmes @knajjars @BeatrixCohere
+src/interfaces/coral_web @tomtobac @abimacarmes @knajjars @BeatrixCohere @tianjing-li
+src/interfaces/assistants_web @tomtobac @abimacarmes @knajjars @BeatrixCohere @tianjing-li


### PR DESCRIPTION
There are several dependency upgrades that can only be merged with a codeowner approval, adding myself to the list so I can review and approve the frontend bumps without having to ping and disturb constantly