### PR TITLE
slackbot: Bump @slack/bolt and prism to latest versions

### DIFF
--- a/src/interfaces/slack_bot/package-lock.json
+++ b/src/interfaces/slack_bot/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@microsoft/fetch-event-source": "^2.0.1",
-        "@prisma/client": "5.14.0",
+        "@prisma/client": "^5.20.0",
         "@sentry/node": "^7.64.0",
         "@slack/bolt": "^3.18.0",
         "@slack/web-api": "^6.12.0",
@@ -1046,9 +1046,9 @@
       "integrity": "sha512-j7P6Rgr3mmtdkeDGTe0E/aYyWEWVtc5yFXtHCRHs28/jptDEWfaVOc5T7cblqy1XKPPfCxJc/8DwQ5YgLOZOVQ=="
     },
     "node_modules/@prisma/client": {
-      "version": "5.14.0",
-      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-5.14.0.tgz",
-      "integrity": "sha512-akMSuyvLKeoU4LeyBAUdThP/uhVP3GuLygFE3MlYzaCb3/J8SfsYBE5PkaFuLuVpLyA6sFoW+16z/aPhNAESqg==",
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-5.20.0.tgz",
+      "integrity": "sha512-CLv55ZuMuUawMsxoqxGtLT3bEZoa2W8L3Qnp6rDIFWy+ZBrUcOFKdoeGPSnbBqxc3SkdxJrF+D1veN/WNynZYA==",
       "hasInstallScript": true,
       "engines": {
         "node": ">=16.13"
@@ -1063,43 +1063,43 @@
       }
     },
     "node_modules/@prisma/debug": {
-      "version": "5.16.2",
-      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-5.16.2.tgz",
-      "integrity": "sha512-ItzB4nR4O8eLzuJiuP3WwUJfoIvewMHqpGCad+64gvThcKEVOtaUza9AEJo2DPqAOa/AWkFyK54oM4WwHeew+A=="
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-5.20.0.tgz",
+      "integrity": "sha512-oCx79MJ4HSujokA8S1g0xgZUGybD4SyIOydoHMngFYiwEwYDQ5tBQkK5XoEHuwOYDKUOKRn/J0MEymckc4IgsQ=="
     },
     "node_modules/@prisma/engines": {
-      "version": "5.16.2",
-      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-5.16.2.tgz",
-      "integrity": "sha512-qUxwMtrwoG3byd4PbX6T7EjHJ8AUhzTuwniOGkh/hIznBfcE2QQnGakyEq4VnwNuttMqvh/GgPFapHQ3lCuRHg==",
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-5.20.0.tgz",
+      "integrity": "sha512-DtqkP+hcZvPEbj8t8dK5df2b7d3B8GNauKqaddRRqQBBlgkbdhJkxhoJTrOowlS3vaRt2iMCkU0+CSNn0KhqAQ==",
       "hasInstallScript": true,
       "dependencies": {
-        "@prisma/debug": "5.16.2",
-        "@prisma/engines-version": "5.16.0-24.34ace0eb2704183d2c05b60b52fba5c43c13f303",
-        "@prisma/fetch-engine": "5.16.2",
-        "@prisma/get-platform": "5.16.2"
+        "@prisma/debug": "5.20.0",
+        "@prisma/engines-version": "5.20.0-12.06fc58a368dc7be9fbbbe894adf8d445d208c284",
+        "@prisma/fetch-engine": "5.20.0",
+        "@prisma/get-platform": "5.20.0"
       }
     },
     "node_modules/@prisma/engines-version": {
-      "version": "5.16.0-24.34ace0eb2704183d2c05b60b52fba5c43c13f303",
-      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-5.16.0-24.34ace0eb2704183d2c05b60b52fba5c43c13f303.tgz",
-      "integrity": "sha512-HkT2WbfmFZ9WUPyuJHhkiADxazHg8Y4gByrTSVeb3OikP6tjQ7txtSUGu9OBOBH0C13dPKN2qqH12xKtHu/Hiw=="
+      "version": "5.20.0-12.06fc58a368dc7be9fbbbe894adf8d445d208c284",
+      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-5.20.0-12.06fc58a368dc7be9fbbbe894adf8d445d208c284.tgz",
+      "integrity": "sha512-Lg8AS5lpi0auZe2Mn4gjuCg081UZf88k3cn0RCwHgR+6cyHHpttPZBElJTHf83ZGsRNAmVCZCfUGA57WB4u4JA=="
     },
     "node_modules/@prisma/fetch-engine": {
-      "version": "5.16.2",
-      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-5.16.2.tgz",
-      "integrity": "sha512-sq51lfHKfH2jjYSjBtMjP+AznFqOJzXpqmq6B9auWrlTJrMgZ7lPyhWUW7VU7LsQU48/TJ+DZeIz8s9bMYvcHg==",
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-5.20.0.tgz",
+      "integrity": "sha512-JVcaPXC940wOGpCOwuqQRTz6I9SaBK0c1BAyC1pcz9xBi+dzFgUu3G/p9GV1FhFs9OKpfSpIhQfUJE9y00zhqw==",
       "dependencies": {
-        "@prisma/debug": "5.16.2",
-        "@prisma/engines-version": "5.16.0-24.34ace0eb2704183d2c05b60b52fba5c43c13f303",
-        "@prisma/get-platform": "5.16.2"
+        "@prisma/debug": "5.20.0",
+        "@prisma/engines-version": "5.20.0-12.06fc58a368dc7be9fbbbe894adf8d445d208c284",
+        "@prisma/get-platform": "5.20.0"
       }
     },
     "node_modules/@prisma/get-platform": {
-      "version": "5.16.2",
-      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-5.16.2.tgz",
-      "integrity": "sha512-cXiHPgNLNyj22vLouPVNegklpRL/iX2jxTeap5GRO3DmCoVyIHmJAV1CgUMUJhHlcol9yYy7EHvsnXTDJ/PKEA==",
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-5.20.0.tgz",
+      "integrity": "sha512-8/+CehTZZNzJlvuryRgc77hZCWrUDYd/PmlZ7p2yNXtmf2Una4BWnTbak3us6WVdqoz5wmptk6IhsXdG2v5fmA==",
       "dependencies": {
-        "@prisma/debug": "5.16.2"
+        "@prisma/debug": "5.20.0"
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -1373,29 +1373,28 @@
       "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA=="
     },
     "node_modules/@slack/bolt": {
-      "version": "3.19.0",
-      "resolved": "https://registry.npmjs.org/@slack/bolt/-/bolt-3.19.0.tgz",
-      "integrity": "sha512-P5Yup/PbO8sE5xsuqkBkpSPkxEkfWZ6yo5ZlmBGxRhhoU1usUSU2w0bgZoiDX4WFm7ZX+3x2Dyf4VMa9kzfmVQ==",
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@slack/bolt/-/bolt-3.22.0.tgz",
+      "integrity": "sha512-iKDqGPEJDnrVwxSVlFW6OKTkijd7s4qLBeSufoBsTM0reTyfdp/5izIQVkxNfzjHi3o6qjdYbRXkYad5HBsBog==",
       "dependencies": {
         "@slack/logger": "^4.0.0",
-        "@slack/oauth": "^2.6.2",
-        "@slack/socket-mode": "^1.3.3",
-        "@slack/types": "^2.11.0",
-        "@slack/web-api": "^6.11.2",
+        "@slack/oauth": "^2.6.3",
+        "@slack/socket-mode": "^1.3.6",
+        "@slack/types": "^2.13.0",
+        "@slack/web-api": "^6.13.0",
         "@types/express": "^4.16.1",
         "@types/promise.allsettled": "^1.0.3",
         "@types/tsscmp": "^1.0.0",
         "axios": "^1.7.4",
-        "express": "^4.16.4",
-        "path-to-regexp": "^6.2.1",
-        "please-upgrade-node": "^3.2.0",
+        "express": "^4.21.0",
+        "path-to-regexp": "^8.1.0",
         "promise.allsettled": "^1.0.2",
         "raw-body": "^2.3.3",
         "tsscmp": "^1.0.6"
       },
       "engines": {
-        "node": ">=12.13.0",
-        "npm": ">=6.12.0"
+        "node": ">=14.21.3",
+        "npm": ">=6.14.18"
       }
     },
     "node_modules/@slack/logger": {
@@ -1411,12 +1410,12 @@
       }
     },
     "node_modules/@slack/oauth": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/@slack/oauth/-/oauth-2.6.2.tgz",
-      "integrity": "sha512-2R3MyB/R63hTRXzk5J6wcui59TBxXzhk+Uh2/Xu3Wp3O4pXg/BNucQhP/DQbL/ScVhLvFtMXirLrKi0Yo5gIVw==",
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/@slack/oauth/-/oauth-2.6.3.tgz",
+      "integrity": "sha512-1amXs6xRkJpoH6zSgjVPgGEJXCibKNff9WNDijcejIuVy1HFAl1adh7lehaGNiHhTWfQkfKxBiF+BGn56kvoFw==",
       "dependencies": {
         "@slack/logger": "^3.0.0",
-        "@slack/web-api": "^6.11.2",
+        "@slack/web-api": "^6.12.1",
         "@types/jsonwebtoken": "^8.3.7",
         "@types/node": ">=12",
         "jsonwebtoken": "^9.0.0",
@@ -1440,12 +1439,12 @@
       }
     },
     "node_modules/@slack/socket-mode": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/@slack/socket-mode/-/socket-mode-1.3.5.tgz",
-      "integrity": "sha512-m2J2hVCIxEvBinkNINNmizDZWBa6D9taFD930aknEDi+2DtzFSMhmxci/VeN7DJVUe+ovLl3lPlvLK9p4hd5CQ==",
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/@slack/socket-mode/-/socket-mode-1.3.6.tgz",
+      "integrity": "sha512-G+im7OP7jVqHhiNSdHgv2VVrnN5U7KY845/5EZimZkrD4ZmtV0P3BiWkgeJhPtdLuM7C7i6+M6h6Bh+S4OOalA==",
       "dependencies": {
         "@slack/logger": "^3.0.0",
-        "@slack/web-api": "^6.11.2",
+        "@slack/web-api": "^6.12.1",
         "@types/node": ">=12.0.0",
         "@types/ws": "^7.4.7",
         "eventemitter3": "^5",
@@ -1470,18 +1469,18 @@
       }
     },
     "node_modules/@slack/types": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@slack/types/-/types-2.12.0.tgz",
-      "integrity": "sha512-yFewzUomYZ2BYaGJidPuIgjoYj5wqPDmi7DLSaGIkf+rCi4YZ2Z3DaiYIbz7qb/PL2NmamWjCvB7e9ArI5HkKg==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/@slack/types/-/types-2.14.0.tgz",
+      "integrity": "sha512-n0EGm7ENQRxlXbgKSrQZL69grzg1gHLAVd+GlRVQJ1NSORo0FrApR7wql/gaKdu2n4TO83Sq/AmeUOqD60aXUA==",
       "engines": {
         "node": ">= 12.13.0",
         "npm": ">= 6.12.0"
       }
     },
     "node_modules/@slack/web-api": {
-      "version": "6.12.0",
-      "resolved": "https://registry.npmjs.org/@slack/web-api/-/web-api-6.12.0.tgz",
-      "integrity": "sha512-RPw6F8rWfGveGkZEJ4+4jUin5iazxRK2q3FpQDz/FvdgzC3nZmPyLx8WRzc6nh0w3MBjEbphNnp2VZksfhpBIQ==",
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/@slack/web-api/-/web-api-6.13.0.tgz",
+      "integrity": "sha512-dv65crIgdh9ZYHrevLU6XFHTQwTyDmNqEqzuIrV+Vqe/vgiG6w37oex5ePDU1RGm2IJ90H8iOvHFvzdEO/vB+g==",
       "dependencies": {
         "@slack/logger": "^3.0.0",
         "@slack/types": "^2.11.0",
@@ -5802,9 +5801,12 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.2.tgz",
-      "integrity": "sha512-GQX3SSMokngb36+whdpRXE+3f9V8UzyAorlYvOGx87ufGHehNTn5lCxrKtLyZ4Yl/wEKnNnr98ZzOwwDZV5ogw=="
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.2.0.tgz",
+      "integrity": "sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ==",
+      "engines": {
+        "node": ">=16"
+      }
     },
     "node_modules/path-type": {
       "version": "3.0.0",
@@ -5907,14 +5909,6 @@
         "confbox": "^0.1.7",
         "mlly": "^1.7.1",
         "pathe": "^1.1.2"
-      }
-    },
-    "node_modules/please-upgrade-node": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/please-upgrade-node/-/please-upgrade-node-3.2.0.tgz",
-      "integrity": "sha512-gQR3WpIgNIKwBMVLkpMUeR3e1/E1y42bqDQZfql+kDeXd8COYfM8PQA4X6y7a8u9Ua9FHmsrrmirW2vHs45hWg==",
-      "dependencies": {
-        "semver-compare": "^1.0.0"
       }
     },
     "node_modules/possible-typed-array-names": {
@@ -6045,18 +6039,21 @@
       }
     },
     "node_modules/prisma": {
-      "version": "5.16.2",
-      "resolved": "https://registry.npmjs.org/prisma/-/prisma-5.16.2.tgz",
-      "integrity": "sha512-rFV/xoBR2hBGGlu4LPLQd4U8WVA+tSAmYyFWGPRVfj+xg7N4kiZV4lSk38htSpF+/IuHKzlrbh4SFk8Z18cI8A==",
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/prisma/-/prisma-5.20.0.tgz",
+      "integrity": "sha512-6obb3ucKgAnsGS9x9gLOe8qa51XxvJ3vLQtmyf52CTey1Qcez3A6W6ROH5HIz5Q5bW+0VpmZb8WBohieMFGpig==",
       "hasInstallScript": true,
       "dependencies": {
-        "@prisma/engines": "5.16.2"
+        "@prisma/engines": "5.20.0"
       },
       "bin": {
         "prisma": "build/index.js"
       },
       "engines": {
         "node": ">=16.13"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.3"
       }
     },
     "node_modules/promise.allsettled": {
@@ -6454,11 +6451,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/semver-compare": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
-      "integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow=="
     },
     "node_modules/send": {
       "version": "0.19.0",

--- a/src/interfaces/slack_bot/package.json
+++ b/src/interfaces/slack_bot/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "@microsoft/fetch-event-source": "^2.0.1",
-    "@prisma/client": "5.14.0",
+    "@prisma/client": "^5.20.0",
     "@sentry/node": "^7.64.0",
     "@slack/bolt": "^3.18.0",
     "@slack/web-api": "^6.12.0",


### PR DESCRIPTION
The bolt package had a dependency graph that included a package with a security vulnerability, so I've bumped it to the latest version. At the same time I saw a warning about prism and prism/client versions being out-of-sync, so I've bumped both to the latest versions.

**AI Description**

<!-- begin-generated-description -->

This PR updates the `@prisma/client` dependency to version `^5.20.0` in the `package.json` and `package-lock.json` files.

- The `@prisma/client` dependency is updated to version `^5.20.0` in the `package.json` file.
- The `@prisma/client` dependency is updated to version `^5.20.0` in the `package-lock.json` file.

<!-- end-generated-description -->
