### PR TITLE
frontend: Fix Agent model being set

### DIFF
--- a/src/backend/routers/agent.py
+++ b/src/backend/routers/agent.py
@@ -280,7 +280,7 @@ async def update_agent(
         db_deployment, db_model = get_deployment_model_from_agent(new_agent, session)
         deployment_config = new_agent.deployment_config
         is_default_deployment = new_agent.is_default_deployment
-        # remove association fields
+        # Remove association fields - handled manually
         new_agent_cleaned = new_agent.dict(
             exclude={
                 "model",
@@ -290,7 +290,6 @@ async def update_agent(
                 "is_default_model",
             }
         )
-        # TODO Eugene - if no deployment or model is provide or if the deployment or model is not found, should we raise an error?
         if db_deployment and db_model:
             current_association = agent_crud.get_agent_model_deployment_association(
                 session, agent, db_model.id, db_deployment.id

--- a/src/interfaces/assistants_web/src/app/(main)/edit/[agentId]/UpdateAgent.tsx
+++ b/src/interfaces/assistants_web/src/app/(main)/edit/[agentId]/UpdateAgent.tsx
@@ -52,6 +52,7 @@ export const UpdateAgent: React.FC<Props> = ({ agent }) => {
         request: { ...fields, tools_metadata },
         agentId: agent.id,
       });
+      setIsSubmitting(false); // Reset button to allow new update after previous one
       info(`Updated ${newAgent?.name}`);
     } catch (e) {
       setIsSubmitting(false);

--- a/src/interfaces/assistants_web/src/components/AgentSettingsForm/ConfigStep.tsx
+++ b/src/interfaces/assistants_web/src/components/AgentSettingsForm/ConfigStep.tsx
@@ -15,7 +15,7 @@ type Props = {
 };
 
 export const ConfigStep: React.FC<Props> = ({ fields, setFields }) => {
-  const [selectedValue, setSelectedValue] = useState<string | undefined>(DEFAULT_AGENT_MODEL);
+  const [selectedValue, setSelectedValue] = useState<string | undefined>(fields.model);
 
   const { data: deployments } = useListAllDeployments();
 

--- a/src/interfaces/assistants_web/src/components/AgentSettingsForm/ConfigStep.tsx
+++ b/src/interfaces/assistants_web/src/components/AgentSettingsForm/ConfigStep.tsx
@@ -4,12 +4,10 @@ import { useState } from 'react';
 
 import { AgentSettingsFields } from '@/components/AgentSettingsForm';
 import { Dropdown } from '@/components/UI';
-import { DEFAULT_AGENT_MODEL } from '@/constants';
 import { useListAllDeployments } from '@/hooks';
 
 type Props = {
   fields: AgentSettingsFields;
-  isNewAssistant: boolean;
   nameError?: string;
   setFields: (fields: AgentSettingsFields) => void;
 };

--- a/src/interfaces/assistants_web/src/components/AgentSettingsForm/index.tsx
+++ b/src/interfaces/assistants_web/src/components/AgentSettingsForm/index.tsx
@@ -59,7 +59,6 @@ export const AgentSettingsForm: React.FC<Props> = (props) => {
   const { data: listToolsData, status: listToolsStatus } = useListTools();
   const isAgentNameUnique = useIsAgentNameUnique();
   const params = useSearchParams();
-  const defaultStep = params.has('datasources');
   const defaultState = params.has('state');
 
   useEffect(() => {
@@ -78,7 +77,7 @@ export const AgentSettingsForm: React.FC<Props> = (props) => {
 
   const [currentStep, setCurrentStep] = useState<
     'define' | 'config' | 'dataSources' | 'tools' | 'visibility' | undefined
-  >(() => (defaultStep ? 'dataSources' : 'define'));
+  >('define');
 
   const [googleFiles, setGoogleFiles] = useState<DataSourceArtifact[]>(
     fields.tools_metadata?.find((metadata) => metadata.tool_name === TOOL_GOOGLE_DRIVE_ID)
@@ -208,12 +207,7 @@ export const AgentSettingsForm: React.FC<Props> = (props) => {
         isExpanded={currentStep === 'config'}
         setIsExpanded={(expanded) => setCurrentStep(expanded ? 'config' : undefined)}
       >
-        <ConfigStep
-          fields={fields}
-          setFields={setFields}
-          nameError={nameError}
-          isNewAssistant={source === 'create'}
-        />
+        <ConfigStep fields={fields} setFields={setFields} nameError={nameError} />
         <StepButtons
           handleNext={() => setCurrentStep('dataSources')}
           hide={source !== 'create'}

--- a/src/interfaces/assistants_web/src/hooks/use-agents.ts
+++ b/src/interfaces/assistants_web/src/hooks/use-agents.ts
@@ -114,8 +114,11 @@ export const useIsAgentNameUnique = () => {
 export const useUpdateAgent = () => {
   const cohereClient = useCohereClient();
   const queryClient = useQueryClient();
+
   return useMutation<AgentPublic, ApiError, { request: UpdateAgentRequest; agentId: string }>({
-    mutationFn: ({ request, agentId }) => cohereClient.updateAgent(request, agentId),
+    mutationFn: ({ request, agentId }) => {
+      return cohereClient.updateAgent(request, agentId);
+    },
     onSettled: (agent) => {
       queryClient.invalidateQueries({ queryKey: ['agent', agent?.id] });
       queryClient.invalidateQueries({ queryKey: ['listAgents'] });


### PR DESCRIPTION

**AI Description**

<!-- begin-generated-description -->

This pull request updates the `useState` hook in the `ConfigStep` component to use the `fields.model` value instead of the `DEFAULT_AGENT_MODEL` constant.

- The `useState` hook now initializes the `selectedValue` state with the value of `fields.model`.
- This change allows the component to dynamically set the initial value of the `selectedValue` state based on the `fields` prop, providing more flexibility in setting the default agent model.

<!-- end-generated-description -->
