### PR TITLE
frontend: Change message for Agent with no tools

### DIFF
--- a/src/backend/config/default_agent.py
+++ b/src/backend/config/default_agent.py
@@ -12,7 +12,7 @@ def get_default_agent() -> AgentPublic:
     return AgentPublic(
         id=DEFAULT_AGENT_ID,
         name='Command R+',
-        description='Ask questions and get answers based on your files.',
+        description='Ask questions and get answers based on your tools and files.',
         created_at=datetime.datetime.now(),
         updated_at=datetime.datetime.now(),
         preamble="",

--- a/src/interfaces/assistants_web/src/components/MessagingContainer/Welcome.tsx
+++ b/src/interfaces/assistants_web/src/components/MessagingContainer/Welcome.tsx
@@ -5,6 +5,7 @@ import React from 'react';
 
 import { AssistantTools } from '@/components/MessagingContainer';
 import { CoralLogo, Icon, Text } from '@/components/UI';
+import { useAvailableTools } from '@/hooks';
 import { useAgent, useBrandedColors, useListTools } from '@/hooks';
 import { checkIsDefaultAgent } from '@/utils';
 import { cn } from '@/utils';
@@ -24,8 +25,15 @@ export const Welcome: React.FC<Props> = ({ show, agentId }) => {
 
   const isDefaultAgent = checkIsDefaultAgent(agent);
 
-  // // Filter out tools that are excluded for the base agent
-  let toolsFiltered = [...tools];
+  const { availableTools } = useAvailableTools({
+    agent,
+    allTools: tools,
+  });
+
+  let toolToggleMessage = 'Toggle Tools On/Off';
+  if (availableTools.length === 0) {
+    toolToggleMessage = 'Your Agent has no Tools enabled. Update your Agent to add Tools.';
+  }
 
   return (
     <Transition
@@ -65,16 +73,15 @@ export const Welcome: React.FC<Props> = ({ show, agentId }) => {
           )}
         </div>
         <Text className="text-mushroom-300 dark:text-marble-800">
-          {agent?.description || 'Ask questions and get answers based on your files.'}
+          {agent?.description || 'Ask questions and get answers based on your tools and files.'}
         </Text>
 
-        {tools.length > 0 && (
-          <div className="flex items-center gap-x-1">
-            <Icon name="circles-four" kind="outline" />
-            <Text className="font-medium">Toggle Tools On/Off</Text>
-          </div>
-        )}
-        <AssistantTools agent={agent} tools={toolsFiltered} />
+        <div className="flex items-center gap-x-1">
+          <Icon name="circles-four" kind="outline" />
+          <Text className="font-medium">{toolToggleMessage}</Text>
+        </div>
+
+        <AssistantTools agent={agent} tools={tools} />
       </div>
     </Transition>
   );


### PR DESCRIPTION

**AI Description**

<!-- begin-generated-description -->

This pull request introduces a new feature to the `src/backend/config/default_agent.py` and `src/interfaces/assistants_web/src/components/MessagingContainer/Welcome.tsx` files, enabling users to ask questions and receive answers based on their tools and files.

## Changes:
- In `src/backend/config/default_agent.py`, the `description` field of the `AgentPublic` class has been updated to include the phrase "based on your tools and files".
- In `src/interfaces/assistants_web/src/components/MessagingContainer/Welcome.tsx`, the `useAvailableTools` hook has been imported and utilized to filter available tools for the base agent.
- The `toolToggleMessage` variable has been introduced to display a message based on the availability of tools. If no tools are available, the message prompts the user to update their agent to add tools.
- The `AssistantTools` component now receives the `tools` array directly, without any filtering.

<!-- end-generated-description -->
