### PR TITLE
icons: fix settings icon view box

### DIFF
--- a/src/interfaces/assistants_web/src/assets/icons/Settings.tsx
+++ b/src/interfaces/assistants_web/src/assets/icons/Settings.tsx
@@ -11,7 +11,7 @@ type Props = {
 export const Setttings: React.FC<Props> = ({ className, kind, ...props }) => (
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    viewBox="0 0 28 28"
+    viewBox="0 0 32 32"
     className={cn('h-full w-full fill-inherit', className)}
     {...props}
   >


### PR DESCRIPTION
**Description**

- Fixed incorrect viewBox for the settings icon

Before:
<img width="210" alt="image" src="https://github.com/user-attachments/assets/86e1a016-1278-40fd-a834-45f2f2c3ce7e">

After:
<img width="221" alt="image" src="https://github.com/user-attachments/assets/e503c898-54b7-456c-a777-4f1a1a54d778">


**AI Description**

<!-- begin-generated-description -->

This pull request updates the `viewBox` attribute of the SVG element in the `Settings.tsx` file.

- The `viewBox` attribute is changed from `0 0 28 28` to `0 0 32 32`.

<!-- end-generated-description -->
