### PR TITLE
chore: Check config when running `make dev`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,9 @@
 # Build & Run
 .PHONY: dev
 dev:
+	make check-config
 	make -j 2 watch up
-
+	
 .PHONY: watch
 watch:
 	@docker compose watch --no-up
@@ -105,9 +106,13 @@ win-setup:
 	poetry install --with setup --verbose
 	poetry run python src/backend/scripts/cli/main.py
 
-.PHONY: check-config
-check-config:
+.PHONY: check-config-install
+check-config-install:
 	poetry install --with setup --verbose
+	poetry run python src/backend/scripts/config/check_config.py
+
+.PHONY: check-config 
+check-config:
 	poetry run python src/backend/scripts/config/check_config.py
 
 .PHONY: first-run


### PR DESCRIPTION

**AI Description**

<!-- begin-generated-description -->

This PR introduces changes to the `Makefile`, primarily focusing on the `check-config` target and related tasks.

## Summary
The `check-config` target has been split into two separate targets: `check-config-install` and `check-config`. The former now handles the installation process, while the latter is responsible for running the configuration check. This separation enhances clarity and modularity in the build process.

## Changes
- Added a new target `check-config-install` to handle the installation process.
- Modified the `check-config` target to only run the configuration check.
- Added a new line `make check-config` to the `dev` target, ensuring the configuration check is executed during development.

<!-- end-generated-description -->
