### PR TITLE
chore: Parallelize pytest runs 

### DIFF
--- a/.github/workflows/backend_unit_tests.yml
+++ b/.github/workflows/backend_unit_tests.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Test with pytest
         if: github.actor != 'dependabot[bot]'
         run: |
-          make run-unit-tests
+          make run-unit-tests-debug
         env:
           PYTHONPATH: src
       - name: Upload coverage reports to Codecov

--- a/Makefile
+++ b/Makefile
@@ -39,10 +39,18 @@ exec-terrarium:
 # Testing & Linting
 .PHONY: run-unit-tests
 run-unit-tests:
+	poetry run pytest -n auto src/backend/tests/unit/$(file) --cov=src/backend --cov-report=xml
+
+.PHONY: run-unit-tests-debug
+run-unit-tests-debug:
 	poetry run pytest src/backend/tests/unit/$(file) --cov=src/backend --cov-report=xml
 
 .PHONY: run-community-tests
 run-community-tests:
+	poetry run pytest -n auto src/community/tests/$(file) --cov=src/community --cov-report=xml
+
+.PHONY: run-community-tests-debug
+run-community-tests-debug:
 	poetry run pytest src/community/tests/$(file) --cov=src/community --cov-report=xml
 
 .PHONY: run-integration-tests

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ exec-terrarium:
 # Testing & Linting
 .PHONY: run-unit-tests
 run-unit-tests:
-	poetry run pytest -n auto src/backend/tests/unit/$(file) --cov=src/backend --cov-report=xml
+	poetry run pytest src/backend/tests/unit/$(file) --cov=src/backend --cov-report=xml
 
 .PHONY: run-community-tests
 run-community-tests:

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ exec-terrarium:
 # Testing & Linting
 .PHONY: run-unit-tests
 run-unit-tests:
-	poetry run pytest src/backend/tests/unit/$(file) --cov=src/backend --cov-report=xml
+	poetry run pytest -n auto src/backend/tests/unit/$(file) --cov=src/backend --cov-report=xml
 
 .PHONY: run-community-tests
 run-community-tests:

--- a/poetry.lock
+++ b/poetry.lock
@@ -1080,6 +1080,20 @@ files = [
 ]
 
 [[package]]
+name = "execnet"
+version = "2.1.1"
+description = "execnet: rapid multi-Python deployment"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "execnet-2.1.1-py3-none-any.whl", hash = "sha256:26dee51f1b80cebd6d0ca8e74dd8745419761d3bef34163928cbebbdc4749fdc"},
+    {file = "execnet-2.1.1.tar.gz", hash = "sha256:5189b52c6121c24feae288166ab41b32549c7e2348652736540b9e6e7d4e72e3"},
+]
+
+[package.extras]
+testing = ["hatch", "pre-commit", "pytest", "tox"]
+
+[[package]]
 name = "factory-boy"
 version = "3.3.1"
 description = "A versatile test fixtures replacement based on thoughtbot's factory_bot for Ruby."
@@ -5026,6 +5040,26 @@ pytest = ">=7.4.3"
 test = ["covdefaults (>=2.3)", "coverage (>=7.3.2)", "pytest-mock (>=3.12)"]
 
 [[package]]
+name = "pytest-xdist"
+version = "3.6.1"
+description = "pytest xdist plugin for distributed testing, most importantly across multiple CPUs"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "pytest_xdist-3.6.1-py3-none-any.whl", hash = "sha256:9ed4adfb68a016610848639bb7e02c9352d5d9f03d04809919e2dafc3be4cca7"},
+    {file = "pytest_xdist-3.6.1.tar.gz", hash = "sha256:ead156a4db231eec769737f57668ef58a2084a34b2e55c4a8fa20d861107300d"},
+]
+
+[package.dependencies]
+execnet = ">=2.1"
+pytest = ">=7.0.0"
+
+[package.extras]
+psutil = ["psutil (>=3.0)"]
+setproctitle = ["setproctitle"]
+testing = ["filelock"]
+
+[[package]]
 name = "python-calamine"
 version = "0.2.3"
 description = "Python binding for Rust's library for reading excel and odf file - calamine"
@@ -6922,4 +6956,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.0"
 python-versions = "~3.11"
-content-hash = "af5099ee84fd05fc417aca11e279c9b4e8581a18814da3cdf9d513254cb56c1a"
+content-hash = "57385bd27cf3678b9386a19ecd9f636ac15d176f58d4cab81fa4416e444a9ce8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,7 @@ freezegun = "^1.5.1"
 pre-commit = "^2.20.0"
 ruff = "^0.6.0"
 pytest-asyncio = "^0.23.7"
+pytest-xdist = "^3.6.1"
 
 [tool.poetry.group.setup]
 optional = true

--- a/src/backend/tests/unit/README.md
+++ b/src/backend/tests/unit/README.md
@@ -1,4 +1,4 @@
-# Writing Unit Test
+# Writing Unit Tests
 
 This README will explain how to best write unit tests for the OSS Toolkit project.
 
@@ -10,7 +10,7 @@ make test-db
 make run-unit-tests
 ```
 
-## Test DB
+## Testing the Database
 
 Some of the unit tests rely on a database being present. The tests are expecting a postgres DB to be running in a docker container. the `make test-db` target will create the test database required for the tests to run.
 

--- a/src/backend/tests/unit/tools/test_lang_chain.py
+++ b/src/backend/tests/unit/tools/test_lang_chain.py
@@ -3,6 +3,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 from langchain_core.documents.base import Document
+from backend.tools.base import ToolError, ToolErrorCode
 
 from backend.services.context import Context
 from backend.tools import LangChainVectorDBRetriever, LangChainWikiRetriever
@@ -78,7 +79,7 @@ async def test_wiki_retriever_no_docs() -> None:
     ):
         result = await retriever.call({"query": query}, ctx)
 
-    assert result == [{'details': '','success': False,'text': 'No results found.','type': 'other'}]
+    assert result == ToolError(type=ToolErrorCode.OTHER, success=False, text='No results found.', details='No results found for the given params.')
 
 
 
@@ -164,4 +165,4 @@ async def test_vector_db_retriever_no_docs() -> None:
         mock_db.as_retriever().get_relevant_documents.return_value = mock_docs
         result = await retriever.call({"query": query}, ctx)
 
-    assert result == [{'details': '', 'success': False, 'text': 'No results found.', 'type': 'other'}]
+    assert result == ToolError(type=ToolErrorCode.OTHER, success=False, text='No results found.', details='No results found for the given params.')

--- a/src/backend/tests/unit/tools/test_lang_chain.py
+++ b/src/backend/tests/unit/tools/test_lang_chain.py
@@ -3,10 +3,10 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 from langchain_core.documents.base import Document
-from backend.tools.base import ToolError, ToolErrorCode
 
 from backend.services.context import Context
 from backend.tools import LangChainVectorDBRetriever, LangChainWikiRetriever
+from backend.tools.base import ToolError, ToolErrorCode
 
 is_cohere_env_set = (
     os.environ.get("COHERE_API_KEY") is not None

--- a/src/backend/tools/base.py
+++ b/src/backend/tools/base.py
@@ -104,7 +104,7 @@ class ToolDefaultPreambleRegistry:
                     preamble = f"If you decide to use the toolkit_python_interpreter tool and plan to plot something, try returning the result as a PNG. Ensure that the generated code does not require an internet connection. Avoid using the following packages in code generation: {forbidden_preamble_packages}. "
                     return preamble
                 except Exception as e:
-                    logger.error(f"Error while retrieving the Python interpreter preamble.: {str(e)}")
+                    logger.error(event=f"Error while retrieving the Python interpreter preamble: {str(e)}")
                     return None
 
         return None


### PR DESCRIPTION
Note: debug traces don't work since pytest-xdist spawns multiple processes, this PR also adds new `-debug` commands to run pytests without the `-n` flag
**AI Description**

<!-- begin-generated-description -->

This PR introduces several changes to the project's testing infrastructure, focusing on unit tests and community tests. It adds new dependencies, modifies test assertions, and enhances error logging.

- **New Testing Commands**: The Makefile now includes new commands for running unit and community tests with debugging capabilities. The `run-unit-tests-debug` and `run-community-tests-debug` commands enable more detailed testing and debugging.
- **Dependency Updates**: The `poetry.lock file has been updated with new dependencies: `execnet` and `pytest-xdist`. These additions are reflected in the `pyproject.toml` file, ensuring consistent dependency management.
- **Test Assertion Changes**: In `src/backend/tests/unit/tools/test_lang_chain.py`, the test assertions have been modified to use the `ToolError` class from `backend.tools.base`. This change provides more informative error messages and a consistent error handling approach.
- **Enhanced Error Logging**: The `src/backend/tools/base.py` file has been updated to include an `event` keyword argument in the error logging statement. This enhancement provides additional context when logging errors, making debugging more efficient.
- **README Update**: The `src/backend/tests/unit/README.md` file has been updated to reflect the new testing commands and provide guidance on writing unit tests.

<!-- end-generated-description -->
