### PR TITLE
[WIP] frontend: Add better web client error when backend failed to start

### DIFF
--- a/src/backend/Dockerfile
+++ b/src/backend/Dockerfile
@@ -46,4 +46,4 @@ COPY .en[v] .env
 
 EXPOSE ${PORT}
 
-CMD uvicorn backend.main:app --reload --host 0.0.0.0 --port ${PORT} --timeout-keep-alive 300
+# CMD uvicorn backend.main:app --reload --host 0.0.0.0 --port ${PORT} --timeout-keep-alive 300

--- a/src/interfaces/assistants_web/src/cohere-client/client.ts
+++ b/src/interfaces/assistants_web/src/cohere-client/client.ts
@@ -52,6 +52,10 @@ export class CohereClient {
     });
   }
 
+  public getHealth() {
+    return this.cohereService.default.healthHealthGet();
+  }
+
   public batchUploadConversationFile(
     formData: Body_batch_upload_file_v1_conversations_batch_upload_file_post
   ) {

--- a/src/interfaces/assistants_web/src/env.mjs
+++ b/src/interfaces/assistants_web/src/env.mjs
@@ -1,38 +1,64 @@
 /* eslint-disable no-process-env */
 import { createEnv } from '@t3-oss/env-nextjs';
+import {
+  useCohereClient,
+} from '@/cohere-client';
 import z from 'zod';
+
+const checkBackendHealth = async () => {
+  const cohereClient = useCohereClient();
+  const health = await cohereClient.getHealth();
+
+  console.log("Checking health")
+  console.log(health)
+
+  if (response.ok) {
+    console.log('Backend is healthy.');
+    return true;
+  } else {
+    console.error('Backend health check failed.');
+    throw new Error('Backend health check failed. Please ensure the backend is running properly.');
+  }
+};
 
 const readVariable = (key) => {
   if (typeof window === 'undefined') return process.env[key];
   return window.__ENV[key];
 };
 
-export const env = createEnv({
-  server: {
-    API_HOSTNAME: z.string().default('http://backend:8000'),
-  },
-  client: {
-    NEXT_PUBLIC_API_HOSTNAME: z.string().default('http://localhost:8000'),
-    NEXT_PUBLIC_FRONTEND_HOSTNAME: z.string().optional().default('http://localhost:4000'),
-    NEXT_PUBLIC_GOOGLE_DRIVE_CLIENT_ID: z.string().optional(),
-    NEXT_PUBLIC_GOOGLE_DRIVE_DEVELOPER_KEY: z.string().optional(),
-    NEXT_PUBLIC_HAS_CUSTOM_LOGO: z
-      .string()
-      .optional()
-      .default('false')
-      .refine((s) => s === 'true' || s === 'false')
-      .transform((s) => s === 'true'),
-  },
-  runtimeEnv: {
-    API_HOSTNAME: process.env.API_HOSTNAME,
-    NEXT_PUBLIC_API_HOSTNAME: readVariable('NEXT_PUBLIC_API_HOSTNAME'),
-    NEXT_PUBLIC_FRONTEND_HOSTNAME: readVariable('NEXT_PUBLIC_FRONTEND_HOSTNAME'),
-    NEXT_PUBLIC_GOOGLE_DRIVE_CLIENT_ID: readVariable('NEXT_PUBLIC_GOOGLE_DRIVE_CLIENT_ID'),
-    NEXT_PUBLIC_GOOGLE_DRIVE_DEVELOPER_KEY: readVariable('NEXT_PUBLIC_GOOGLE_DRIVE_DEVELOPER_KEY'),
-    NEXT_PUBLIC_HAS_CUSTOM_LOGO: readVariable('NEXT_PUBLIC_HAS_CUSTOM_LOGO'),
-  },
-  emptyStringAsUndefined: true,
-  skipValidation: ['lint', 'format', 'test', 'test:coverage', 'test:watch', 'build'].includes(
-    process.env.npm_lifecycle_event
-  ),
-});
+async function setupEnv() {
+  await checkBackendHealth();
+
+  return createEnv({
+    server: {
+      API_HOSTNAME: z.string().default('http://backend:8000'),
+    },
+    client: {
+      NEXT_PUBLIC_API_HOSTNAME: z.string().default('http://localhost:8000'),
+      NEXT_PUBLIC_FRONTEND_HOSTNAME: z.string().optional().default('http://localhost:4000'),
+      NEXT_PUBLIC_GOOGLE_DRIVE_CLIENT_ID: z.string().optional(),
+      NEXT_PUBLIC_GOOGLE_DRIVE_DEVELOPER_KEY: z.string().optional(),
+      NEXT_PUBLIC_HAS_CUSTOM_LOGO: z
+        .string()
+        .optional()
+        .default('false')
+        .refine((s) => s === 'true' || s === 'false')
+        .transform((s) => s === 'true'),
+    },
+    runtimeEnv: {
+      API_HOSTNAME: process.env.API_HOSTNAME,
+      NEXT_PUBLIC_API_HOSTNAME: readVariable('NEXT_PUBLIC_API_HOSTNAME'),
+      NEXT_PUBLIC_FRONTEND_HOSTNAME: readVariable('NEXT_PUBLIC_FRONTEND_HOSTNAME'),
+      NEXT_PUBLIC_GOOGLE_DRIVE_CLIENT_ID: readVariable('NEXT_PUBLIC_GOOGLE_DRIVE_CLIENT_ID'),
+      NEXT_PUBLIC_GOOGLE_DRIVE_DEVELOPER_KEY: readVariable('NEXT_PUBLIC_GOOGLE_DRIVE_DEVELOPER_KEY'),
+      NEXT_PUBLIC_HAS_CUSTOM_LOGO: readVariable('NEXT_PUBLIC_HAS_CUSTOM_LOGO'),
+    },
+    emptyStringAsUndefined: true,
+    skipValidation: ['lint', 'format', 'test', 'test:coverage', 'test:watch', 'build'].includes(
+      process.env.npm_lifecycle_event
+    ),
+  });
+};
+
+// Export the environment setup as a promise that resolves when the health check is done
+export const env = await setupEnv();

--- a/src/interfaces/assistants_web/src/env.mjs
+++ b/src/interfaces/assistants_web/src/env.mjs
@@ -1,23 +1,20 @@
 /* eslint-disable no-process-env */
 import { createEnv } from '@t3-oss/env-nextjs';
-import {
-  useCohereClient,
-} from '@/cohere-client';
 import z from 'zod';
 
 const checkBackendHealth = async () => {
-  const cohereClient = useCohereClient();
-  const health = await cohereClient.getHealth();
+  const url = process.env.API_HOSTNAME || 'http://backend:8000';
 
-  console.log("Checking health")
-  console.log(health)
-
-  if (response.ok) {
-    console.log('Backend is healthy.');
-    return true;
-  } else {
-    console.error('Backend health check failed.');
-    throw new Error('Backend health check failed. Please ensure the backend is running properly.');
+  try {
+    const response = await fetch(`${url}/health`);
+    if (response.ok) {
+      console.log('Backend is healthy, business as usual.');
+    } else {
+      throw new Error('Backend health check failed, make sure your backend server is running correctly.');
+    }
+  } catch (error) {
+    console.error('Backend is unreachable:', error.message);
+    throw new Error('Backend is unreachable. Make sure your backend server is running correctly.');
   }
 };
 


### PR DESCRIPTION

**AI Description**

<!-- begin-generated-description -->

This pull request introduces a backend health check mechanism and a new `getHealth` method to the `CohereClient` class.

## src/backend/Dockerfile
The CMD command to run the backend server has been commented out, possibly to prevent automatic server startup during the build process.

## src/interfaces/assistants_web/src/env.mjs
- A new `checkBackendHealth` function has been added to perform a health check on the backend server.
- The `setupEnv` function now awaits the `checkBackendHealth` function before creating the environment.
- The `env` object is now exported as a promise that resolves when the health check is complete.

## src/interfaces/assistants_web/src/cohere-client/client.ts
- A new `getHealth` method has been added to the `CohereClient` class, which returns the health status of the Cohere service.

<!-- end-generated-description -->
