### PR TITLE
backend: Make post_init_check an instance method

### DIFF
--- a/src/backend/services/auth/strategies/base.py
+++ b/src/backend/services/auth/strategies/base.py
@@ -43,14 +43,13 @@ class BaseOAuthStrategy:
     def __init__(self, *args, **kwargs):
         self._post_init_check()
 
-    @classmethod
-    def _post_init_check(cls):
+    def _post_init_check(self):
         if any(
             [
-                cls.NAME is None,
+                self.NAME is None,
             ]
         ):
-            raise ValueError(f"{cls.__name__} must have NAME attribute defined.")
+            raise ValueError(f"{self.__name__} must have NAME attribute defined.")
 
     @abstractmethod
     def get_client_id(self, **kwargs: Any):

--- a/src/backend/tools/base.py
+++ b/src/backend/tools/base.py
@@ -26,10 +26,9 @@ class BaseTool():
     def __init__(self, *args, **kwargs):
         self._post_init_check()
 
-    @classmethod
-    def _post_init_check(cls):
-        if cls.ID is None:
-            raise ValueError(f"{cls.__name__} must have ID attribute defined.")
+    def _post_init_check(self):
+        if self.ID is None:
+            raise ValueError(f"{self.__name__} must have ID attribute defined.")
 
     @classmethod
     @abstractmethod
@@ -68,13 +67,12 @@ class BaseToolAuthentication(ABC):
 
         self._post_init_check()
 
-    @classmethod
-    def _post_init_check(cls):
+    def _post_init_check(self):
         if any(
             [
-                cls.BACKEND_HOST is None,
-                cls.FRONTEND_HOST is None,
-                cls.AUTH_SECRET_KEY is None,
+                self.BACKEND_HOST is None,
+                self.FRONTEND_HOST is None,
+                self.AUTH_SECRET_KEY is None,
             ]
         ):
             raise ValueError(


### PR DESCRIPTION
Thank you for contributing to the Cohere Toolkit!

- [ ] **PR title**: "area: description"
  - Where "area" is whichever of interface, frontend, model, tools, backend, etc. is being modified. Use "docs: ..." for purely docs changes, "infra: ..." for CI changes.
  - Example: "deployment: add Azure model option"


- [ ] **PR message**: ***Delete this entire checklist*** and replace with
    - **Description:** a description of the change
    - **Issue:** the issue # it fixes, if applicable
    - **Dependencies:** any dependencies required for this change


- [ ] **Add tests and docs**: Please include testing and documentation for your changes
- [ ] **Lint and test**: Run `make lint` and `make run-tests`

**AI Description**

<!-- begin-generated-description -->

This pull request modifies the `_post_init_check` method in the `BaseOAuthStrategy and `BaseTool classes. The changes ensure that the method is an instance method rather than a class method, and it raises a `ValueError` if the `NAME` attribute is not defined in the `BaseOAuthStrategy class or the `ID` attribute is not defined in the `BaseTool class.

- The `_post_init_check` method is changed from a class method to an instance method in both the `BaseOAuthStrategy and `BaseTool classes.
- The `ValueError` raised in the `_post_init_check` method now uses the instance name (`self.__name__`) instead of the class name (`cls.__name__`) to provide more specific error messages.
- The `BaseTool class's `_post_init_check` method now checks for the `ID` attribute, ensuring it is defined.

<!-- end-generated-description -->
