### PR TITLE
chore: Remove merge tests

### DIFF
--- a/.github/workflows/backend_unit_tests.yml
+++ b/.github/workflows/backend_unit_tests.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [main]
   pull_request: {}
-  merge_group: {}
 
 jobs:
   pytest:

--- a/.github/workflows/frontend_assistants_web_tests.yml
+++ b/.github/workflows/frontend_assistants_web_tests.yml
@@ -6,7 +6,6 @@ on:
     paths:
       - src/interfaces/assistants_web/**
   pull_request: {}
-  merge_group: {}
 
 jobs:
   interface_tests:

--- a/.github/workflows/frontend_coral_web_tests.yml
+++ b/.github/workflows/frontend_coral_web_tests.yml
@@ -6,7 +6,6 @@ on:
     paths:
       - src/interfaces/coral_web/**
   pull_request: {}
-  merge_group: {}
 
 jobs:
   interface_tests:

--- a/.github/workflows/frontend_slack_bot_tests.yml
+++ b/.github/workflows/frontend_slack_bot_tests.yml
@@ -6,7 +6,6 @@ on:
     paths:
       - src/interfaces/slack_bot/**
   pull_request: {}
-  merge_group: {}
 
 jobs:
   interface_tests:


### PR DESCRIPTION
Frontend/Unit tests: No point in running format/build and unit tests on merge when they're run on all PRs and must be successful to induce a merge

Integration: Currently known fail on `main` so blocking merges -> Need to push this, Alex to take care of resolving tests