### PR TITLE
frontend: Fall back to browser default clipboard behaviour if clipboard API is unavailable

### DIFF
--- a/src/interfaces/assistants_web/src/components/UI/CopyToClipboardButton.tsx
+++ b/src/interfaces/assistants_web/src/components/UI/CopyToClipboardButton.tsx
@@ -40,6 +40,9 @@ export const CopyToClipboardButton = forwardRef<
 ) {
   const [copied, setCopied] = useState(false);
 
+  const available = !!window?.navigator?.clipboard;
+  const buttonLabel = !available ? 'Copy (requires HTTPS)' : copied ? 'Copied!' : label;
+
   const handleCopy = async (e: MouseEvent<HTMLElement>) => {
     e.stopPropagation();
     e.preventDefault();
@@ -65,11 +68,11 @@ export const CopyToClipboardButton = forwardRef<
     <Button
       kind={kind}
       onClick={handleCopy}
-      label={copied ? 'Copied!' : label}
+      label={buttonLabel}
       icon="copy"
       iconPosition={iconAtStart ? 'start' : 'end'}
       className={className}
-      disabled={disabled}
+      disabled={disabled || !available}
       aria-label={copied ? 'copied' : 'copy'}
     />
   );
@@ -101,7 +104,13 @@ export const CopyToClipboardIconButton: React.FC<CopyToClipboardIconButtonProps>
 }) => {
   const [isCopied, setIsCopied] = useState(false);
 
+  const available = !!window?.navigator?.clipboard;
+  const label = !available ? 'Copy (requires HTTPS)' : isCopied ? 'Copied!' : 'Copy';
+
   const handleCopy = async (e: MouseEvent<HTMLElement>) => {
+    if (!available) {
+      return;
+    }
     try {
       await window?.navigator?.clipboard.writeText(value ?? '');
       setIsCopied(true);
@@ -118,7 +127,7 @@ export const CopyToClipboardIconButton: React.FC<CopyToClipboardIconButtonProps>
   return (
     <div>
       <Tooltip
-        label={isCopied ? 'Copied!' : 'Copy'}
+        label={label}
         duration={duration}
         size="sm"
         showOutline={false}
@@ -128,7 +137,8 @@ export const CopyToClipboardIconButton: React.FC<CopyToClipboardIconButtonProps>
         buttonClassName={buttonClassName}
       >
         <IconButton
-          aria-disabled={disabled}
+          aria-disabled={disabled || !available}
+          disabled={disabled || !available}
           iconName={iconName}
           iconKind={isCopied ? 'default' : 'outline'}
           className="grid place-items-center rounded hover:bg-mushroom-900 dark:hover:bg-volcanic-200"

--- a/src/interfaces/assistants_web/src/hooks/use-fixCopyBug.ts
+++ b/src/interfaces/assistants_web/src/hooks/use-fixCopyBug.ts
@@ -6,6 +6,10 @@ import { useEventListener } from '@react-hookz/web';
 export const useFixCopyBug = () => {
   const target = typeof document !== 'undefined' ? document : null;
   useEventListener(target, 'copy', async (event: Event) => {
+    // Clipboard API is not available over HTTP, so fall back to the default behavior unless we're on localhost
+    if (!window?.navigator?.clipboard) {
+      return;
+    }
     const selectedText = window.getSelection()?.toString().trim();
     if (selectedText) {
       event.preventDefault(); // Prevents the default copy behavior


### PR DESCRIPTION
When the client is loaded over HTTP the clipboard is disabled. In that case, it's probably better to have the clipboard copy fix hook fall back to the default behaviour. In addition, let's have the copy button show a hint that the user should set up HTTPS to get the copy button working.

Fixes #797 

**AI Description**

<!-- begin-generated-description -->

This PR introduces a fix for a copy bug, ensuring that the Clipboard API is only used when available over HTTPS.

## Changes:
- Added a check to determine if the Clipboard API is available (`window.navigator.clipboard`) before attempting to use it.
- Updated the button label to display a message indicating that copying requires HTTPS if the Clipboard API is not available.
- Disabled the copy button when the Clipboard API is not available.
- Added a check to prevent the copy function from executing if the Clipboard API is not available.

<!-- end-generated-description -->
