### PR TITLE
feat: add FinishReason enum on server side

### DIFF
--- a/src/backend/chat/custom/custom.py
+++ b/src/backend/chat/custom/custom.py
@@ -6,7 +6,7 @@ from sqlalchemy.orm import Session
 from backend.chat.base import BaseChat
 from backend.chat.custom.tool_calls import async_call_tools
 from backend.chat.custom.utils import get_deployment
-from backend.chat.enums import StreamEvent
+from backend.chat.enums import FinishReason, StreamEvent
 from backend.config import Settings
 from backend.config.tools import get_available_tools
 from backend.database_models.file import File
@@ -87,7 +87,7 @@ class CustomChat(BaseChat):
             )
             yield {
                 "event_type": StreamEvent.STREAM_END,
-                "finish_reason": "ERROR",
+                "finish_reason": FinishReason.ERROR,
                 "error": str(e),
                 "status_code": 500,
             }

--- a/src/backend/chat/enums.py
+++ b/src/backend/chat/enums.py
@@ -16,3 +16,12 @@ class StreamEvent(StrEnum):
     NON_STREAMED_CHAT_RESPONSE = "non-streamed-chat-response"
     TOOL_CALLS_GENERATION = "tool-calls-generation"
     TOOL_CALLS_CHUNK = "tool-calls-chunk"
+
+
+class FinishReason(StrEnum):
+    """
+    Reasons why the model finished the request.
+    """
+    ERROR = "ERROR"
+    COMPLETE = "COMPLETE"
+    MAX_TOKENS = "MAX_TOKENS"

--- a/src/backend/schemas/chat.py
+++ b/src/backend/schemas/chat.py
@@ -6,7 +6,7 @@ from uuid import uuid4
 
 from pydantic import BaseModel, Field
 
-from backend.chat.enums import StreamEvent
+from backend.chat.enums import FinishReason, StreamEvent
 from backend.schemas.citation import Citation
 from backend.schemas.document import Document
 from backend.schemas.search_query import SearchQuery
@@ -288,7 +288,7 @@ class StreamEnd(ChatResponse):
         title="Tool Calls",
         description="List of tool calls generated for custom tools",
     )
-    finish_reason: Optional[str] = Field(
+    finish_reason: Optional[FinishReason] = Field(
         None,
         title="Finish Reason",
         description="Reson why the model finished the request",
@@ -322,7 +322,7 @@ class NonStreamedChatResponse(ChatResponse):
         title="Chat History",
         description="A list of previous messages between the user and the model, meant to give the model conversational context for responding to the user's message.",
     )
-    finish_reason: str = Field(
+    finish_reason: FinishReason = Field(
         ...,
         title="Finish Reason",
         description="Reason the chat stream ended",

--- a/src/backend/tests/integration/conftest.py
+++ b/src/backend/tests/integration/conftest.py
@@ -9,6 +9,7 @@ from fastapi.testclient import TestClient
 from sqlalchemy import create_engine
 from sqlalchemy.orm import Session
 
+from backend.chat.enums import FinishReason
 from backend.database_models import get_session
 from backend.database_models.agent import Agent
 from backend.database_models.deployment import Deployment
@@ -204,7 +205,7 @@ def mock_event_stream(inject_events: list[dict]) -> list[dict]:
                 "search_results": [],
                 "search_queries": [],
             },
-            "finish_reason": "COMPLETE",
+            "finish_reason": FinishReason.COMPLETE,
         }
     ])
     return events

--- a/src/backend/tests/unit/conftest.py
+++ b/src/backend/tests/unit/conftest.py
@@ -13,6 +13,7 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import Session
 from sqlalchemy.sql import text
 
+from backend.chat.enums import FinishReason
 from backend.database_models import get_session
 from backend.database_models.base import CustomFilterQuery
 from backend.database_models.deployment import Deployment
@@ -252,7 +253,7 @@ def mock_event_stream(inject_events: list[dict]) -> list[dict]:
                 "search_results": [],
                 "search_queries": [],
             },
-            "finish_reason": "COMPLETE",
+            "finish_reason": FinishReason.COMPLETE,
         }
     ])
     return events

--- a/src/backend/tests/unit/model_deployments/mock_deployments/mock_azure.py
+++ b/src/backend/tests/unit/model_deployments/mock_deployments/mock_azure.py
@@ -2,6 +2,7 @@ from typing import Any, Generator
 
 from cohere.types import StreamedChatResponse
 
+from backend.chat.enums import FinishReason
 from backend.schemas.cohere_chat import CohereChatRequest
 from backend.schemas.context import Context
 from backend.tests.unit.model_deployments.mock_deployments.mock_base import (
@@ -51,7 +52,7 @@ class MockAzureDeployment(MockDeployment):
             "is_search_required": None,
             "search_queries": None,
             "search_results": None,
-            "finish_reason": "MAX_TOKENS",
+            "finish_reason": FinishReason.MAX_TOKENS,
             "tool_calls": None,
             "chat_history": [
                 {"role": "USER", "message": "Hello"},

--- a/src/backend/tests/unit/model_deployments/mock_deployments/mock_bedrock.py
+++ b/src/backend/tests/unit/model_deployments/mock_deployments/mock_bedrock.py
@@ -2,6 +2,7 @@ from typing import Any, Generator
 
 from cohere.types import StreamedChatResponse
 
+from backend.chat.enums import FinishReason
 from backend.schemas.cohere_chat import CohereChatRequest
 from backend.schemas.context import Context
 from backend.tests.unit.model_deployments.mock_deployments.mock_base import (
@@ -48,7 +49,7 @@ class MockBedrockDeployment(MockDeployment):
             "is_search_required": None,
             "search_queries": None,
             "search_results": None,
-            "finish_reason": "MAX_TOKENS",
+            "finish_reason": FinishReason.MAX_TOKENS,
             "tool_calls": None,
             "chat_history": [
                 {"role": "USER", "message": "Hello"},

--- a/src/backend/tests/unit/model_deployments/mock_deployments/mock_cohere_platform.py
+++ b/src/backend/tests/unit/model_deployments/mock_deployments/mock_cohere_platform.py
@@ -3,6 +3,7 @@ from typing import Any, Generator
 
 from cohere.types import StreamedChatResponse
 
+from backend.chat.enums import FinishReason
 from backend.schemas.cohere_chat import CohereChatRequest
 from backend.schemas.context import Context
 from backend.services.conversation import SEARCH_RELEVANCE_THRESHOLD
@@ -55,7 +56,7 @@ class MockCohereDeployment(MockDeployment):
             "is_search_required": None,
             "search_queries": None,
             "search_results": None,
-            "finish_reason": "MAX_TOKENS",
+            "finish_reason": FinishReason.MAX_TOKENS,
             "tool_calls": None,
             "chat_history": [
                 {"role": "USER", "message": "Hello"},

--- a/src/backend/tests/unit/model_deployments/mock_deployments/mock_single_container.py
+++ b/src/backend/tests/unit/model_deployments/mock_deployments/mock_single_container.py
@@ -2,6 +2,7 @@ from typing import Any, Generator
 
 from cohere.types import StreamedChatResponse
 
+from backend.chat.enums import FinishReason
 from backend.schemas.cohere_chat import CohereChatRequest
 from backend.schemas.context import Context
 from backend.tests.unit.model_deployments.mock_deployments.mock_base import (
@@ -48,7 +49,7 @@ class MockSingleContainerDeployment(MockDeployment):
             "is_search_required": None,
             "search_queries": None,
             "search_results": None,
-            "finish_reason": "MAX_TOKENS",
+            "finish_reason": FinishReason.MAX_TOKENS,
             "tool_calls": None,
             "chat_history": [
                 {"role": "USER", "message": "Hello"},

--- a/src/backend/tests/unit/routers/test_chat.py
+++ b/src/backend/tests/unit/routers/test_chat.py
@@ -6,7 +6,7 @@ import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
-from backend.chat.enums import StreamEvent
+from backend.chat.enums import FinishReason, StreamEvent
 from backend.database_models.conversation import Conversation
 from backend.database_models.message import Message, MessageAgent
 from backend.database_models.user import User
@@ -1110,7 +1110,7 @@ def validate_stream_end_event(
     assert is_valid_uuid(data["response_id"])
     assert is_valid_uuid(data["conversation_id"])
     assert is_valid_uuid(data["generation_id"])
-    assert data["finish_reason"] == "COMPLETE" or data["finish_reason"] == "MAX_TOKENS"
+    assert data["finish_reason"] == FinishReason.COMPLETE or data["finish_reason"] == FinishReason.MAX_TOKENS
 
     return data["conversation_id"]
 

--- a/src/interfaces/assistants_web/src/cohere-client/constants.ts
+++ b/src/interfaces/assistants_web/src/cohere-client/constants.ts
@@ -1,4 +1,5 @@
-// @todo: import from generated types when available
+// @todo: Once backend FinishReason enum is merged, run `make generate-client-web`
+// and remove this enum in favor of the generated type from backend
 export enum FinishReason {
   ERROR = 'ERROR',
   COMPLETE = 'COMPLETE',


### PR DESCRIPTION
## Summary

Adds a type-safe `FinishReason` enum on the server side and replaces all string constants with the enum throughout the codebase. This improves type safety and ensures consistency across the backend and frontend.

## Changes

### Backend
- **Added** `FinishReason` enum to `backend/chat/enums.py` with values: `ERROR`, `COMPLETE`, `MAX_TOKENS`
- **Updated** `backend/schemas/chat.py` to use `FinishReason` type instead of `str` for:
  - `ChatResponse.finish_reason` (Optional[FinishReason])
  - `NonStreamedChatResponse.finish_reason` (FinishReason)
- **Replaced** string constant `"ERROR"` with `FinishReason.ERROR` in `backend/chat/custom/custom.py`
- **Updated** all mock deployments to use `FinishReason.MAX_TOKENS` instead of string literal
- **Updated** test files to use enum values and assertions

### Frontend
- **Updated** `src/interfaces/assistants_web/src/cohere-client/constants.ts` with TODO comment to use generated types after running `make generate-client-web`

## Implementation Details

The `FinishReason` enum follows the same pattern as the existing `StreamEvent` enum in the codebase, using Python's `StrEnum` for compatibility with string-based APIs while providing type safety.

### Files Modified
- `src/backend/chat/enums.py` - Added FinishReason enum
- `src/backend/schemas/chat.py` - Updated type annotations
- `src/backend/chat/custom/custom.py` - Replaced string constant
- `src/backend/tests/unit/conftest.py` - Updated test fixtures
- `src/backend/tests/integration/conftest.py` - Updated test fixtures
- `src/backend/tests/unit/routers/test_chat.py` - Updated assertions
- `src/backend/tests/unit/model_deployments/mock_deployments/*.py` - Updated mock responses (4 files)
- `src/interfaces/assistants_web/src/cohere-client/constants.ts` - Added TODO for type generation

## Testing

- [x] Enum imports successfully
- [x] All enum values are correct (ERROR, COMPLETE, MAX_TOKENS)
- [x] No linter errors in modified files
- [x] Existing tests updated to use enum values

## Next Steps

After this PR is merged, run `make generate-client-web` to generate TypeScript types from the backend schema. The frontend can then remove the local `FinishReason` enum and use the generated types.

## Related Issue

Closes #914
