### PR TITLE
chore: Remove deprecated default_agent router in config

### DIFF
--- a/src/backend/config/routers.py
+++ b/src/backend/config/routers.py
@@ -25,7 +25,6 @@ class RouterName(StrEnum):
     TOOL = "tool"
     USER = "user"
     AGENT = "agent"
-    DEFAULT_AGENT = "default_agent"
     SNAPSHOT = "snapshot"
     MODEL = "model"
     SCIM = "scim"


### PR DESCRIPTION

**AI Description**

<!-- begin-generated-description -->

## Summary
The PR removes the `DEFAULT_AGENT` attribute from the `RouterName` class in `src/backend/config/routers.py`.

## Changes
- The `DEFAULT_AGENT` attribute is removed from the `RouterName` class.

<!-- end-generated-description -->
