### PR TITLE
Auth Cache fix

### DIFF
--- a/src/backend/services/cache.py
+++ b/src/backend/services/cache.py
@@ -25,7 +25,7 @@ def cache_put(key: str, value: Any) -> None:
     client = get_client()
 
     if isinstance(value, dict):
-        client.hset(key, value)
+        client.hset(key, mapping=value)
     else:
         client.set(key, value)
 


### PR DESCRIPTION
Cache set issue fix

**AI Description**

<!-- begin-generated-description -->

This pull request makes a small but significant change to the `cache_put` function in the `cache.py` file. The function is responsible for storing key-value pairs in a cache, and the update ensures that the `hset` method is called with the correct argument when the value is a dictionary.

## Changes:
- In the `cache_put` function, the line `client.hset(key, value)` is replaced with `client.hset(key, mapping=value)`.

<!-- end-generated-description -->
