### PR TITLE
Infra: reduce workflow runs

### DIFF
--- a/.github/workflows/backend_integration_tests.yml
+++ b/.github/workflows/backend_integration_tests.yml
@@ -2,8 +2,13 @@ name: Backend - Integration tests
 
 on:
   push:
-    branches: [main]
-  pull_request: {}
+    branches:
+      - main
+    paths:
+      - src/backend/**
+  pull_request:
+    paths:
+      - src/backend/**
 
 jobs:
   pytest:

--- a/.github/workflows/backend_lint.yml
+++ b/.github/workflows/backend_lint.yml
@@ -2,8 +2,13 @@ name: Backend - Lint
 
 on:
   push:
-    branches: [main]
-  pull_request: {}
+    branches:
+      - main
+    paths:
+      - src/backend/**
+  pull_request:
+    paths:
+      - src/backend/**
 
 jobs:
   lint:
@@ -15,7 +20,7 @@ jobs:
           fetch-depth: 0
           clean: true
       - name: Run lint checks
-        uses: chartboost/ruff-action@v1
+        uses: astral-sh/ruff-action@v3
         with:
           src: './src/'
           version: 0.6.0

--- a/.github/workflows/backend_typecheck.yml
+++ b/.github/workflows/backend_typecheck.yml
@@ -2,8 +2,13 @@ name: Backend - Typecheck new files
 
 on:
   push:
-    branches: [main]
-  pull_request: {}
+    branches:
+      - main
+    paths:
+      - src/backend/**
+  pull_request:
+    paths:
+      - src/backend/**
 
 jobs:
   check:

--- a/.github/workflows/backend_unit_tests.yml
+++ b/.github/workflows/backend_unit_tests.yml
@@ -2,8 +2,13 @@ name: Backend - Unit tests
 
 on:
   push:
-    branches: [main]
-  pull_request: {}
+    branches:
+      - main
+    paths:
+      - src/backend/**
+  pull_request:
+    paths:
+      - src/backend/**
 
 jobs:
   pytest:


### PR DESCRIPTION
Only run CI/CD workflows when necessary to reduce GitHub Actions billing

**AI Description**

<!-- begin-generated-description -->

This PR updates the GitHub workflows for backend integration tests, linting, type checking, and unit tests. The changes ensure that the workflows are triggered only when changes are made to the `src/backend` directory.

## Changes:
- The `branches` field is updated to include only the `main` branch.
- A new `paths` field is added to specify the `src/backend` directory as the target for changes.
- The `pull_request` field is updated to include the `paths` field, ensuring that pull requests are triggered only when changes are made to the specified path.

<!-- end-generated-description -->
