### PR TITLE
fix: update default model to command-r-plus-08-2024

### DIFF
--- a/src/backend/config/default_agent.py
+++ b/src/backend/config/default_agent.py
@@ -6,7 +6,7 @@ from backend.schemas.agent import AgentPublic
 
 DEFAULT_AGENT_ID = "default"
 DEFAULT_DEPLOYMENT = CohereDeployment.name()
-DEFAULT_MODEL = "command-r-plus"
+DEFAULT_MODEL = "command-r-plus-08-2024"
 
 def get_default_agent() -> AgentPublic:
     return AgentPublic(

--- a/src/backend/routers/utils.py
+++ b/src/backend/routers/utils.py
@@ -50,7 +50,7 @@ def get_default_deployment_model(session: DBSessionDep):
             (
                 model
                 for model in deployment_db.models
-                if model.name == 'command-r-plus'
+                if model.name == 'command-r-plus-08-2024'
             ),
             None,
         )

--- a/src/backend/schemas/cohere_chat.py
+++ b/src/backend/schemas/cohere_chat.py
@@ -38,7 +38,7 @@ class CohereChatRequest(BaseChatRequest):
         """,
     )
     model: Optional[str] = Field(
-        "command-r-plus",
+        "command-r-plus-08-2024",
         title="Model",
         description="The model to use for generating the response.",
     )

--- a/src/backend/tests/integration/conftest.py
+++ b/src/backend/tests/integration/conftest.py
@@ -226,6 +226,6 @@ def mock_available_model_deployments(mock_event_stream: list[dict]):
 def mock_cohere_list_models():
     with patch(
         "backend.model_deployments.cohere_platform.CohereDeployment.list_models",
-        return_value=["command", "command-r", "command-r-plus", "command-light-nightly"]
+        return_value=["command", "command-r", "command-r-plus-08-2024", "command-light-nightly"]
     ) as mock:
         yield mock

--- a/src/backend/tests/integration/routers/test_agent.py
+++ b/src/backend/tests/integration/routers/test_agent.py
@@ -26,7 +26,7 @@ def test_create_agent(
         "description": "test description",
         "preamble": "test preamble",
         "temperature": 0.5,
-        "model": "command-r-plus",
+        "model": "command-r-plus-08-2024",
         "deployment": CohereDeployment.name(),
         "tools": [Tool.Calculator.value.ID, Tool.Search_File.value.ID, Tool.Read_File.value.ID],
     }
@@ -70,7 +70,7 @@ def test_create_agent_with_tool_metadata(
         "description": "test description",
         "preamble": "test preamble",
         "temperature": 0.5,
-        "model": "command-r-plus",
+        "model": "command-r-plus-08-2024",
         "deployment": CohereDeployment.name(),
         "tools": [Tool.Google_Drive.value.ID, Tool.Search_File.value.ID],
         "tools_metadata": [
@@ -127,7 +127,7 @@ def test_create_agent_missing_non_required_fields(
 ) -> None:
     request_json = {
         "name": "test agent",
-        "model": "command-r-plus",
+        "model": "command-r-plus-08-2024",
         "deployment": CohereDeployment.name(),
     }
 
@@ -207,7 +207,7 @@ def test_create_agent_missing_name(
         "description": "test description",
         "preamble": "test preamble",
         "temperature": 0.5,
-        "model": "command-r-plus",
+        "model": "command-r-plus-08-2024",
         "deployment": CohereDeployment.name(),
     }
     response = session_client.post(
@@ -242,7 +242,7 @@ def test_create_agent_missing_deployment(
         "description": "test description",
         "preamble": "test preamble",
         "temperature": 0.5,
-        "model": "command-r-plus",
+        "model": "command-r-plus-08-2024",
     }
     response = session_client.post(
         "/v1/agents", json=request_json, headers={"User-Id": user.id}
@@ -256,7 +256,7 @@ def test_create_agent_missing_user_id_header(
 ) -> None:
     request_json = {
         "name": "test agent",
-        "model": "command-r-plus",
+        "model": "command-r-plus-08-2024",
         "deployment": CohereDeployment.name(),
     }
     response = session_client.post("/v1/agents", json=request_json)
@@ -273,7 +273,7 @@ def test_create_agent_invalid_deployment(
         "description": "test description",
         "preamble": "test preamble",
         "temperature": 0.5,
-        "model": "command-r-plus",
+        "model": "command-r-plus-08-2024",
         "deployment": "not a real deployment",
     }
 
@@ -294,7 +294,7 @@ def test_create_agent_deployment_not_in_db(
         "description": "test description",
         "preamble": "test preamble",
         "temperature": 0.5,
-        "model": "command-r-plus",
+        "model": "command-r-plus-08-2024",
         "deployment": CohereDeployment.name(),
     }
     cohere_deployment = deployment_crud.get_deployment_by_name(session, CohereDeployment.name())
@@ -308,7 +308,7 @@ def test_create_agent_deployment_not_in_db(
     deployment_models_list = [model.name for model in deployment_models]
     assert response.status_code == 200
     assert cohere_deployment
-    assert "command-r-plus" in deployment_models_list
+    assert "command-r-plus-08-2024" in deployment_models_list
 
 
 def test_create_agent_invalid_tool(
@@ -316,7 +316,7 @@ def test_create_agent_invalid_tool(
 ) -> None:
     request_json = {
         "name": "test agent",
-        "model": "command-r-plus",
+        "model": "command-r-plus-08-2024",
         "deployment": CohereDeployment.name(),
         "tools": [Tool.Calculator.value.ID, "fake_tool"],
     }

--- a/src/backend/tests/unit/factories/model.py
+++ b/src/backend/tests/unit/factories/model.py
@@ -11,6 +11,6 @@ class ModelFactory(BaseFactory):
 
     deployment = factory.SubFactory(DeploymentFactory)
     deployment_id = factory.SelfAttribute("deployment.id")
-    name = "command-r-plus"
+    name = "command-r-plus-08-2024"
     cohere_name = factory.Faker("name")
     description = factory.Faker("text")

--- a/src/interfaces/assistants_web/src/constants/conversation.ts
+++ b/src/interfaces/assistants_web/src/constants/conversation.ts
@@ -1,7 +1,7 @@
 import { FileAccept } from '@/components/UI';
 
 export const DEFAULT_CONVERSATION_NAME = 'New Conversation';
-export const DEFAULT_AGENT_MODEL = 'command-r-plus';
+export const DEFAULT_AGENT_MODEL = 'command-r-plus-08-2024';
 export const DEFAULT_AGENT_ID = 'default';
 export const DEFAULT_AGENT_TEMPERATURE = 0.3;
 export const DEFAULT_TYPING_VELOCITY = 35;

--- a/src/interfaces/coral_web/src/constants.ts
+++ b/src/interfaces/coral_web/src/constants.ts
@@ -10,7 +10,7 @@ export const DEFAULT_TYPING_VELOCITY = 35;
 
 export const DEPLOYMENT_COHERE_PLATFORM = 'Cohere Platform';
 export const DEPLOYMENT_SINGLE_CONTAINER = 'Single Container';
-export const DEFAULT_AGENT_MODEL = 'command-r-plus';
+export const DEFAULT_AGENT_MODEL = 'command-r-plus-08-2024';
 export const DEFAULT_PREAMBLE =
   "## Task And Context\nYou help people answer their questions and other requests interactively. You will be asked a very wide array of requests on all kinds of topics. You will be equipped with a wide range of search engines or similar tools to help you, which you use to research your answer. You should focus on serving the user's needs as best you can, which will be wide-ranging.\n\n## Style Guide\nUnless the user asks for a different style of answer, you should answer in full sentences, using proper grammar and spelling.";
 


### PR DESCRIPTION
## Summary
Update the default model from `command-r-plus` to `command-r-plus-08-2024` because Cohere deprecated the old model name.

## Root Cause
Cohere renamed the model `command-r-plus` to `command-r-plus-08-2024`. The old model name no longer exists in Cohere's API, causing fresh installs to fail when using the hardcoded default model.

## Fix
Updated all references to the default model across the codebase:
- `src/backend/config/default_agent.py`
- `src/backend/routers/utils.py`
- `src/backend/schemas/cohere_chat.py`
- `src/backend/tests/integration/conftest.py`
- `src/backend/tests/integration/routers/test_agent.py`
- `src/backend/tests/unit/factories/model.py`
- `src/interfaces/assistants_web/src/constants/conversation.ts`
- `src/interfaces/coral_web/src/constants.ts`

## Testing
Updated test fixtures and mocks to use the new model name. All existing tests pass with the updated model reference.

Closes #972