### PR TITLE
docs: add text to speech setup guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Toolkit is a deployable all-in-one RAG application that enables users to quickly
   - [How to add tools](/docs/custom_tool_guides/tool_guide.md)
   - [How to add auth to your tools](/docs/custom_tool_guides/tool_auth_guide.md)
   - [How to setup Google Drive](/docs/custom_tool_guides/google_drive.md)
+  - [How to setup Google Text-to-Speech](/docs/text_to_speech.md)
   - [How to add authentication](/docs/auth_guide.md)
   - [How to deploy toolkit services](/docs/service_deployments.md)
   - [How to set up Github Actions for automated DB migrations](/docs/github_migrations_action.md)

--- a/docs/text_to_speech.md
+++ b/docs/text_to_speech.md
@@ -1,0 +1,30 @@
+# Google Cloud Text-to-Speech Setup
+
+To use Google Cloud Text-to-Speech, you'll need to create a Google Cloud project and follow the steps below:
+
+## 1. Enable Required APIs
+
+You'll need to head to Google Cloud Console, navigate to APIs & Services, and enable:
+- Cloud Text-to-Speech API
+- Cloud Translation API
+
+## 2. Create API Credentials
+
+In the Google Cloud Console, go to APIs & Services > Credentials.
+Click Create Credentials and select API key.
+Copy the generated API key for using in the next step.
+
+## 3. Configure Environment Variable
+
+You can either set the API key in your `.env` file:
+
+```bash
+GOOGLE_CLOUD_API_KEY=<your_api_key>
+```
+
+or update your `secrets.yaml` configuration to contain:
+
+```bash
+google_cloud:
+  api_key:<your_api_key>
+```

--- a/docs/text_to_speech.md
+++ b/docs/text_to_speech.md
@@ -4,14 +4,14 @@ To use Google Cloud Text-to-Speech, you'll need to create a Google Cloud project
 
 ## 1. Enable Required APIs
 
-You'll need to head to Google Cloud Console, navigate to APIs & Services, and enable:
-- Cloud Text-to-Speech API
-- Cloud Translation API
+Open the **Google Cloud Console**, navigate to **APIs & Services**, and enable:
+- **Cloud Text-to-Speech API**
+- **Cloud Translation API**
 
 ## 2. Create API Credentials
 
-In the Google Cloud Console, go to APIs & Services > Credentials.
-Click Create Credentials and select API key.
+In the **Google Cloud Console**, go to **APIs & Services** > **Credentials**.
+Click **Create Credentials** and select **API key**.
 Copy the generated API key for using in the next step.
 
 ## 3. Configure Environment Variable


### PR DESCRIPTION
**Description**

Added documentation for the Text-to-Speech setup.

**AI Description**

<!-- begin-generated-description -->

This PR adds a new section to the README.md file, providing a step-by-step guide on setting up Google Cloud Text-to-Speech. The guide is also available as a separate document, docs/text_to_speech.md.

## Changes:
- A new section is added to the README.md file, titled "How to setup Google Text-to-Speech".
- The new section includes a link to the docs/text_to_speech.md file.
- The docs/text_to_speech.md file is created, containing detailed instructions on setting up Google Cloud Text-to-Speech.

<!-- end-generated-description -->
