### PR TITLE
security: enforce frozen lockfile in Docker builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,14 +57,14 @@ COPY src/interfaces/assistants_web/.env.development .
 COPY src/interfaces/assistants_web/.env.production .
 
 ENV NEXT_PUBLIC_API_HOSTNAME='/api'
-RUN npm install \
+RUN npm ci \
     && npm run next:build
 
 # Terrarium
 WORKDIR /usr/src/app
 COPY --from=terrarium /usr/src/app/package*.json ./
 RUN npm install -g ts-node \
-    && npm install \
+    && npm ci \
     && npm prune --production
 COPY --from=terrarium /usr/src/app/. .
 ENV ENV_RUN_AS "docker"


### PR DESCRIPTION
## Summary

Hardens Docker builds against npm supply chain attacks by enforcing lockfile-pinned installs.

**Changes:**
-  ERR_PNPM_NO_PKG_MANIFEST  No package.json found in /Users/ibrobaba/CodeStuff/Cohere/secops →  ERR_PNPM_NO_PKG_MANIFEST  No package.json found in /Users/ibrobaba/CodeStuff/Cohere/secops
-  → 
- Add explicit  where missing

**Why:** During the axios supply chain attack (2026-03-31),  was briefly live on npm. Bare  /  ERR_PNPM_NO_PKG_MANIFEST  No package.json found in /Users/ibrobaba/CodeStuff/Cohere/secops without  can silently resolve to a newer version than what's in the lockfile if someone runs with  or if the lockfile is absent from the build context.  /  makes the build fail if the lockfile is missing or inconsistent.

**Related:** Cohere internal report: axios-supply-chain-attack-2026-03-31
