### PR TITLE
backend: Handle error when web scraping fails in Hybrid search

### DIFF
--- a/src/backend/tools/hybrid_search.py
+++ b/src/backend/tools/hybrid_search.py
@@ -141,7 +141,8 @@ class HybridWebSearch(BaseTool):
                 documents=[
                     f"{result.get('title', '')} {result.get('text')}"
                     for result in results_batch
-                    if "text" in result
+                    if isinstance(result, dict)
+                    and "text" in result
                 ],
                 ctx=ctx,
             )

--- a/src/backend/tools/web_scrape.py
+++ b/src/backend/tools/web_scrape.py
@@ -64,15 +64,15 @@ class WebScrapeTool(BaseTool):
                     return await self.handle_response(response, url)
 
             except aiohttp.ClientError as e:
-                return  {
+                return  [{
                     "text": f"Client error using web scrape: {str(e)}",
                     "url": url,
-                }
+                }]
             except Exception as e:
-                return {
+                return [{
                     "text": f"Request failed using web scrape: {str(e)}",
                     "url": url,
-                }
+                }]
 
     async def handle_response(self, response: aiohttp.ClientResponse, url: str):
         content_type = response.headers.get("content-type")


### PR DESCRIPTION
Thank you for contributing to the Cohere Toolkit!

- [ ] **PR title**: "area: description"
  - Where "area" is whichever of interface, frontend, model, tools, backend, etc. is being modified. Use "docs: ..." for purely docs changes, "infra: ..." for CI changes.
  - Example: "deployment: add Azure model option"


- [ ] **PR message**: ***Delete this entire checklist*** and replace with
    - **Description:** a description of the change
    - **Issue:** the issue # it fixes, if applicable
    - **Dependencies:** any dependencies required for this change


- [ ] **Add tests and docs**: Please include testing and documentation for your changes
- [ ] **Lint and test**: Run `make lint` and `make run-tests`

**AI Description**

<!-- begin-generated-description -->

This pull request introduces changes to two Python scripts, `src/backend/tools/hybrid_search.py` and `src/backend/tools/web_scrape.py`, which are part of a backend system for web scraping and search functionality.

## `src/backend/tools/hybrid_search.py`
The `rerank_results` function has been updated to include a more robust check for the presence of the `'text'` key in the `result` dictionary. This change ensures that the function only processes results that are dictionaries and contain the `'text'` key.

## `src/backend/tools/web_scrape.py`
The `call` function now returns a list of dictionaries instead of a single dictionary in the case of errors. This modification standardises the error handling and ensures that the returned data structure is consistent.

<!-- end-generated-description -->
