### PR TITLE
Backend: Fix DB session not being patched by test fixture

### DIFF
--- a/src/backend/chat/custom/utils.py
+++ b/src/backend/chat/custom/utils.py
@@ -1,25 +1,28 @@
 from typing import Any
 
-from backend.database_models.database import get_session
+from sqlalchemy.orm import Session
+
 from backend.exceptions import DeploymentNotFoundError
 from backend.model_deployments.base import BaseDeployment
 from backend.schemas.context import Context
 from backend.services import deployment as deployment_service
 
 
-def get_deployment(name: str, ctx: Context, **kwargs: Any) -> BaseDeployment:
+def get_deployment(name: str, session: Session, ctx: Context, **kwargs: Any) -> BaseDeployment:
     """
     Get the deployment implementation instance.
 
     Args:
-        deployment (str): Deployment name.
+        name (str): Deployment name.
+        session (Session): SQLAchemy db session for the request.
+        ctx (Context): Request context
+        **kwargs (Any): Keyword arguments.
 
     Returns:
         BaseDeployment: Deployment implementation instance based on the deployment name.
     """
     kwargs["ctx"] = ctx
     try:
-        session = next(get_session())
         deployment = deployment_service.get_deployment_instance_by_name(session, name, **kwargs)
     except DeploymentNotFoundError:
         deployment = deployment_service.get_default_deployment_instance(**kwargs)

--- a/src/backend/routers/chat.py
+++ b/src/backend/routers/chat.py
@@ -174,6 +174,7 @@ async def chat(
         session,
         CustomChat().chat(
             chat_request,
+            session=session,
             stream=False,
             managed_tools=managed_tools,
             ctx=ctx,

--- a/src/backend/routers/conversation.py
+++ b/src/backend/routers/conversation.py
@@ -265,7 +265,7 @@ async def search_conversations(
     """
     user_id = ctx.get_user_id()
     deployment_name = ctx.get_deployment_name()
-    model_deployment = get_deployment(deployment_name, ctx)
+    model_deployment = get_deployment(deployment_name, session, ctx)
 
     agent = None
     if agent_id:

--- a/src/backend/services/conversation.py
+++ b/src/backend/services/conversation.py
@@ -263,6 +263,7 @@ async def generate_conversation_title(
             session,
             CustomChat().chat(
                 chat_request,
+                session=session,
                 stream=False,
                 agent_id=agent_id,
                 ctx=ctx,


### PR DESCRIPTION
Noticed that the session in the `get_deployment` method was not being patched by the fixture. Decided to pass request session through function calls to ensure the same session is being used for all db requests.

**AI Description**

<!-- begin-generated-description -->

This PR introduces a new `session` parameter to the `get_deployment` function in src/backend/chat/custom/utils.py, which is then used in various other functions and methods across the codebase.

- The `get_deployment` function now takes an additional `session` parameter of type `Session`.
- The `session` parameter is then passed to the `deployment_service.get_deployment_instance_by_name` function, replacing the previous `session = next(get_session())` line.
- The `CustomChat.chat` method in src/backend/chat/custom/custom.py now takes a new `session` parameter, which is used in the `get_deployment` call and the `self.call_chat` method.
- The `call_chat` method in the same file also receives a new `session` parameter, replacing the previous `session = kwargs.get("session")` line.
- The `chat` function in src/backend/routers/chat.py and src/backend/services/conversation.py now passes the `session` parameter to the `CustomChat.chat` method.
- The `search_conversations` function in src/backend/routers/conversation.py now uses the `session` parameter in the `get_deployment` call.

<!-- end-generated-description -->
