### PR TITLE
Assistants Web: Add hot key bindings button

### DIFF
--- a/src/interfaces/assistants_web/src/components/HotKeys/HotKeysProvider.tsx
+++ b/src/interfaces/assistants_web/src/components/HotKeys/HotKeysProvider.tsx
@@ -1,28 +1,29 @@
 'use client';
 
-import { useState } from 'react';
 import { useHotkeys } from 'react-hotkeys-hook';
 
 import { CustomHotKey, type HotKeyGroupOption, HotKeysDialog } from '@/components/HotKeys';
+import { useSettingsStore } from '@/stores';
 
 type HotKeysProviderProps = {
   hotKeys: HotKeyGroupOption[];
 };
 
 export const HotKeysProvider: React.FC<HotKeysProviderProps> = ({ hotKeys = [] }) => {
-  const [isDialogOpen, setIsDialogOpen] = useState(false);
+  const { isHotKeysDialogOpen, setIsHotKeysDialogOpen } = useSettingsStore();
+
   const open = () => {
-    setIsDialogOpen(true);
+    setIsHotKeysDialogOpen(true);
   };
 
   const close = () => {
-    setIsDialogOpen(false);
+    setIsHotKeysDialogOpen(false);
   };
 
   useHotkeys(
     ['ctrl+k', 'meta+k'],
     () => {
-      if (isDialogOpen) {
+      if (isHotKeysDialogOpen) {
         close();
         return;
       }
@@ -31,12 +32,12 @@ export const HotKeysProvider: React.FC<HotKeysProviderProps> = ({ hotKeys = [] }
     {
       enableOnFormTags: true,
     },
-    [isDialogOpen, close, open]
+    [isHotKeysDialogOpen, close, open]
   );
 
   return (
     <>
-      <HotKeysDialog isOpen={isDialogOpen} close={close} options={hotKeys} />
+      <HotKeysDialog isOpen={isHotKeysDialogOpen} close={close} options={hotKeys} />
       {hotKeys
         .map((hk) => hk.quickActions)
         .flat()
@@ -45,7 +46,7 @@ export const HotKeysProvider: React.FC<HotKeysProviderProps> = ({ hotKeys = [] }
           <HotKeyRegisterAction
             key={hk.name}
             hotKey={hk}
-            isDialogOpen={isDialogOpen}
+            isDialogOpen={isHotKeysDialogOpen}
             close={close}
           />
         ))}

--- a/src/interfaces/assistants_web/src/components/SideNavPanel/SideNavPanel.tsx
+++ b/src/interfaces/assistants_web/src/components/SideNavPanel/SideNavPanel.tsx
@@ -27,10 +27,13 @@ import { cn } from '@/utils';
  */
 export const SideNavPanel: React.FC<{ className?: string }> = ({ className = '' }) => {
   const asideRef = React.useRef<HTMLDivElement>(null);
-  const { isLeftPanelOpen } = useSettingsStore();
+  const { isLeftPanelOpen, isHotKeysDialogOpen, setIsHotKeysDialogOpen } = useSettingsStore();
   const isDesktop = useIsDesktop();
   const isMobile = !isDesktop;
   const navigateToNewChat = useNavigateToNewChat();
+  const openHotKeysDialog = () => {
+    setIsHotKeysDialogOpen(!isHotKeysDialogOpen);
+  };
 
   return (
     <Transition
@@ -113,6 +116,20 @@ export const SideNavPanel: React.FC<{ className?: string }> = ({ className = '' 
         <ConversationList />
 
         <footer className={cn('flex flex-col gap-4', { 'items-center': !isLeftPanelOpen })}>
+          <AgentsSidePanelButton
+            label={
+              <div className="group flex w-full items-center justify-between">
+                <Text>Hot keys</Text>
+                <Shortcut sequence={['⌘', 'K']} className="hidden group-hover:flex" />
+              </div>
+            }
+            tooltip="Hot keys"
+            iconName="menu"
+            theme="mushroom"
+            onClick={() => openHotKeysDialog()}
+            stretch
+          />
+
           <AgentsSidePanelButton
             label="Settings"
             tooltip="Settings"

--- a/src/interfaces/assistants_web/src/components/UI/Icon.tsx
+++ b/src/interfaces/assistants_web/src/components/UI/Icon.tsx
@@ -475,5 +475,10 @@ const getIcon = (name: IconName, kind: IconKind): React.ReactNode => {
         <Slack />
       </AccessibleIcon>
     ),
+    ['hot-keys']: (
+      <AccessibleIcon label="">
+        <Menu />
+      </AccessibleIcon>
+    ),
   }[name];
 };

--- a/src/interfaces/assistants_web/src/stores/persistedStore.ts
+++ b/src/interfaces/assistants_web/src/stores/persistedStore.ts
@@ -55,6 +55,8 @@ export const useSettingsStore = () => {
       setRightPanelOpen: state.setRightPanelOpen,
       setUseAssistantKnowledge: state.setUseAssistantKnowledge,
       setShowSteps: state.setShowSteps,
+      isHotKeysDialogOpen: state.isHotKeysDialogOpen,
+      setIsHotKeysDialogOpen: state.setIsHotKeysDialogOpen,
     }),
     shallow
   );

--- a/src/interfaces/assistants_web/src/stores/slices/settingsSlice.ts
+++ b/src/interfaces/assistants_web/src/stores/slices/settingsSlice.ts
@@ -5,6 +5,7 @@ const INITIAL_STATE = {
   isLeftPanelOpen: true,
   isRightPanelOpen: false,
   showSteps: true,
+  isHotKeysDialogOpen: false,
 };
 
 type State = {
@@ -12,6 +13,7 @@ type State = {
   isLeftPanelOpen: boolean;
   isRightPanelOpen: boolean;
   showSteps: boolean;
+  isHotKeysDialogOpen: boolean;
 };
 
 type Actions = {
@@ -19,6 +21,7 @@ type Actions = {
   setLeftPanelOpen: (isOpen: boolean) => void;
   setRightPanelOpen: (isOpen: boolean) => void;
   setShowSteps: (showSteps: boolean) => void;
+  setIsHotKeysDialogOpen: (isOpen: boolean) => void;
 };
 
 export type SettingsStore = State & Actions;
@@ -48,6 +51,12 @@ export const createSettingsSlice: StateCreator<SettingsStore, [], [], SettingsSt
     set((state) => ({
       ...state,
       showSteps: showSteps,
+    }));
+  },
+  setIsHotKeysDialogOpen(isOpen: boolean) {
+    set((state) => ({
+      ...state,
+      isHotKeysDialogOpen: isOpen,
     }));
   },
   ...INITIAL_STATE,


### PR DESCRIPTION
There is a modal dialog that already exists in the Assistants Web interface, that shows the available keyboard shortcuts. This modal dialog can already be accessed by pressing Ctrl + K or Cmd + K.

This PR modifies the left navigation menu to include a "Hot Keys" button that can be used to access the hot keys dialog:

<img width="294" alt="Screenshot 2024-11-13 at 1 47 15 PM" src="https://github.com/user-attachments/assets/67fba47b-4719-4c99-9709-7aba02e81365">

When hovering over the button, it shows the keystroke to the right:

<img width="295" alt="Screenshot 2024-11-13 at 1 47 28 PM" src="https://github.com/user-attachments/assets/7a28b4b2-23e3-4f52-b2ae-246eac7cc631">

**AI Description**

<!-- begin-generated-description -->

This PR introduces a new feature for managing hotkeys in the application. The changes include:

- **src/interfaces/assistants_web/src/components/HotKeys/HotKeysProvider.tsx**:
  - The `useSettingsStore` hook is imported from `@/stores`.
  - The `useState` hook is removed, and the `isHotKeysDialogOpen` and `setIsHotKeysDialogOpen` states are now managed using the `useSettingsStore` hook.
  - The `open` and `close` functions now use `setIsHotKeysDialogOpen` to toggle the dialog.
  - The `HotKeysDialog` component is updated to use `isHotKeysDialogOpen` and `setIsHotKeysDialogOpen` from the `useSettingsStore` hook.

- **src/interfaces/assistants_web/src/components/SideNavPanel/SideNavPanel.tsx**:
  - The `isHotKeysDialogOpen` and `setIsHotKeysDialogOpen` states are added to the `useSettingsStore` hook.
  - A new function `openHotKeysDialog` is introduced, which toggles the `isHotKeysDialogOpen` state.
  - A new `AgentsSidePanelButton` is added to the footer, allowing users to open the hotkeys dialog.

- **src/interfaces/assistants_web/src/components/UI/Icon.tsx**:
  - A new icon named `'hot-keys'` is added to the `getIcon` function.

- **src/interfaces/assistants_web/src/stores/persistedStore.ts**:
  - The `isHotKeysDialogOpen` and `setIsHotKeysDialogOpen` states are added to the `useSettingsStore` hook.

- **src/interfaces/assistants_web/src/stores/slices/settingsSlice.ts**:
  - The `isHotKeysDialogOpen` state is added to the `INITIAL_STATE` object.
  - A new action `setIsHotKeysDialogOpen` is introduced to update the `isHotKeysDialogOpen` state.

<!-- end-generated-description -->
