### PR TITLE
Remove web_scrape as default background tool

### DIFF
--- a/src/interfaces/assistants_web/src/constants/tools.ts
+++ b/src/interfaces/assistants_web/src/constants/tools.ts
@@ -15,7 +15,7 @@ export const TOOL_GOOGLE_DRIVE_ID = 'google_drive';
 export const TOOL_SLACK_ID = 'slack';
 export const TOOL_GMAIL_ID = 'gmail';
 
-export const BACKGROUND_TOOLS = [TOOL_SEARCH_FILE_ID, TOOL_READ_DOCUMENT_ID, TOOL_WEB_SCRAPE_ID];
+export const BACKGROUND_TOOLS = [TOOL_SEARCH_FILE_ID, TOOL_READ_DOCUMENT_ID];
 
 export const TOOL_FALLBACK_ICON = 'circles-four';
 export const TOOL_ID_TO_DISPLAY_INFO: { [id: string]: { icon: IconName } } = {


### PR DESCRIPTION

**AI Description**

<!-- begin-generated-description -->

This pull request modifies the `BACKGROUND_TOOLS` array in the `src/interfaces/assistants_web/src/constants/tools.ts` file.

## Changes
- The `TOOL_WEB_SCRAPE_ID` is removed from the `BACKGROUND_TOOLS` array.

<!-- end-generated-description -->
