### PR TITLE
docs: Update setup docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,10 @@ Toolkit is a deployable all-in-one RAG application that enables users to quickly
 ## Try Now:
 There are two main ways for quickly running Toolkit: local and cloud. See the specific instructions given below. 
 ### Local
-*You will need to have [Docker](https://www.docker.com/products/docker-desktop/) and [Docker-compose >= 2.22](https://docs.docker.com/compose/install/) installed. [Go here for a more detailed setup.](/docs/setup.md)*  
+*You will need to have [Docker](https://www.docker.com/products/docker-desktop/), [Docker-compose >= 2.22](https://docs.docker.com/compose/install/), and [Poetry](https://python-poetry.org/docs/#installation) installed. [Go here for a more detailed setup.](/docs/setup.md)*  
 Note: to include community tools when building locally, set the `INSTALL_COMMUNITY_DEPS` build arg in the `docker-compose.yml` to `true`.
 
-Both options will make the frontend available at http://localhost:4000.
+Both options will serve the frontend at http://localhost:4000.
 
 #### Using `make`
 Use the provided Makefile to simplify and automate your development workflow with Cohere Toolkit, including Docker Compose management, testing, linting, and environment setup.
@@ -41,8 +41,6 @@ git clone https://github.com/cohere-ai/cohere-toolkit.git
 cd cohere-toolkit
 make first-run
 ```
-
-
 
 #### Docker Compose only
 Use Docker Compose directly if you want to quickly spin up and manage your container environment without the additional automation provided by the Makefile.

--- a/docs/custom_tool_guides/tool_auth_guide.md
+++ b/docs/custom_tool_guides/tool_auth_guide.md
@@ -1,5 +1,5 @@
 ### 1. **Create an Authentication Class**
-You need to create a class specifically for your tool's authentication.
+You need to create a class specifically for your tool's authentication. For great examples, check out the implementations for GMail, GDrive or Slack.
 
 ### 2. **Inheritance**
 Your authentication class should inherit from:
@@ -85,5 +85,5 @@ def retrieve_auth_token(self, request: Request, session: DBSessionDep, user_id: 
 ### 4. **Integrate the Auth Class**
 Once you've created your authentication class, integrate it into your tool’s configuration so that the frontend can use it for authenticating users when interacting with the tool.
 
-To do so, go to your tool config definition and add:
+To do so, go to your tool's `get_tool_definition` method and add:
 `auth_implementation=<YourAuthClass>,`

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -6,14 +6,19 @@
    cd <repository-folder>
    ```
 
-2. **Set Up with Make**:
+2. **Install Poetry and Docker**:
+   Install [Poetry >= 1.7.1](https://python-poetry.org/docs/#installation)
+   Install [Docker](https://www.docker.com/products/docker-desktop/)
+   Install [Docker Compose >= 2.22](https://docs.docker.com/compose/install/)
+
+3. **Set Up with Make**:
    Run:
    ```bash
    make first-run
    ```
    This generates the necessary configuration files and applies database migrations.
 
-3. **Manual Configuration**:
+4. **Manual Configuration**:
    If you prefer:
    - Create a `configuration.yaml` file based on `configuration.template.yaml`.
    - Replace the placeholders with your actual values.
@@ -25,10 +30,11 @@
 
 ### Environment Variables
 
-Ensure to configure your environment variables appropriately. Important ones include:
-- `COHERE_API_KEY`: Your API key for Cohere.
-- `DATABASE_URL`: Connection string for PostgreSQL.
-- `REDIS_URL`: Connection string for Redis.
+Ensure your `configuration.yaml` and `secrets.yaml` file are properly generated and have valid values, especially for the following: 
+
+- `cohere_platform.api_key` (in the secrets file): Your API key for Cohere.
+- `database.url` (in the config file): Connection string for PostgreSQL.
+- `redis.url` (in the config file): Connection string for Redis.
 
 ### Local Database Setup
 
@@ -72,6 +78,5 @@ Ensure to configure your environment variables appropriately. Important ones inc
 
 ### Additional Tips
 
-- **Use Poetry**: It manages dependencies efficiently. Ensure to install the required version (`1.7.1` or higher).
 - **Linting and Formatting**: Use `make lint` and `make lint-fix` for maintaining code quality.
 - **VSCode Setup**: Install extensions for Ruff and set up your environment as per the provided recommendations.

--- a/docs/walkthrough/walkthrough.md
+++ b/docs/walkthrough/walkthrough.md
@@ -5,7 +5,7 @@
   <h1 align="center" >Toolkit Guide</h1>
 </p>
 
-Cohere Toolkit is a collection of plug-in pre-built components enabling customers to quickly build and deploy **production** level RAG applications. Principles of the toolkit is that it is:
+Cohere Toolkit is a collection of plug-and-play pre-built components enabling customers to quickly build and deploy **production** level RAG applications. Toolkit was built with the following principles in mind:
 
 - Quick and simple to set up a light weight version
 - Quick and simple to configure for your needs
@@ -15,12 +15,7 @@ Cohere Toolkit is a collection of plug-in pre-built components enabling customer
 
 <h2>Initial Set Up</h2>
 
-When you first set up the toolkit by running one of the following commands:
-- `docker run -e COHERE_API_KEY='>>YOUR_API_KEY<<' -p 8000:8000 -p 4000:4000 ghcr.io/cohere-ai/cohere-toolkit:latest` 
-- Or cloning:
-  - `git clone https://github.com/cohere-ai/cohere-toolkit.git`
-  - `cd cohere-toolkit`
-  - `make first-run`
+Quickly setup Toolkit by following our [setup guide.](../setup.md)
 
 The default configuration of the toolkit is: 
 
@@ -33,7 +28,6 @@ On top of this the toolkit offers many configurable components
 Below we will go through each of these components including the prebuilt options and how to plug in your own. 
 
 
-
 <p align="center">
   <img src="assets/interfaces.png" width="100px" height="100px" />
   <h1 align="center" >Interfaces</h1>
@@ -42,9 +36,9 @@ Below we will go through each of these components including the prebuilt options
 Interfaces are applications on top of the backend API this could be anything from a website, workflows, a bot etc. 
 
 Pre-built interfaces which your can customize to your needs include:
-- Chat UI (Coral)
-
-- SlackBot
+- Assistants UI (Agentic, default)
+- Chat UI (Coral, non-agentic)
+- Slack Bot
 
 To add your own: 
 
@@ -138,10 +132,3 @@ We have a [detailed guide for each cloud deployment here](../service_deployments
 </p>
 
 The toolkit stores history of conversations to improve next turn generations. It stores these turns in a PostgreSQL database. It is possible to switch this out for a database that you prefer. There is also an option with no storage. 
-
-<p align="center">
-  <img src="assets/analytics.png" width="100px" height="100px" />
-  <h1 align="center" >Analytics</h1>
-</p>
-
-Currently in development. 

--- a/src/backend/config/configuration.template.yaml
+++ b/src/backend/config/configuration.template.yaml
@@ -21,7 +21,7 @@ redis:
   url: redis://:redis@redis:6379
 tools:
   hybrid_web_search:
-    # List of web search tool names, eg: google_web_search, tavily_web_search
+    # List of web search tool names, from: google_web_search, tavily_web_search, brave_web_search
     enabled_web_searches:
       - tavily_web_search
     # List of domains to filter (exclusively) for web search


### PR DESCRIPTION
Thank you for contributing to the Cohere Toolkit!

- [ ] **PR title**: "area: description"
  - Where "area" is whichever of interface, frontend, model, tools, backend, etc. is being modified. Use "docs: ..." for purely docs changes, "infra: ..." for CI changes.
  - Example: "deployment: add Azure model option"


- [ ] **PR message**: ***Delete this entire checklist*** and replace with
    - **Description:** a description of the change
    - **Issue:** the issue # it fixes, if applicable
    - **Dependencies:** any dependencies required for this change


- [ ] **Add tests and docs**: Please include testing and documentation for your changes
- [ ] **Lint and test**: Run `make lint` and `make run-tests`

**AI Description**

<!-- begin-generated-description -->

This PR introduces several changes to the Cohere Toolkit documentation, focusing on setup instructions, tool authentication, and configuration.

## Setup Instructions:
- **README.md**: The local setup instructions now include the installation of [Poetry](https://python-poetry.org/docs/#installation) alongside Docker and Docker Compose.
- **docs/setup.md**: The setup guide has been restructured, with a new section for installing Poetry, Docker, and Docker Compose. The manual configuration section has been updated to mention the `secrets.yaml` file and provide specific environment variable names.

## Tool Authentication:
- **docs/custom_tool_guides/tool_auth_guide.md**: The tool authentication guide now suggests creating an authentication class, providing examples from GMail, GDrive, and Slack. It also clarifies that the `auth_implementation` should be added to the tool's `get_tool_definition` method.

## Configuration:
- **docs/setup.md**: The environment variable configuration section has been updated to mention `secrets.yaml` and provide specific variable names for `cohere_platform.api_key`, `database.url`, and `redis.url`.
- **src/backend/config/configuration.template.yaml**: The configuration template now includes 'brave_web_search' in the list of web search tool names.

<!-- end-generated-description -->
