### PR TITLE
backend: add new Cohere Platform models to seeder

### DIFF
--- a/src/backend/database_models/seeders/deplyments_models_seed.py
+++ b/src/backend/database_models/seeders/deplyments_models_seed.py
@@ -47,6 +47,18 @@ MODELS_NAME_MAPPING = {
             "cohere_name": "c4ai-aya-23",
             "is_default": False,
         },
+        "c4ai-aya-23-35b": {
+            "cohere_name": "c4ai-aya-23-35b",
+            "is_default": False,
+        },
+        "command-r-08-2024": {
+            "cohere_name": "command-r-08-2024",
+            "is_default": False,
+        },
+        "command-r-plus-08-2024": {
+            "cohere_name": "command-r-plus-08-2024",
+            "is_default": False,
+        },
     },
     ModelDeploymentName.SingleContainer: {
         "command": {
@@ -75,6 +87,18 @@ MODELS_NAME_MAPPING = {
         },
         "c4ai-aya-23": {
             "cohere_name": "c4ai-aya-23",
+            "is_default": False,
+        },
+        "c4ai-aya-23-35b": {
+            "cohere_name": "c4ai-aya-23-35b",
+            "is_default": False,
+        },
+        "command-r-08-2024": {
+            "cohere_name": "command-r-08-2024",
+            "is_default": False,
+        },
+        "command-r-plus-08-2024": {
+            "cohere_name": "command-r-plus-08-2024",
             "is_default": False,
         },
     },

--- a/src/backend/model_deployments/cohere_platform.py
+++ b/src/backend/model_deployments/cohere_platform.py
@@ -55,11 +55,7 @@ class CohereDeployment(BaseDeployment):
             return []
 
         models = response.json()["models"]
-        return [
-            model["name"]
-            for model in models
-            if model.get("endpoints") and "chat" in model["endpoints"]
-        ]
+        return [model["name"] for model in models if model.get("endpoints") and "chat" in model["endpoints"]]
 
     @classmethod
     def is_available(cls) -> bool:


### PR DESCRIPTION
<!-- begin-generated-description -->

This pull request introduces changes to two files, `src/backend/database_models/seeders/deplyments_models_seed.py` and `src/backend/model_deployments/cohere_platform.py`.

## `src/backend/database_models/seeders/deplyments_models_seed.py`
This file undergoes the following modifications:
- Addition of four new dictionaries: `"c4ai-aya-23-35b"`, `"command-r-08-2024"`, `"command-r-plus-08-2024"`, and `"c4ai-aya-23-35b"`. These dictionaries are nested within the `ModelDeploymentName.SingleContainer` and `ModelDeploymentName.MultiContainer` objects.

## `src/backend/model_deployments/cohere_platform.py`
The `list_models` function is updated to streamline the filtering process by removing unnecessary indentation and simplifying the list comprehension.

<!-- end-generated-description -->