### PR TITLE
tests: add the ability to specify a specific test for unit and community tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,11 +16,11 @@ down:
 
 .PHONY: run-unit-tests
 run-unit-tests:
-	poetry run pytest src/backend/tests/unit --cov=src/backend --cov-report=xml
+	poetry run pytest src/backend/tests/unit/$(file) --cov=src/backend --cov-report=xml
 
 .PHONY: run-community-tests
 run-community-tests:
-	poetry run pytest src/community/tests --cov=src/community --cov-report=xml
+	poetry run pytest src/community/tests/$(file) --cov=src/community --cov-report=xml
 
 .PHONY: run-integration-tests
 run-integration-tests:


### PR DESCRIPTION
**Description**

- Added the ability to specify a specific test for unit and community tests

**AI Description**

<!-- begin-generated-description -->

This pull request modifies the `Makefile` to enhance the test execution process by introducing a new variable, `$(file)`, in the `run-unit-tests` and `run-community-tests` targets.

## Changes:
- In the `run-unit-tests` target, the command has been updated to `poetry run pytest src/backend/tests/unit/$(file) --cov=src/backend --cov-report=xml`.
- Similarly, the `run-community-tests` target now includes the variable `$(file)` in the command: `poetry run pytest src/community/tests/$(file) --cov=src/community --cov-report=xml`.

The addition of the `$(file)` variable allows for more flexibility in specifying the test file or pattern to be executed, enabling more granular control over the test execution process.

<!-- end-generated-description -->
