### PR TITLE
chore: Silence Pydantic UserWarning

### DIFF
--- a/src/backend/main.py
+++ b/src/backend/main.py
@@ -1,4 +1,5 @@
 import logging
+import warnings
 
 from alembic.command import upgrade
 from alembic.config import Config
@@ -33,6 +34,8 @@ from backend.services.logger.middleware import LoggingMiddleware
 
 # Only show errors for Pydantic
 logging.getLogger('pydantic').setLevel(logging.ERROR)
+# Supress UserWarnings clogging logs
+warnings.filterwarnings("ignore", category=UserWarning, module="pydantic")
 
 load_dotenv()
 


### PR DESCRIPTION
Silences backend pydantic warnings that were not useful

**AI Description**

<!-- begin-generated-description -->

This PR introduces a new import, `warnings`, to suppress `UserWarnings` clogging logs.

- A new import, `warnings`, is added to the list of imports.
- The `warnings.filterwarnings("ignore", category=UserWarning, module="pydantic")` line is added to suppress `UserWarnings` clogging logs.

<!-- end-generated-description -->
