### PR TITLE
frontend: Allow toggling tools for non-default agents

### DIFF
--- a/src/interfaces/assistants_web/src/components/Composer/DataSourceMenu.tsx
+++ b/src/interfaces/assistants_web/src/components/Composer/DataSourceMenu.tsx
@@ -7,7 +7,7 @@ import { AgentPublic, ToolDefinition } from '@/cohere-client';
 import { Icon, Switch, Text } from '@/components/UI';
 import { useAvailableTools, useBrandedColors } from '@/hooks';
 import { useParamsStore } from '@/stores';
-import { checkIsBaseAgent, cn, getToolIcon } from '@/utils';
+import { cn, getToolIcon } from '@/utils';
 
 export type Props = {
   agent?: AgentPublic;
@@ -25,9 +25,8 @@ export const DataSourceMenu: React.FC<Props> = ({ agent, tools }) => {
     agent,
     allTools: tools,
   });
+  const { theme, text, contrastText, border, bg } = useBrandedColors(agent?.id);
 
-  const { text, contrastText, border, bg } = useBrandedColors(agent?.id);
-  const isBaseAgent = checkIsBaseAgent(agent);
   return (
     <Popover className="relative">
       <PopoverButton
@@ -46,7 +45,7 @@ export const DataSourceMenu: React.FC<Props> = ({ agent, tools }) => {
             as="span"
             className={cn('font-medium', text, { [contrastText]: open })}
           >
-            Tools: {isBaseAgent ? paramsTools?.length ?? 0 : availableTools.length ?? 0}
+            Tools: {paramsTools ? paramsTools?.length ?? 0 : availableTools.length ?? 0}
           </Text>
         )}
       </PopoverButton>
@@ -107,14 +106,12 @@ export const DataSourceMenu: React.FC<Props> = ({ agent, tools }) => {
                     <Text as="span">{tool.display_name}</Text>
                   </div>
                 </div>
-                {isBaseAgent && (
-                  <Switch
-                    theme="evolved-blue"
-                    checked={!!paramsTools?.find((t) => t.name === tool.name)}
-                    onChange={(checked) => handleToggle(tool.name!, checked)}
-                    showCheckedState
-                  />
-                )}
+                <Switch
+                  theme={theme}
+                  checked={!!paramsTools?.find((t) => t.name === tool.name)}
+                  onChange={(checked) => handleToggle(tool.name!, checked)}
+                  showCheckedState
+                />
               </div>
             </div>
           ))}

--- a/src/interfaces/assistants_web/src/components/MessagingContainer/AssistantTools.tsx
+++ b/src/interfaces/assistants_web/src/components/MessagingContainer/AssistantTools.tsx
@@ -7,7 +7,7 @@ import { WelcomeGuideTooltip } from '@/components/MessagingContainer';
 import { Button, Icon, Text, ToggleCard } from '@/components/UI';
 import { useAvailableTools } from '@/hooks';
 import { useParamsStore } from '@/stores';
-import { checkIsBaseAgent, cn, getToolIcon } from '@/utils';
+import { cn, getToolIcon } from '@/utils';
 
 /**
  * @description Tools for the assistant to use in the conversation.
@@ -41,18 +41,16 @@ export const AssistantTools: React.FC<{
             {availableTools.map(({ name, display_name, description, error_message }) => {
               const enabledTool = enabledTools.find((enabledTool) => enabledTool.name === name);
               const checked = !!enabledTool;
-              const disabled = !checkIsBaseAgent(agent);
 
               return (
                 <ToggleCard
                   key={name}
-                  disabled={disabled}
                   errorMessage={error_message}
                   checked={checked}
                   label={display_name ?? name ?? ''}
                   icon={getToolIcon(name)}
                   description={description ?? ''}
-                  onToggle={(checked) => handleToggle(name ?? '', checked)}
+                  onToggle={(checked) => handleToggle(name!, checked)}
                   agentId={agent?.id}
                 />
               );

--- a/src/interfaces/assistants_web/src/components/MessagingContainer/Welcome.tsx
+++ b/src/interfaces/assistants_web/src/components/MessagingContainer/Welcome.tsx
@@ -71,12 +71,10 @@ export const Welcome: React.FC<Props> = ({ show, agentId }) => {
           {agent?.description || 'Ask questions and get answers based on your files.'}
         </Text>
 
-        {isBaseAgent && (
-          <div className="flex items-center gap-x-1">
-            <Icon name="circles-four" kind="outline" />
-            <Text className="font-medium">Toggle Tools On/Off</Text>
-          </div>
-        )}
+        <div className="flex items-center gap-x-1">
+          <Icon name="circles-four" kind="outline" />
+          <Text className="font-medium">Toggle Tools On/Off</Text>
+        </div>
         <AssistantTools agent={agent} tools={toolsFiltered} />
       </div>
     </Transition>


### PR DESCRIPTION
Allow toggling tools for custom Assistants too

**AI Description**

<!-- begin-generated-description -->

This pull request makes changes to the `DataSourceMenu.tsx`, `AssistantTools.tsx`, and `Welcome.tsx` components.

## Summary
The changes remove the `checkIsBaseAgent` function from the imports and usage in the `DataSourceMenu.tsx` and `AssistantTools.tsx` components. Instead, the `isBaseAgent` variable is replaced with a `paramsTools` variable, which is used to determine the number of tools and the state of the switch component.

## Changes
- The `checkIsBaseAgent` function is removed from the imports in `DataSourceMenu.tsx` and `AssistantTools.tsx`.
- In `DataSourceMenu.tsx`, the `isBaseAgent` variable is replaced with a `paramsTools` variable, which is used to determine the number of tools and the state of the switch component.
- In `AssistantTools.tsx`, the `disabled` prop of the `ToggleCard` component is removed, and the `onToggle` prop is updated to use the `name` property of the tool.
- In `Welcome.tsx`, the `isBaseAgent` variable is removed, and the `Toggle Tools On/Off` text is always displayed.

<!-- end-generated-description -->
