### PR TITLE
bug: Fix `make first-run` command not setting proper Tavily api_key config

### DIFF
--- a/src/backend/scripts/cli/constants.py
+++ b/src/backend/scripts/cli/constants.py
@@ -87,7 +87,7 @@ ENV_YAML_CONFIG_MAPPING = {
         "type": "config",
         "path": "tools.python_interpreter.url",
     },
-    "TAVILY_API_KEY": {"type": "secret", "path": "tools.tavily.api_key"},
+    "TAVILY_API_KEY": {"type": "secret", "path": "tools.tavily_web_search.api_key"},
     "COHERE_API_KEY": {"type": "secret", "path": "deployments.cohere_platform.api_key"},
     "SAGE_MAKER_ACCESS_KEY": {
         "type": "secret",

--- a/src/backend/scripts/cli/constants.py
+++ b/src/backend/scripts/cli/constants.py
@@ -73,7 +73,8 @@ COMMUNITY_TOOLS = {
     },
 }
 
-
+# Perhaps there is a better way to do this by using the Settings
+# class from the backend?
 ENV_YAML_CONFIG_MAPPING = {
     "USE_COMMUNITY_FEATURES": {
         "type": "config",


### PR DESCRIPTION
Thank you for contributing to the Cohere Toolkit!

- [ ] **PR title**: "area: description"

  - Where "area" is whichever of interface, frontend, model, tools, backend, etc. is being modified. Use "docs: ..." for purely docs changes, "infra: ..." for CI changes.
  - Example: "deployment: add Azure model option"

- [ ] **PR message**: **_Delete this entire checklist_** and replace with

  - **Description:** a description of the change
  - **Issue:** the issue # it fixes, if applicable
  - **Dependencies:** any dependencies required for this change

- [ ] **Add tests and docs**: Please include testing and documentation for your changes
- [ ] **Lint and test**: Run `make lint` and `make run-unit-tests`

**AI Description**

<!-- begin-generated-description -->

This PR updates the `ENV_YAML_CONFIG_MAPPING` dictionary in the `constants.py` file. The change involves modifying the path for the `TAVILY_API_KEY` entry, which now points to `tools.tavily_web_search.api_key`.

- The `TAVILY_API_KEY` path is updated from `tools.tavily.api_key` to `tools.tavily_web_search.api_key`.
- A comment is added, suggesting the use of the `Settings` class from the backend as a potential alternative approach.

<!-- end-generated-description -->
