### PR TITLE
frontend: fix react-scroll-to-bottom import

### DIFF
--- a/src/interfaces/assistants_web/src/components/MessagingContainer/MessagingContainer.tsx
+++ b/src/interfaces/assistants_web/src/components/MessagingContainer/MessagingContainer.tsx
@@ -2,8 +2,9 @@
 
 import { Transition } from '@headlessui/react';
 import { usePrevious } from '@react-hookz/web';
+import dynamic from 'next/dynamic';
 import React, { ReactNode, memo, useEffect, useMemo } from 'react';
-import ScrollToBottom, { useScrollToBottom, useSticky } from 'react-scroll-to-bottom';
+import { useScrollToBottom, useSticky } from 'react-scroll-to-bottom';
 
 import { MessageRow } from '@/components/MessageRow';
 import { Welcome } from '@/components/MessagingContainer';
@@ -12,6 +13,8 @@ import { useFixCopyBug } from '@/hooks';
 import { useSynthesizer } from '@/hooks/use-synthesizer';
 import { ChatMessage, MessageType, StreamingMessage, isFulfilledMessage } from '@/types/message';
 import { cn } from '@/utils';
+
+const ScrollToBottom = dynamic(() => import('react-scroll-to-bottom'), { ssr: false });
 
 type Props = {
   isStreaming: boolean;


### PR DESCRIPTION
**Description**

- Changed the way of importing the `ScrollToBottom` component to avoid  the `Prop “className” did not match` warning. 

**AI Description**

<!-- begin-generated-description -->

## Description
The PR introduces changes to the `src/interfaces/assistants_web/src/components/MessagingContainer/MessagingContainer.tsx` file. The main modification involves the import statements, where the `ScrollToBottom` component is now imported dynamically using the `dynamic` function from the `next/dynamic` module. This dynamic import ensures that the component is only loaded when needed, improving the performance and reducing the initial bundle size.

## Changes
- Added `import dynamic from 'next/dynamic';` to enable dynamic imports.
- Replaced `import ScrollToBottom, { useScrollToBottom, useSticky } from 'react-scroll-to-bottom';` with `import { useScrollToBottom, useSticky } from 'react-scroll-to-bottom';` to remove the direct import of `ScrollToBottom`.
- Introduced `const ScrollToBottom = dynamic(() => import('react-scroll-to-bottom'), { ssr: false });` to dynamically import the `ScrollToBottom` component.

<!-- end-generated-description -->
