### PR TITLE
refactor: update deprecated hmset function to hset

### DIFF
--- a/src/backend/services/cache.py
+++ b/src/backend/services/cache.py
@@ -25,7 +25,7 @@ def cache_put(key: str, value: Any) -> None:
     client = get_client()
 
     if isinstance(value, dict):
-        client.hmset(key, value)
+        client.hset(key, value)
     else:
         client.set(key, value)
 


### PR DESCRIPTION
  - **Description:** Update redis to use newer `hset` function instead of deprecated `hmset`.
  - **Issue:** Fixes #915 
  - **Dependencies:** No dependency changes

**AI Description**

<!-- begin-generated-description -->

This pull request updates the `cache_put` function in the `cache.py` file. The function now uses the `hset` method instead of `hmset` to set the key-value pair in the cache.

## Changes:
- In `cache.py`, the `cache_put` function now uses `client.hset(key, value)` instead of `client.hmset(key, value)`.

<!-- end-generated-description -->
