### PR TITLE
chore: Fix Groups/UserGroupsAssociation table overlap issue

### DIFF
--- a/src/backend/database_models/group.py
+++ b/src/backend/database_models/group.py
@@ -10,6 +10,6 @@ class Group(Base):
     display_name: Mapped[str] = mapped_column(String)
 
     users = relationship("User", secondary="user_group", backref="groups")
-    user_associations = relationship("UserGroupAssociation", back_populates="group")
+    user_associations = relationship("UserGroupAssociation", back_populates="group", overlaps="groups,users")
 
     __table_args__ = (UniqueConstraint("display_name", name="unique_display_name"),)

--- a/src/backend/database_models/user.py
+++ b/src/backend/database_models/user.py
@@ -28,7 +28,7 @@ class UserGroupAssociation(Base):
     )
     display: Mapped[str] = mapped_column()
 
-    group = relationship("Group", back_populates="user_associations")
+    group = relationship("Group", back_populates="user_associations", overlaps="groups,user_associations,users")
 
 
 class User(Base):


### PR DESCRIPTION
These relationship overlap but in a harmless way, we explicitely add the overlap field here in the sqlalchemy models to silence the warning. 
**AI Description**

<!-- begin-generated-description -->

This PR updates the `user_associations` relationship in the `Group` and `UserGroupAssociation` classes to include the `overlaps` parameter.

- In `Group`, the `user_associations` relationship is updated to include the `overlaps` parameter with the value `"groups,users"`.
- In `UserGroupAssociation`, the `group` relationship is updated to include the `overlaps` parameter with the value `"groups,user_associations,users"`.

<!-- end-generated-description -->
